### PR TITLE
Druid Limit Spec Update for sorting columns

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -460,7 +460,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
           new OrderByColumnSpec(fsc.alias, findDirection(fsc.order), findComparator(aliasColumnMap(fsc.alias).dataType))
         }
 
-      val limitSpec = if (orderByColumnSpecList.nonEmpty) {
+      val limitSpec = if ((aggregatorList.nonEmpty || postAggregatorList.nonEmpty) && orderByColumnSpecList.nonEmpty) {
         new DefaultLimitSpec(orderByColumnSpecList.asJava, threshold)
       } else {
         new DefaultLimitSpec(null, threshold)

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
@@ -5,7 +5,7 @@ import com.yahoo.maha.core.DruidDerivedFunction._
 import com.yahoo.maha.core.DruidPostResultFunction.{POST_RESULT_DECODE, START_OF_THE_MONTH, START_OF_THE_WEEK}
 import com.yahoo.maha.core.FilterOperation.{Equality, In, InBetweenEquality, InEquality}
 import com.yahoo.maha.core._
-import com.yahoo.maha.core.dimension._
+import com.yahoo.maha.core.dimension.{DimCol, DruidFuncDimCol, DruidPostResultFuncDimCol, PubCol, ConstDimCol}
 import com.yahoo.maha.core.fact.{PublicFactCol, _}
 import com.yahoo.maha.core.query.{BaseQueryGeneratorTest, SharedDimSchema}
 import com.yahoo.maha.core.query.oracle.OracleQueryGenerator
@@ -522,7 +522,6 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
       }
     }
     val view = UnionView("account_a_stats", Seq(tableOne, tableTwo))
