### PR TITLE
Druid Limit Spec Update for sorting columns

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -456,11 +456,12 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         .view
         .filter(_.isInstanceOf[FactSortByColumnInfo])
         .map(_.asInstanceOf[FactSortByColumnInfo])
+        .filter(fsc => !aliasColumnMap(fsc.alias).isInstanceOf[ConstFactCol])
         .map{ fsc : FactSortByColumnInfo =>
           new OrderByColumnSpec(fsc.alias, findDirection(fsc.order), findComparator(aliasColumnMap(fsc.alias).dataType))
         }
 
-      val limitSpec = if (orderByColumnSpecList.nonEmpty) {
+      val limitSpec = if ((aggregatorList.nonEmpty || postAggregatorList.nonEmpty) && orderByColumnSpecList.nonEmpty) {
         new DefaultLimitSpec(orderByColumnSpecList.asJava, threshold)
       } else {
         new DefaultLimitSpec(null, threshold)

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -461,7 +461,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
           new OrderByColumnSpec(fsc.alias, findDirection(fsc.order), findComparator(aliasColumnMap(fsc.alias).dataType))
         }
 
-      val limitSpec = if ((aggregatorList.nonEmpty || postAggregatorList.nonEmpty) && orderByColumnSpecList.nonEmpty) {
+      val limitSpec = if (orderByColumnSpecList.nonEmpty) {
         new DefaultLimitSpec(orderByColumnSpecList.asJava, threshold)
       } else {
         new DefaultLimitSpec(null, threshold)

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -456,7 +456,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         .view
         .filter(_.isInstanceOf[FactSortByColumnInfo])
         .map(_.asInstanceOf[FactSortByColumnInfo])
-        .filter(fsc => !aliasColumnMap(fsc.alias).isInstanceOf[ConstFactCol])
+        .filter(fsc => !aliasColumnMap(fsc.alias).isInstanceOf[ConstFactCol] && !aliasColumnMap(fsc.alias).isInstanceOf[BaseConstDerivedFactCol])
         .map{ fsc : FactSortByColumnInfo =>
           new OrderByColumnSpec(fsc.alias, findDirection(fsc.order), findComparator(aliasColumnMap(fsc.alias).dataType))
         }

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
@@ -1,11 +1,11 @@
 package com.yahoo.maha.core.query.druid
 
-import com.yahoo.maha.core.CoreSchema.{AdvertiserSchema, InternalSchema}
+import com.yahoo.maha.core.CoreSchema.{AdvertiserSchema, InternalSchema, ResellerSchema}
 import com.yahoo.maha.core.DruidDerivedFunction._
 import com.yahoo.maha.core.DruidPostResultFunction.{POST_RESULT_DECODE, START_OF_THE_MONTH, START_OF_THE_WEEK}
 import com.yahoo.maha.core.FilterOperation.{Equality, In, InBetweenEquality, InEquality}
 import com.yahoo.maha.core._
-import com.yahoo.maha.core.dimension.{DimCol, DruidFuncDimCol, DruidPostResultFuncDimCol, PubCol}
+import com.yahoo.maha.core.dimension.{DimCol, DruidFuncDimCol, DruidPostResultFuncDimCol, PubCol, ConstDimCol}
 import com.yahoo.maha.core.fact.{PublicFactCol, _}
 import com.yahoo.maha.core.query.{BaseQueryGeneratorTest, SharedDimSchema}
 import com.yahoo.maha.core.query.oracle.OracleQueryGenerator
@@ -30,6 +30,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
     registryBuilder.register(pubfact4(forcedFilters))
     registryBuilder.register(pubfact_start_time(forcedFilters))
     registryBuilder.register(pubfact_minute_grain(forcedFilters))
+    registryBuilder.register(pubfact5(forcedFilters))
   }
 
   private[this] def factBuilder(annotations: Set[FactAnnotation]): FactBuilder = {
@@ -466,6 +467,98 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
         //Set(EqualityFilter("Source", "2")),
         Set(),
         getMaxDaysWindow, getMaxDaysLookBack, renderLocalTimeFilter = true
+      )
+  }
+
+  private[this] def pubfact5(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+
+    val tableOne  = {
+      ColumnContext.withColumnContext {
+        import DruidExpression._
+        implicit dc: ColumnContext =>
+          Fact.newFactForView(
+            "account_stats", DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
+            Set(
+              DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+              , ConstDimCol("is_adjustment", StrType(1), "N")
+              , DimCol("stats_date", DateType("YYYY-MM-DD"))
+              , DimCol("test_flag", IntType())
+              , DimCol("Test Flag", IntType(), alias = Option("{test_flag}"))
+              , DruidFuncDimCol("Month", DateType(), GET_INTERVAL_DATE("{stats_date}", "M"))
+              , DruidFuncDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "w"))
+            ),
+            Set(
+              FactCol("impressions", IntType(3, 1))
+              , FactCol("clicks", IntType(3, 0, 1, 800))
+              , FactCol("spend", DecType(0, "0.0"))
+              , DruidConstDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}", "1")
+            )
+          )
+      }
+    }
+
+    val tableTwo  = {
+      ColumnContext.withColumnContext {
+        import DruidExpression._
+        implicit dc: ColumnContext =>
+          Fact.newFactForView(
+            "a_adjustments", DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
+            Set(
+              DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+              , ConstDimCol("is_adjustment", StrType(1), "Y")
+              , DimCol("stats_date", DateType("YYYY-MM-DD"))
+              , DimCol("test_flag", IntType())
+              , DimCol("Test Flag", IntType(), alias = Option("{test_flag}"))
+              , DruidFuncDimCol("Month", DateType(), GET_INTERVAL_DATE("{stats_date}", "M"))
+              , DruidFuncDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "w"))
+            ),
+            Set(
+              ConstFactCol("impressions", IntType(3, 1), "0")
+              , ConstFactCol("clicks", IntType(3, 0, 1, 800), "0")
+              , FactCol("spend", DecType(0, "0.0"))
+              , DruidConstDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}", "0")
+            )
+          )
+      }
+    }
+    val view = UnionView("account_a_stats", Seq(tableOne, tableTwo))
+
+    ColumnContext.withColumnContext {
+      import DruidExpression._
+      implicit dc: ColumnContext =>
+        Fact.newUnionView(view, DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
+          Set(
+            DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+            , DimCol("stats_date", DateType("YYYY-MM-DD"))
+            , DimCol("test_flag", IntType())
+            , DimCol("Test Flag", IntType(), alias = Option("{test_flag}"))
+            , DimCol("is_adjustment", StrType(1))
+            , DruidFuncDimCol("Month", DateType(), GET_INTERVAL_DATE("{stats_date}", "M"))
+            , DruidFuncDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "w"))
+          ),
+          Set(
+            FactCol("impressions", IntType(3, 1))
+            , FactCol("clicks", IntType(3, 0, 1, 800))
+            , FactCol("spend", DecType(0, "0.0"))
+            , DruidDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}")
+          )
+        )
+    }
+      .toPublicFact("a_stats",
+        Set(
+          PubCol("stats_date", "Day", InBetweenEquality),
+          PubCol("advertiser_id", "Advertiser ID", InEquality),
+          PubCol("is_adjustment", "Is Adjustment", Equality),
+          PubCol("Test Flag", "Test Flag", Equality),
+          PubCol("Month", "Month", Equality),
+          PubCol("Week", "Week", Equality)
+        ),
+        Set(
+          PublicFactCol("impressions", "Impressions", InBetweenEquality),
+          PublicFactCol("clicks", "Clicks", InBetweenEquality),
+          PublicFactCol("spend", "Spend", Set.empty),
+          PublicFactCol("Der Fact Col A", "Der Fact Col A", InBetweenEquality)
+        ), Set(EqualityFilter("Test Flag", "0", isForceFilter = true)),  getMaxDaysWindow, getMaxDaysLookBack
       )
   }
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
@@ -491,7 +491,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
               FactCol("impressions", IntType(3, 1))
               , FactCol("clicks", IntType(3, 0, 1, 800))
               , FactCol("spend", DecType(0, "0.0"))