-
 
     ColumnContext.withColumnContext {
       import DruidExpression._

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
@@ -1,11 +1,11 @@
 package com.yahoo.maha.core.query.druid
 
-import com.yahoo.maha.core.CoreSchema.{AdvertiserSchema, InternalSchema}
+import com.yahoo.maha.core.CoreSchema.{AdvertiserSchema, InternalSchema, ResellerSchema}
 import com.yahoo.maha.core.DruidDerivedFunction._
 import com.yahoo.maha.core.DruidPostResultFunction.{POST_RESULT_DECODE, START_OF_THE_MONTH, START_OF_THE_WEEK}
 import com.yahoo.maha.core.FilterOperation.{Equality, In, InBetweenEquality, InEquality}
 import com.yahoo.maha.core._
-import com.yahoo.maha.core.dimension.{DimCol, DruidFuncDimCol, DruidPostResultFuncDimCol, PubCol}
+import com.yahoo.maha.core.dimension._
 import com.yahoo.maha.core.fact.{PublicFactCol, _}
 import com.yahoo.maha.core.query.{BaseQueryGeneratorTest, SharedDimSchema}
 import com.yahoo.maha.core.query.oracle.OracleQueryGenerator
@@ -30,6 +30,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
     registryBuilder.register(pubfact4(forcedFilters))
     registryBuilder.register(pubfact_start_time(forcedFilters))
     registryBuilder.register(pubfact_minute_grain(forcedFilters))
+    registryBuilder.register(pubfact5(forcedFilters))
   }
 
   private[this] def factBuilder(annotations: Set[FactAnnotation]): FactBuilder = {
@@ -466,6 +467,99 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
         //Set(EqualityFilter("Source", "2")),
         Set(),
         getMaxDaysWindow, getMaxDaysLookBack, renderLocalTimeFilter = true
+      )
+  }
+
+  private[this] def pubfact5(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+
+    val tableOne  = {
+      ColumnContext.withColumnContext {
+        import DruidExpression._
+        implicit dc: ColumnContext =>
+          Fact.newFactForView(
+            "account_stats", DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
+            Set(
+              DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+              , ConstDimCol("is_adjustment", StrType(1), "N")
+              , DimCol("stats_date", DateType("YYYY-MM-DD"))
+              , DimCol("test_flag", IntType())
+              , DimCol("Test Flag", IntType(), alias = Option("{test_flag}"))
+              , DruidFuncDimCol("Month", DateType(), GET_INTERVAL_DATE("{stats_date}", "M"))
+              , DruidFuncDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "w"))
+            ),
+            Set(
+              FactCol("impressions", IntType(3, 1))
+              , FactCol("clicks", IntType(3, 0, 1, 800))
+              , FactCol("spend", DecType(0, "0.0"))
+              , DruidConstDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}", "1")
+            )
+          )
+      }
+    }
+
+    val tableTwo  = {
+      ColumnContext.withColumnContext {
+        import DruidExpression._
+        implicit dc: ColumnContext =>
+          Fact.newFactForView(
+            "a_adjustments", DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
+            Set(
+              DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+              , ConstDimCol("is_adjustment", StrType(1), "Y")
+              , DimCol("stats_date", DateType("YYYY-MM-DD"))
+              , DimCol("test_flag", IntType())
+              , DimCol("Test Flag", IntType(), alias = Option("{test_flag}"))
+              , DruidFuncDimCol("Month", DateType(), GET_INTERVAL_DATE("{stats_date}", "M"))
+              , DruidFuncDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "w"))
+            ),
+            Set(
+              FactCol("impressions", IntType(3, 1))
+              , FactCol("clicks", IntType(3, 0, 1, 800))
+              , FactCol("spend", DecType(0, "0.0"))
+              , DruidConstDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}", "0")
+            )
+          )
+      }
+    }
+    val view = UnionView("account_a_stats", Seq(tableOne, tableTwo))
+
+
+    ColumnContext.withColumnContext {
+      import DruidExpression._
+      implicit dc: ColumnContext =>
+        Fact.newUnionView(view, DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
+          Set(
+            DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+            , DimCol("stats_date", DateType("YYYY-MM-DD"))
+            , DimCol("test_flag", IntType())
+            , DimCol("Test Flag", IntType(), alias = Option("{test_flag}"))
+            , DimCol("is_adjustment", StrType(1))
+            , DruidFuncDimCol("Month", DateType(), GET_INTERVAL_DATE("{stats_date}", "M"))
+            , DruidFuncDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "w"))
+          ),
+          Set(
+            FactCol("impressions", IntType(3, 1))
+            , FactCol("clicks", IntType(3, 0, 1, 800))
+            , FactCol("spend", DecType(0, "0.0"))
+            , DruidDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}")
+          )
+        )
+    }
+      .toPublicFact("a_stats",
+        Set(
+          PubCol("stats_date", "Day", InBetweenEquality),
+          PubCol("advertiser_id", "Advertiser ID", InEquality),
+          PubCol("is_adjustment", "Is Adjustment", Equality),
+          PubCol("Test Flag", "Test Flag", Equality),
+          PubCol("Month", "Month", Equality),
+          PubCol("Week", "Week", Equality)
+        ),
+        Set(
+          PublicFactCol("impressions", "Impressions", InBetweenEquality),
+          PublicFactCol("clicks", "Clicks", InBetweenEquality),
+          PublicFactCol("spend", "Spend", Set.empty),
+          PublicFactCol("Der Fact Col A", "Der Fact Col A", InBetweenEquality)
+        ), Set(EqualityFilter("Test Flag", "0", isForceFilter = true)),  getMaxDaysWindow, getMaxDaysLookBack
       )
   }
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
@@ -1823,7 +1823,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     result should fullyMatch regex json
   }
 
-  test("Fact View Query Tests Adjustment Stats with constant column filter and sorting on fact column") {
+  test("Fact View Query Tests Adjustment Stats with constant column filter and sorting on fact columns") {
     val jsonString =
       s"""{ "cube": "a_stats",
          |   "selectFields": [

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
@@ -1890,7 +1890,4 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     result should fullyMatch regex expectedJson
 
   }
-
-
-
 }


### PR DESCRIPTION
@pavanab4u @pranavbhole @patelh : For Union View queries, LimitSpec flow gets evaluated twice, hence sortBy columns try to get added twice, and Druid query gen fails with error: `Unknown column in order clause`. Fixing this by checking the aggList and postAggList values, which are empty in one case.