-              , DruidConstDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}", "1")
+              , DruidDerFactCol("Const Der Fact Col A", DecType(), "{clicks}" / "{impressions}")
             )
           )
       }
@@ -516,7 +516,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
               ConstFactCol("impressions", IntType(3, 1), "0")
               , ConstFactCol("clicks", IntType(3, 0, 1, 800), "0")
               , FactCol("spend", DecType(0, "0.0"))
-              , DruidConstDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}", "0")
+              , DruidConstDerFactCol("Const Der Fact Col A", DecType(), "{clicks}" / "{impressions}", "0")
             )
           )
       }
@@ -540,7 +540,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
             FactCol("impressions", IntType(3, 1))
             , FactCol("clicks", IntType(3, 0, 1, 800))
             , FactCol("spend", DecType(0, "0.0"))
-            , DruidDerFactCol("Der Fact Col A", DecType(), "{clicks}" / "{impressions}")
+            , DruidDerFactCol("Const Der Fact Col A", DecType(), "{clicks}" / "{impressions}")
           )
         )
     }
@@ -557,7 +557,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
           PublicFactCol("impressions", "Impressions", InBetweenEquality),
           PublicFactCol("clicks", "Clicks", InBetweenEquality),
           PublicFactCol("spend", "Spend", Set.empty),
-          PublicFactCol("Der Fact Col A", "Der Fact Col A", InBetweenEquality)
+          PublicFactCol("Const Der Fact Col A", "Const Der Fact Col A", InBetweenEquality)
         ), Set(EqualityFilter("Test Flag", "0", isForceFilter = true)),  getMaxDaysWindow, getMaxDaysLookBack
       )
   }

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
@@ -1841,6 +1841,9 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
          |      },
          |      {
          |         "field": "Spend"
+         |      },
+         |      {
+         |         "field": "Const Der Fact Col A"
          |      }
          |   ],
          |   "filterExpressions": [
@@ -1868,6 +1871,10 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
          |      {
          |          "field": "Spend",
          |          "order": "Desc"
+         |      },
+         |      {
+         |          "field": "Const Der Fact Col A",
+         |          "order": "Desc"
          |      }
          |   ]
          |}
@@ -1884,7 +1891,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
     val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-    val expectedJson = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"account_stats"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"stats_date","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"1035663"\},\{"type":"selector","dimension":"\{test_flag\}","value":"0"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\},\{"type":"default","dimension":"stats_date","outputName":"Day","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"Spend","fieldName":"spend","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"ascending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Spend","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":200\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
+    val expectedJson = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"account_stats"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"stats_date","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"1035663"\},\{"type":"selector","dimension":"\{test_flag\}","value":"0"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\},\{"type":"default","dimension":"stats_date","outputName":"Day","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"Spend","fieldName":"spend","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"longSum","name":"clicks","fieldName":"clicks"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Const Der Fact Col A","fn":"/","fields":\[\{"type":"fieldAccess","name":"clicks","fieldName":"clicks"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"ascending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Spend","direction":"descending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Const Der Fact Col A","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":200\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
     println(result)
     println(expectedJson)
     result should fullyMatch regex expectedJson

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
@@ -1823,7 +1823,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     result should fullyMatch regex json
   }
 
-  test("Fact View Query Tests Adjustment Stats with constant column filter and sorting on fact columns") {
+  test("Fact View Query Tests Adjustment Stats with constant column filter and sorting on const fact columns") {
     val jsonString =
       s"""{ "cube": "a_stats",
          |   "selectFields": [

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
@@ -1823,4 +1823,76 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     result should fullyMatch regex json
   }
 
+  test("Fact View Query Tests Adjustment Stats with constant column filter and sorting on fact columns") {
+    val jsonString =
+      s"""{ "cube": "a_stats",
+         |   "selectFields": [
+         |      {
+         |         "field": "Advertiser ID"
+         |      },
+         |      {
+         |         "field": "Day"
+         |      },
+         |      {
+         |         "field": "Is Adjustment"
+         |      },
+         |      {
+         |         "field": "Impressions"
+         |      },
+         |      {
+         |         "field": "Spend"
+         |      }
+         |   ],
+         |   "filterExpressions": [
+         |      {
+         |         "field": "Advertiser ID",
+         |         "operator": "=",
+         |         "value": "1035663"
+         |      },
+         |      {
+         |         "field": "Is Adjustment",
+         |         "operator": "=",
+         |         "value": "Y"
+         |      },
+         |      {
+         |         "field": "Day",
+         |         "operator": "=",
+         |         "value": "$fromDate"
+         |      }
+         |   ],
+         |   "sortBy": [
+         |      {
+         |          "field": "Impressions",
+         |          "order": "Asc"
+         |      },
+         |      {
+         |          "field": "Spend",
+         |          "order": "Desc"
+         |      }
+         |   ]
+         |}
+      """.stripMargin
+
+    val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = RequestModel.from(request, registry)
+    require(requestModel.isSuccess, requestModel)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val expectedJson = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"account_stats"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"stats_date","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"1035663"\},\{"type":"selector","dimension":"\{test_flag\}","value":"0"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\},\{"type":"default","dimension":"stats_date","outputName":"Day","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"Spend","fieldName":"spend","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"ascending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Spend","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":200\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
+    println(result)
+    println(expectedJson)
+    result should fullyMatch regex expectedJson
+
+    val subSequentQuery = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head.asString
+    val expectedSubQueryJson = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"a_adjustments"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"stats_date","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"1035663"\},\{"type":"selector","dimension":"\{test_flag\}","value":"0"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\},\{"type":"default","dimension":"stats_date","outputName":"Day","outputType":"STRING"\}\],"aggregations":\[\{"type":"roundingDoubleSum","name":"Spend","fieldName":"spend","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Spend","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":200\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
+    println(subSequentQuery)
+    println(expectedSubQueryJson)
+    subSequentQuery should fullyMatch regex expectedSubQueryJson
+  }
 }

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.184-SNAPSHOT</version>
+    <version>5.185-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.184-SNAPSHOT</version>
+        <version>5.185-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
@pavanab4u @pranavbhole @patelh 
*  For Union View queries, LimitSpec flow gets evaluated twice, and contains fact columns. `ConstFactCol` presence both times, has a Druid query gen error: Unknown column in order clause. Fixing this by filter `ConstFactCol` and `BaseConstDerivedFactCol` columns from table2 from ordering.