### PR TITLE
Adding support for druid select query

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/api-jersey/src/test/scala/com/yahoo/maha/api/jersey/JsonStreamingOutputTest.scala
+++ b/api-jersey/src/test/scala/com/yahoo/maha/api/jersey/JsonStreamingOutputTest.scala
@@ -95,7 +95,7 @@ class JsonStreamingOutputTest extends FunSuite {
     row.addValue("Total Marks", 99)
     rowList.addRow(row)
 
-    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty)
+    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty, Map.empty)
     val requestResult = pse.immediateResult("label", new Right(RequestResult(queryPipelineResult)))
     val parRequestResult = ParRequestResult(Try(queryPipeline), requestResult, None)
     val requestModelResult = RequestModelResult(query.queryContext.requestModel, None)
@@ -135,7 +135,7 @@ class JsonStreamingOutputTest extends FunSuite {
     row.addValue("Total Marks", 99)
     rowList.addRow(row)
 
-    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty)
+    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty, Map.empty)
     val requestResult = pse.immediateResult("label", new Right(RequestResult(queryPipelineResult)))
     val parRequestResult = ParRequestResult(Try(queryPipeline), requestResult, None)
     val requestModelResult = RequestModelResult(query.queryContext.requestModel, None)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/Engine.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/Engine.scala
@@ -22,15 +22,11 @@ case object PrestoEngine extends Engine {
 }
 
 object Engine {
-  def from(s: String): Option[Engine] = {
-    s.toLowerCase match {
-      case "hive" => Option(HiveEngine)
-      case "oracle" => Option(OracleEngine)
-      case "druid" => Option(DruidEngine)
-      case "presto" => Option(PrestoEngine)
-      case _ => None
-    }
-  }
+  //keep list in one place and derive from here so we only need to update in one place
+  val engines: IndexedSeq[Engine] = IndexedSeq(DruidEngine, OracleEngine, PrestoEngine, HiveEngine)
+  require(engines.size == engines.toSet.size, "Engines list must be unique!")
+  val enginesMap: Map[String, Engine] = engines.map(e => e.toString.toLowerCase -> e).toMap
+  def from(s: String): Option[Engine] = enginesMap.get(s.toLowerCase)
 }
 
 sealed trait EngineRequirement {

--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryResult.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryResult.scala
@@ -1,14 +1,27 @@
 package com.yahoo.maha.core.query
 
 import com.yahoo.maha.core.query.QueryResultStatus.QueryResultStatus
+import org.json4s.JValue
 
-case class QueryResult[T <: RowList](rowList: T,
-                       queryAttributes: QueryAttributes,
-                       queryResultStatus: QueryResultStatus,
-                       message: String = "") {
+case class QueryResult[T <: RowList](rowList: T
+                                     , queryAttributes: QueryAttributes
+                                     , queryResultStatus: QueryResultStatus
+                                     , exception: Option[Throwable] = None
+                                     , pagination: Option[JValue] = None
+                                    ) {
 
   def isFailure: Boolean = {
     queryResultStatus == QueryResultStatus.FAILURE
+  }
+
+  def requireSuccess(errMessage: String): Unit = {
+    if(isFailure) {
+      if(exception.isDefined) {
+        throw new IllegalArgumentException(s"$errMessage : ${exception.get.getMessage}", exception.get)
+      } else {
+        throw new IllegalArgumentException(errMessage)
+      }
+    }
   }
 }
 

--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryResult.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryResult.scala
@@ -17,9 +17,9 @@ case class QueryResult[T <: RowList](rowList: T
   def requireSuccess(errMessage: String): Unit = {
     if(isFailure) {
       if(exception.isDefined) {
-        throw new IllegalArgumentException(s"$errMessage : ${exception.get.getMessage}", exception.get)
+        throw new RuntimeException(s"$errMessage : ${exception.get.getMessage}", exception.get)
       } else {
-        throw new IllegalArgumentException(errMessage)
+        throw new RuntimeException(errMessage)
       }
     }
   }

--- a/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
@@ -5,6 +5,7 @@ package com.yahoo.maha.core.query
 import com.yahoo.maha.core._
 import com.yahoo.maha.parrequest2.future.ParFunction
 import com.yahoo.maha.report.{RowCSVWriter, RowCSVWriterProvider}
+import org.json4s.JValue
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.mutable
@@ -82,7 +83,7 @@ sealed trait RowListLifeCycle {
 }
 
 trait RowList extends RowListLifeCycle {
-  val columns: IndexedSeq[ColumnInfo]
+  def columns: IndexedSeq[ColumnInfo]
   def addRow(r: Row, er: Option[Row] = None) : Unit
   def isEmpty : Boolean
   def foreach(fn: Row => Unit) : Unit

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -32,21 +32,22 @@ import io.druid.query.groupby.having.{AndHavingSpec, HavingSpec}
 import io.druid.query.groupby.orderby.{DefaultLimitSpec, OrderByColumnSpec}
 import io.druid.query.lookup.LookupExtractionFn
 import io.druid.query.ordering.{StringComparator, StringComparators}
+import io.druid.query.select.{PagingSpec, SelectResultValue}
 import io.druid.query.spec.{MultipleIntervalSegmentSpec, QuerySegmentSpec}
 import io.druid.query.timeseries.TimeseriesResultValue
 import io.druid.query.topn.{InvertedTopNMetricSpec, NumericTopNMetricSpec, TopNQueryBuilder, TopNResultValue}
 import io.druid.query.{Druids, Result}
 import io.druid.segment.column.ValueType
-import javax.annotation.RegEx
 import org.joda.time.{DateTime, Interval}
+import org.json4s.{DefaultFormats, JValue}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{SortedSet, mutable}
 import scala.util.Try
 
 /**
- * Created by hiral on 12/11/15.
- */
+  * Created by hiral on 12/11/15.
+  */
 
 object DruidQueryOptimizer {
   val GROUP_BY_IS_SINGLE_THREADED = "groupByIsSingleThreaded"
@@ -69,7 +70,7 @@ class SyncDruidQueryOptimizer(maxSingleThreadedDimCardinality: Long = DruidQuery
                               , maxNoChunkCost: Long = DruidQueryGenerator.defaultMaxNoChunkCost
                               , maxChunks: Int = DruidQueryGenerator.defaultMaxChunks
                               , timeout: Int = DruidQueryGenerator.defaultTimeout
-                               ) extends DruidQueryOptimizer {
+                             ) extends DruidQueryOptimizer {
 
   import DruidQueryOptimizer._
 
@@ -92,31 +93,32 @@ class SyncDruidQueryOptimizer(maxSingleThreadedDimCardinality: Long = DruidQuery
   }
 
   def optimize(queryContext: FactQueryContext, context: java.util.Map[String, AnyRef]): Unit = {
+    val isGroupByQuery = queryContext.requestModel.reportingRequest.queryType == com.yahoo.maha.core.request.GroupByQuery
     queryContext.factBestCandidate.fact.annotations.foreach {
       case DruidQueryPriority(priority) =>
         context.put(QUERY_PRIORITY, priority.asInstanceOf[AnyRef])
-        if(priority == ASYNC_QUERY_PRIORITY) {
-          if(!queryContext.factBestCandidate.isGrainOptimized || !queryContext.factBestCandidate.isIndexOptimized) {
+        if (priority == ASYNC_QUERY_PRIORITY) {
+          if (!queryContext.factBestCandidate.isGrainOptimized || !queryContext.factBestCandidate.isIndexOptimized) {
             context.put(GROUP_BY_IS_SINGLE_THREADED, java.lang.Boolean.FALSE.asInstanceOf[AnyRef])
           }
         }
-      case DruidGroupByStrategyV2 =>
+      case DruidGroupByStrategyV2 if isGroupByQuery =>
         context.put(GROUP_BY_STRATEGY, "v2")
-      case DruidGroupByStrategyV1 =>
+      case DruidGroupByStrategyV1 if isGroupByQuery =>
         context.put(GROUP_BY_STRATEGY, "v1")
-      case DruidGroupByIsSingleThreaded(isSingleThreaded) =>
+      case DruidGroupByIsSingleThreaded(isSingleThreaded) if isGroupByQuery =>
         context.put(GROUP_BY_IS_SINGLE_THREADED, isSingleThreaded.asInstanceOf[AnyRef])
-        if(!isSingleThreaded) {
+        if (!isSingleThreaded) {
           chunkPeriod(queryContext).foreach(p => context.put(CHUNK_PERIOD, p))
         }
       case _ => //do nothing
     }
 
-    if(!context.containsKey(GROUP_BY_IS_SINGLE_THREADED)){
+    if (!context.containsKey(GROUP_BY_IS_SINGLE_THREADED) && isGroupByQuery) {
       val dimCardinalityEstimate: Long = queryContext.requestModel.dimCardinalityEstimate.getOrElse(queryContext.factBestCandidate.fact.defaultCardinality.toLong)
       val groupBySingleThreadedBoolean = groupByIsSingleThreaded(dimCardinalityEstimate)
       context.put(GROUP_BY_IS_SINGLE_THREADED, groupBySingleThreadedBoolean.asInstanceOf[AnyRef])
-      if(!groupBySingleThreadedBoolean) {
+      if (!groupBySingleThreadedBoolean) {
         chunkPeriod(queryContext).foreach(p => context.put(CHUNK_PERIOD, p))
       }
     }
@@ -131,8 +133,10 @@ class AsyncDruidQueryOptimizer(maxSingleThreadedDimCardinality: Long = DruidQuer
                                , maxNoChunkCost: Long = DruidQueryGenerator.defaultMaxNoChunkCost
                                , maxChunks: Int = DruidQueryGenerator.defaultMaxChunks
                                , timeout: Int = DruidQueryGenerator.defaultTimeout
-                                ) extends SyncDruidQueryOptimizer(maxSingleThreadedDimCardinality, maxNoChunkCost, maxChunks, timeout) {
+                              ) extends SyncDruidQueryOptimizer(maxSingleThreadedDimCardinality, maxNoChunkCost, maxChunks, timeout) {
+
   import DruidQueryOptimizer._
+
   override def optimize(queryContext: FactQueryContext, context: java.util.Map[String, AnyRef]): Unit = {
     super.optimize(queryContext, context)
     queryContext.requestModel.requestType match {
@@ -159,7 +163,7 @@ object DruidQueryGenerator extends Logging {
                , maximumMaxRows: Int = defaultMaximumMaxRows
                , maximumTopNMaxRows: Int = defaultMaximumTopNMaxRows
                , maximumMaxRowsAsync: Int = defaultMaximumMaxRowsAsync
-                ) = {
+              ) = {
     if (!queryGeneratorRegistry.isEngineRegistered(DruidEngine, Option(Version.DEFAULT))) {
       val generator = new DruidQueryGenerator(queryOptimizer, defaultDimCardinality, maximumMaxRows, maximumTopNMaxRows, maximumMaxRowsAsync)
       queryGeneratorRegistry.register(DruidEngine, generator)
@@ -176,7 +180,9 @@ object DruidQueryGenerator extends Logging {
 }
 
 object DruidQuery {
+
   import scala.collection.JavaConverters._
+
   val mapper = new DefaultObjectMapper()
   mapper.setSerializationInclusion(Include.NON_NULL)
   val sketchModulesList = new SketchModule().getJacksonModules()
@@ -187,6 +193,7 @@ object DruidQuery {
   def toJson(query: io.druid.query.Query[_]): String = {
     mapper.writeValueAsString(query)
   }
+
   val replaceMissingValueWith = "MAHA_LOOKUP_EMPTY"
 }
 
@@ -194,8 +201,11 @@ abstract class DruidQuery[T] extends Query with WithDruidEngine {
   def query: io.druid.query.Query[T]
 
   def asString: String = DruidQuery.toJson(query)
+
   def maxRows: Int
+
   def isPaginated: Boolean
+
   def queryGenVersion: Option[Version] = None
 }
 
@@ -205,7 +215,7 @@ case class TimeseriesDruidQuery(queryContext: QueryContext
                                 , additionalColumns: IndexedSeq[String]
                                 , maxRows: Int
                                 , isPaginated: Boolean
-                                 ) extends DruidQuery[Result[TimeseriesResultValue]]
+                               ) extends DruidQuery[Result[TimeseriesResultValue]]
 
 case class TopNDruidQuery(queryContext: QueryContext
                           , aliasColumnMap: Map[String, Column]
@@ -213,7 +223,7 @@ case class TopNDruidQuery(queryContext: QueryContext
                           , additionalColumns: IndexedSeq[String]
                           , maxRows: Int
                           , isPaginated: Boolean
-                           ) extends DruidQuery[Result[TopNResultValue]]
+                         ) extends DruidQuery[Result[TopNResultValue]]
 
 case class GroupByDruidQuery(queryContext: QueryContext
                              , aliasColumnMap: Map[String, Column]
@@ -222,7 +232,15 @@ case class GroupByDruidQuery(queryContext: QueryContext
                              , override val ephemeralAliasColumnMap: Map[String, Column]
                              , maxRows: Int
                              , isPaginated: Boolean
-                              ) extends DruidQuery[io.druid.data.input.Row]
+                            ) extends DruidQuery[io.druid.data.input.Row]
+
+case class SelectDruidQuery(queryContext: QueryContext
+                            , aliasColumnMap: Map[String, Column]
+                            , query: io.druid.query.Query[Result[SelectResultValue]]
+                            , additionalColumns: IndexedSeq[String]
+                            , maxRows: Int
+                            , isPaginated: Boolean
+                           ) extends DruidQuery[Result[SelectResultValue]]
 
 class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
                           , defaultDimCardinality: Long
@@ -239,15 +257,15 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
   private[this] val DRUID_USER_ID_CONTEXT = "userId"
   private[this] val MIN_TOPN_THRESHOLD = "minTopNThreshold"
 
-  private[this] def findDirection(order: Order) : OrderByColumnSpec.Direction = order match {
+  private[this] def findDirection(order: Order): OrderByColumnSpec.Direction = order match {
     case ASC => OrderByColumnSpec.Direction.ASCENDING
     case DESC => OrderByColumnSpec.Direction.DESCENDING
     case any => throw new UnsupportedOperationException(s"Sort order not supported : $any")
   }
 
-  private[this] def findComparator(dataType: DataType) : StringComparator = dataType match {
-    case IntType(_,_,_,_,_) => StringComparators.NUMERIC
-    case DecType(_,_,_,_,_,_) => StringComparators.NUMERIC
+  private[this] def findComparator(dataType: DataType): StringComparator = dataType match {
+    case IntType(_, _, _, _, _) => StringComparators.NUMERIC
+    case DecType(_, _, _, _, _, _) => StringComparators.NUMERIC
     case any => StringComparators.LEXICOGRAPHIC
   }
 
@@ -262,7 +280,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
   }
 
   override def validateEngineConstraints(requestModel: RequestModel): Boolean = {
-    return requestModel.startIndex < maximumMaxRows ;
+    return requestModel.startIndex < maximumMaxRows;
   }
 
   private[this] def generateFactQuery(dims: SortedSet[DimensionBundle], queryContext: FactQueryContext): Query = {
@@ -310,7 +328,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     val attemptToRenderSortByNames = {
       val sortByColAliases = queryContext.factBestCandidate.requestModel.requestSortByCols
       val intermediary = sortByColAliases.map(colInfo => colInfo.alias)
-      intermediary.collect{ case name if aliasColumnMap contains name => aliasColumnMap(name).name}
+      intermediary.collect { case name if aliasColumnMap contains name => aliasColumnMap(name).name }
     }
 
     val factRequestCols: Set[String] = {
@@ -326,13 +344,6 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         queryContext.factBestCandidate.requestCols
       }
     }
-
-    val (aggregatorList, postAggregatorList) = getAggregators(queryContext)
-    val (dimFilterList, factFilterList) = getFilters(queryContext, dims)
-    val dimensionSpecTupleList: mutable.Buffer[(DimensionSpec, Option[DimensionSpec])] = getDimensions(queryContext, factRequestCols, dims, isUsingDruidLookup)
-
-    require(queryContext.requestModel.startIndex < maximumMaxRows, s"startIndex can not exceed $maximumMaxRows")
-
     val maxRows = if (queryContext.requestModel.isAsyncRequest) {
       maximumMaxRowsAsync
     } else if (queryContext.requestModel.maxRows < 1) {
@@ -343,141 +354,224 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
       queryContext.requestModel.maxRows
     }
 
-    val maximumMaxRowsForReq = if (queryContext.requestModel.isAsyncRequest) maximumMaxRowsAsync else maximumMaxRows
-    val maxRowsPlusStartIndex = maxRows + queryContext.requestModel.startIndex
-    val threshold = if (maxRowsPlusStartIndex > maximumMaxRows) {
-      maximumMaxRowsForReq
-    } else if (queryContext.requestModel.hasNonFKDimFilters) {
-      Math.min(2 * maxRows + queryContext.requestModel.startIndex, maximumMaxRowsForReq)
-    } else {
-      maxRowsPlusStartIndex
-    }
+    queryContext.requestModel.reportingRequest.queryType match {
+      case com.yahoo.maha.core.request.GroupByQuery =>
+        val (dimFilterList, factFilterList) = getFilters(queryContext, dims)
 
-    val haveFactDimCols = queryContext
-      .factBestCandidate
-      .dimColMapping
-      .filterNot { case (name, alias) => Grain.grainFields(alias) }
-      .keys
-      .exists(factRequestCols)
+        val (aggregatorList, postAggregatorList) = getAggregators(queryContext)
+        val dimensionSpecTupleList: mutable.Buffer[(DimensionSpec, Option[DimensionSpec])] = getDimensions(queryContext, factRequestCols, dims, isUsingDruidLookup)
 
+        require(queryContext.requestModel.startIndex < maximumMaxRows, s"startIndex can not exceed $maximumMaxRows")
 
-    //if there is a single fact sort (and sort not on derived column), and single group by, use Top N
-    if (queryContext.requestModel.factSortByMap.size == 1
-      && factFilterList.isEmpty
-      && dimensionSpecTupleList.size <= 1
-      && threshold <= maximumTopNMaxRows
-      && queryContext.factBestCandidate.publicFact.aliasToNameColumnMap
-      .get(queryContext.requestModel.factSortByMap.head._1)
-      .flatMap(queryContext.factBestCandidate.fact.columnsByNameMap.get)
-      .exists(!_.isDerivedColumn)
-    ) {
-
-      val (sortByAlias, order) = queryContext.requestModel.factSortByMap.head
-      val metric = order match {
-        case ASC =>
-          new InvertedTopNMetricSpec(new NumericTopNMetricSpec(sortByAlias))
-        case DESC =>
-          new NumericTopNMetricSpec(sortByAlias)
-      }
-
-      if (queryContext.requestModel.dimCardinalityEstimate.isDefined) {
-        context.put(MIN_TOPN_THRESHOLD, dimCardinality.asInstanceOf[AnyRef])
-      }
-
-      val builder: TopNQueryBuilder = new TopNQueryBuilder()
-        .dataSource(dataSource)
-        .intervals(getInterval(model))
-        .granularity(getGranularity(queryContext))
-        .metric(metric)
-        .threshold(threshold)
-        .context(context)
-
-      if (dimensionSpecTupleList.nonEmpty)
-        builder.dimension(dimensionSpecTupleList.head._1)
-
-      if (dimFilterList.nonEmpty)
-        builder.filters(new AndDimFilter(dimFilterList.asJava))
-
-      if (aggregatorList.nonEmpty)
-        builder.aggregators(aggregatorList.asJava)
-
-      if (postAggregatorList.nonEmpty)
-        builder.postAggregators(postAggregatorList.asJava)
-
-      new TopNDruidQuery(queryContext, aliasColumnMap, builder.build(), additionalColumns(queryContext), threshold, model.isSyncRequest)
-    }
-    //if there are no dimension cols in requested cols and no sorts, use time series request
-    else if (!haveFactDimCols
-      && factFilterList.isEmpty
-      && dimensionSpecTupleList.isEmpty
-      && !queryContext.requestModel.hasFactSortBy
-      && queryContext.requestModel.isTimeSeries) {
-      val builder = Druids.newTimeseriesQueryBuilder()
-        .dataSource(dataSource)
-        .intervals(getInterval(model))
-        .granularity(getGranularity(queryContext))
-        .context(context)
-
-      if (dimFilterList.nonEmpty)
-        builder.filters(new AndDimFilter(dimFilterList.asJava))
-
-      if (aggregatorList.nonEmpty)
-        builder.aggregators(aggregatorList.asJava)
-
-      if (postAggregatorList.nonEmpty)
-        builder.postAggregators(postAggregatorList.asJava)
-
-      new TimeseriesDruidQuery(queryContext, aliasColumnMap, builder.build(), additionalColumns(queryContext), threshold, model.isSyncRequest)
-    }
-    //else use group by
-    else {
-      val builder = GroupByQuery.builder()
-        .setDataSource(dataSource)
-        .setQuerySegmentSpec(getInterval(model))
-        .setGranularity(getGranularity(queryContext))
-        .setContext(context)
-
-      if (dimensionSpecTupleList.nonEmpty)
-        builder.setDimensions(dimensionSpecTupleList.map(_._1).asJava)
-
-      if (dimFilterList.nonEmpty)
-        builder.setDimFilter(new AndDimFilter(dimFilterList.asJava))
-
-      val havingSpec: AndHavingSpec = if (factFilterList.nonEmpty) {
-        new AndHavingSpec(factFilterList.asJava)
-      } else {
-        null
-      }
-      builder.setHavingSpec(havingSpec)
-
-      if (aggregatorList.nonEmpty)
-        builder.setAggregatorSpecs(aggregatorList.asJava)
-
-      if (postAggregatorList.nonEmpty)
-        builder.setPostAggregatorSpecs(postAggregatorList.asJava)
-
-      val orderByColumnSpecList = queryContext.requestModel.requestSortByCols
-        .view
-        .filter(_.isInstanceOf[FactSortByColumnInfo])
-        .map(_.asInstanceOf[FactSortByColumnInfo])
-        .filter(fsc => !aliasColumnMap(fsc.alias).isInstanceOf[ConstFactCol] && !aliasColumnMap(fsc.alias).isInstanceOf[BaseConstDerivedFactCol])
-        .map{ fsc : FactSortByColumnInfo =>
-          new OrderByColumnSpec(fsc.alias, findDirection(fsc.order), findComparator(aliasColumnMap(fsc.alias).dataType))
+        val maximumMaxRowsForReq = if (queryContext.requestModel.isAsyncRequest) maximumMaxRowsAsync else maximumMaxRows
+        val maxRowsPlusStartIndex = maxRows + queryContext.requestModel.startIndex
+        val threshold = if (maxRowsPlusStartIndex > maximumMaxRows) {
+          maximumMaxRowsForReq
+        } else if (queryContext.requestModel.hasNonFKDimFilters) {
+          Math.min(2 * maxRows + queryContext.requestModel.startIndex, maximumMaxRowsForReq)
+        } else {
+          maxRowsPlusStartIndex
         }
 
-      val limitSpec = if (orderByColumnSpecList.nonEmpty) {
-        new DefaultLimitSpec(orderByColumnSpecList.asJava, threshold)
-      } else {
-        new DefaultLimitSpec(null, threshold)
-      }
+        val haveFactDimCols = queryContext
+          .factBestCandidate
+          .dimColMapping
+          .filterNot { case (name, alias) => Grain.grainFields(alias) }
+          .keys
+          .exists(factRequestCols)
 
-      builder.setLimitSpec(limitSpec)
+        //if there is a single fact sort (and sort not on derived column), and single group by, use Top N
+        if (queryContext.requestModel.factSortByMap.size == 1
+          && factFilterList.isEmpty
+          && dimensionSpecTupleList.size <= 1
+          && threshold <= maximumTopNMaxRows
+          && queryContext.requestModel.factSortByMap.nonEmpty
+          && queryContext.factBestCandidate.publicFact.aliasToNameColumnMap
+          .get(queryContext.requestModel.factSortByMap.head._1)
+          .flatMap(queryContext.factBestCandidate.fact.columnsByNameMap.get)
+          .exists(!_.isDerivedColumn)
+        ) {
 
-      val ephemeralAliasColumns: Map[String, Column] = ephemeralAliasColumnMap(queryContext)
+          val (sortByAlias, order) = queryContext.requestModel.factSortByMap.head
+          val metric = order match {
+            case ASC =>
+              new InvertedTopNMetricSpec(new NumericTopNMetricSpec(sortByAlias))
+            case DESC =>
+              new NumericTopNMetricSpec(sortByAlias)
+          }
 
-      val query: GroupByQuery = generateGroupByQuery(dims, queryContext, dimensionSpecTupleList, builder, havingSpec, limitSpec, context, ephemeralAliasColumns)
+          if (queryContext.requestModel.dimCardinalityEstimate.isDefined) {
+            context.put(MIN_TOPN_THRESHOLD, dimCardinality.asInstanceOf[AnyRef])
+          }
 
-      new GroupByDruidQuery(queryContext, aliasColumnMap, query, additionalColumns(queryContext), ephemeralAliasColumns, threshold, model.isSyncRequest)
+          val builder: TopNQueryBuilder = new TopNQueryBuilder()
+            .dataSource(dataSource)
+            .intervals(getInterval(model))
+            .granularity(getGranularity(queryContext))
+            .metric(metric)
+            .threshold(threshold)
+            .context(context)
+
+          if (dimensionSpecTupleList.nonEmpty)
+            builder.dimension(dimensionSpecTupleList.head._1)
+
+          if (dimFilterList.nonEmpty)
+            builder.filters(new AndDimFilter(dimFilterList.asJava))
+
+          if (aggregatorList.nonEmpty)
+            builder.aggregators(aggregatorList.asJava)
+
+          if (postAggregatorList.nonEmpty)
+            builder.postAggregators(postAggregatorList.asJava)
+
+          new TopNDruidQuery(queryContext, aliasColumnMap, builder.build(), additionalColumns(queryContext), threshold, model.isSyncRequest)
+        }
+        //if there are no dimension cols in requested cols and no sorts, use time series request
+        else if (!haveFactDimCols
+          && factFilterList.isEmpty
+          //we ignore the grain fields from dimension spec list since timeseries already provides it
+          //so we only expect grain fields in the dimension spec list, otherwise it's not timeseries
+          && dimensionSpecTupleList.forall{ case (ds, ods) => Grain.grainFields(ds.getOutputName)}
+          && !queryContext.requestModel.hasFactSortBy
+          && queryContext.requestModel.isTimeSeries) {
+          val builder = Druids.newTimeseriesQueryBuilder()
+            .dataSource(dataSource)
+            .intervals(getInterval(model))
+            .granularity(getGranularity(queryContext))
+            .context(context)
+
+          if (dimFilterList.nonEmpty)
+            builder.filters(new AndDimFilter(dimFilterList.asJava))
+
+          if (aggregatorList.nonEmpty)
+            builder.aggregators(aggregatorList.asJava)
+
+          if (postAggregatorList.nonEmpty)
+            builder.postAggregators(postAggregatorList.asJava)
+
+          new TimeseriesDruidQuery(queryContext, aliasColumnMap, builder.build(), additionalColumns(queryContext), threshold, model.isSyncRequest)
+        }
+        //else use group by
+        else {
+          val builder = GroupByQuery.builder()
+            .setDataSource(dataSource)
+            .setQuerySegmentSpec(getInterval(model))
+            .setGranularity(getGranularity(queryContext))
+            .setContext(context)
+
+          if (dimensionSpecTupleList.nonEmpty)
+            builder.setDimensions(dimensionSpecTupleList.map(_._1).asJava)
+
+          if (dimFilterList.nonEmpty)
+            builder.setDimFilter(new AndDimFilter(dimFilterList.asJava))
+
+          val havingSpec: AndHavingSpec = if (factFilterList.nonEmpty) {
+            new AndHavingSpec(factFilterList.asJava)
+          } else {
+            null
+          }
+          builder.setHavingSpec(havingSpec)
+
+          if (aggregatorList.nonEmpty)
+            builder.setAggregatorSpecs(aggregatorList.asJava)
+
+          if (postAggregatorList.nonEmpty)
+            builder.setPostAggregatorSpecs(postAggregatorList.asJava)
+
+          val orderByColumnSpecList = queryContext.requestModel.requestSortByCols
+            .view
+            .filter(_.isInstanceOf[FactSortByColumnInfo])
+            .map(_.asInstanceOf[FactSortByColumnInfo])
+            .filter(fsc => !aliasColumnMap(fsc.alias).isInstanceOf[ConstFactCol] && !aliasColumnMap(fsc.alias).isInstanceOf[BaseConstDerivedFactCol])
+            .map { fsc: FactSortByColumnInfo =>
+              new OrderByColumnSpec(fsc.alias, findDirection(fsc.order), findComparator(aliasColumnMap(fsc.alias).dataType))
+            }
+
+          val limitSpec = if (orderByColumnSpecList.nonEmpty) {
+            new DefaultLimitSpec(orderByColumnSpecList.asJava, threshold)
+          } else {
+            new DefaultLimitSpec(null, threshold)
+          }
+
+          builder.setLimitSpec(limitSpec)
+
+          val ephemeralAliasColumns: Map[String, Column] = ephemeralAliasColumnMap(queryContext)
+
+          val query: GroupByQuery = generateGroupByQuery(dims, queryContext, dimensionSpecTupleList, builder, havingSpec, limitSpec, context, ephemeralAliasColumns)
+
+          new GroupByDruidQuery(queryContext, aliasColumnMap, query, additionalColumns(queryContext), ephemeralAliasColumns, threshold, model.isSyncRequest)
+        }
+
+      case com.yahoo.maha.core.request.SelectQuery =>
+        require(queryContext.requestModel.reportingRequest.sortBy.isEmpty
+          , "druid select query type does not support sort by functionality!")
+        require(!isUsingDruidLookup
+          , "druid select query type does not support druid lookups!")
+        queryContext.factBestCandidate.filterCols.foreach {
+          colName =>
+            require(!fact.columnsByNameMap(colName).isDerivedColumn
+              , s"druid select query type does not support filter on derived columns: $colName")
+        }
+        val (dimFilterList, factFilterList) = getFilters(queryContext, dims)
+        val maximumMaxRowsForReq = if (queryContext.requestModel.isAsyncRequest) maximumMaxRowsAsync else maximumMaxRows
+        //since select query supports pagination, we don't need to add the offset to the threshold
+        val threshold = maxRows
+
+        val builder = Druids.newSelectQueryBuilder()
+          .dataSource(dataSource)
+          .intervals(getInterval(model))
+          .context(context)
+
+        queryContext.factBestCandidate.dimColMapping.collect {
+          case (dimCol, alias) if factRequestCols(dimCol) =>
+            val column = fact.columnsByNameMap(dimCol)
+            require(!column.isDerivedColumn, s"druid select query type does not support derived columns : $alias")
+        }
+        val dimensionSpecTupleList: mutable.Buffer[(DimensionSpec, Option[DimensionSpec])] = getDimensions(queryContext, factRequestCols, dims, isUsingDruidLookup)
+        builder.dimensionSpecs(dimensionSpecTupleList.map(_._1).asJava)
+
+        val factCols = queryContext.factBestCandidate.factColMapping.toList.collect {
+          case (nonFkCol, alias) if queryContext.factBestCandidate.requestCols(nonFkCol) =>
+            (fact.columnsByNameMap(nonFkCol), alias)
+        }
+
+        //render derived columns last
+        val groupedFactCols = factCols.groupBy(_._1.isDerivedColumn)
+
+        if (groupedFactCols.contains(true)) {
+          throw new UnsupportedOperationException(s"druid select query does not support derived columns : ${groupedFactCols(true).map(_._2).mkString(" ")}")
+        }
+
+        if (dimFilterList.nonEmpty)
+          builder.filters(new AndDimFilter(dimFilterList.asJava))
+
+        groupedFactCols.get(false).foreach {
+          nonDerivedColsList =>
+            builder.metrics(nonDerivedColsList.map {
+              case (col, alias) => col.alias.getOrElse(col.name)
+            }.asJava)
+        }
+
+        val pagination: Option[JValue] = queryContext.requestModel.reportingRequest.pagination.config.get(DruidEngine)
+
+        implicit val formats: org.json4s.Formats = DefaultFormats
+
+        pagination.fold[Unit] {
+          val spec = PagingSpec.newSpec(threshold)
+          builder.pagingSpec(spec)
+        } {
+          jvalue =>
+            jvalue.findField(_._1 == "pagingIdentifiers").foreach {
+              case (_, identifiersJson) =>
+                val identifiers: java.util.Map[String, java.lang.Integer] = identifiersJson.extract[Map[String, Int]].mapValues(new java.lang.Integer(_)).asJava
+                val spec = new PagingSpec(identifiers, threshold)
+                builder.pagingSpec(spec)
+            }
+        }
+
+        new SelectDruidQuery(queryContext, aliasColumnMap, builder.build(), additionalColumns(queryContext), threshold, model.isSyncRequest)
+      case other =>
+        throw new UnsupportedOperationException(s"query type unsupported : $other")
     }
   }
 
@@ -503,10 +597,10 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
                   df match {
                     case LOOKUP(_, _, _) => true
                     case LOOKUP_WITH_EMPTY_VALUE_OVERRIDE(_, _, _, _) => true
-                    case LOOKUP_WITH_DECODE(_, _, _, args @ _*) => true
-                    case LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE(_, _, _, _, _, args @ _*) => true
-                    case LOOKUP_WITH_DECODE_ON_OTHER_COLUMN( _, _, _, _, _, _) => true
-                    case LOOKUP_WITH_TIMEFORMATTER( _, _,_, _, _) => true
+                    case LOOKUP_WITH_DECODE(_, _, _, args@_*) => true
+                    case LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE(_, _, _, _, _, args@_*) => true
+                    case LOOKUP_WITH_DECODE_ON_OTHER_COLUMN(_, _, _, _, _, _) => true
+                    case LOOKUP_WITH_TIMEFORMATTER(_, _, _, _, _) => true
                     case _ => false
                   }
                 case _ => false
@@ -530,9 +624,9 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               column match {
                 case DruidFuncDimCol(_, _, _, df, _, _, _) =>
                   df match {
-                    case LOOKUP_WITH_DECODE(_, _, _, args @ _*) => true
-                    case LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE(_, _, _, _, _, args @ _*) => true
-                    case LOOKUP_WITH_TIMEFORMATTER(__,_, _, _, _) => true
+                    case LOOKUP_WITH_DECODE(_, _, _, args@_*) => true
+                    case LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE(_, _, _, _, _, args@_*) => true
+                    case LOOKUP_WITH_TIMEFORMATTER(__, _, _, _, _) => true
                     case _ => false
                   }
                 case _ => false
@@ -554,12 +648,12 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         .setContext(context)
 
       val outerQueryDimensionSpecList: mutable.Buffer[DimensionSpec] = new ArrayBuffer[DimensionSpec](queryContext.requestModel.requestCols.size)
-        dimensionSpecTupleList.map {
+      dimensionSpecTupleList.map {
         dimensionSpecTuple => {
           val outputName: String = dimensionSpecTuple._1.getOutputName
           queryContext.requestModel.requestCols.map {
             requestCol => {
-              if(requestCol.alias == outputName) {
+              if (requestCol.alias == outputName) {
                 outerQueryDimensionSpecList += dimensionSpecTuple._2.getOrElse(new DefaultDimensionSpec(outputName, outputName))
               }
             }
@@ -568,8 +662,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
             ephemeralColAlias => {
 
 
-
-              if(ephemeralColAlias == outputName) {
+              if (ephemeralColAlias == outputName) {
                 outerQueryDimensionSpecList += dimensionSpecTuple._2.getOrElse(new DefaultDimensionSpec(outputName, outputName))
               }
             }
@@ -709,8 +802,8 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     val aggregatorList = new ArrayBuffer[AggregatorFactory](2 * queryContext.factBestCandidate.factColMapping.size)
     val postAggregatorList = new ArrayBuffer[PostAggregator](2 * queryContext.factBestCandidate.factColMapping.size)
 
-    def applyScaleCleanup(scale:Int) : Int = {
-      if(scale==0) {
+    def applyScaleCleanup(scale: Int): Int = {
+      if (scale == 0) {
         10
       } else scale
     }
@@ -861,7 +954,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         case AverageRollup =>
           val sumName = s"_sum_$columnAlias"
           val countName = s"_count_$columnAlias"
-          aggregatorList += getSumAggregatorFactory(dataType, sumName, if(forOuterQuery) sumName else columnAlias)
+          aggregatorList += getSumAggregatorFactory(dataType, sumName, if (forOuterQuery) sumName else columnAlias)
           aggregatorAliasSet += sumName
           aggregatorNameAliasMap += (sumName -> sumName)
           aggregatorList += getCountAggregatorFactory(dataType, countName)
@@ -871,7 +964,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
           val countFieldAccess = new FieldAccessPostAggregator(countName, countName)
           postAggregatorList += new ArithmeticPostAggregator(alias, "/", Lists.newArrayList(sumFieldAccess, countFieldAccess))
         case any =>
-          aggregatorList += getAggregatorFactory(dataType, rollup, alias, if(forOuterQuery) alias else columnAlias)
+          aggregatorList += getAggregatorFactory(dataType, rollup, alias, if (forOuterQuery) alias else columnAlias)
           aggregatorAliasSet += columnAlias
           aggregatorNameAliasMap += (columnAlias -> alias)
           aggregatorNameAliasMap += (columnName -> alias)
@@ -883,46 +976,46 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         case FactCol(_, dt, cc, rollup, _, annotations, _) =>
           addAggregatorFactory(dt, rollup, alias, column.alias.getOrElse(column.name), column.name)
         case DruidDerFactCol(_, _, dt, cc, de, annotations, rollup, _) =>
-            //this is a post aggregate but we need to add source columns
-            de.sourceColumns.foreach {
-              src =>
-                val sourceCol = fact.columnsByNameMap(src)
-                if (!sourceCol.isDerivedColumn) {
-                  val name = sourceCol.alias.getOrElse(sourceCol.name)
-                  sourceCol match {
-                    case FactCol(_, _, _, rollup, _, _, _) =>
-                      rollup match {
-                        case DruidFilteredRollup(filter, _, re) =>
-                          re match {
-                            case DruidThetaSketchRollup =>
-                              if(queryContext.factBestCandidate.dimColMapping.contains(filter.field)) {
-                                //check if we already added this column
-                                if (!aggregatorAliasSet(name)) {
-                                  renderColumnWithAlias(fact, sourceCol, name, forPostAggregator = true)
-                                }
-                              }
-                            case _ =>
+          //this is a post aggregate but we need to add source columns
+          de.sourceColumns.foreach {
+            src =>
+              val sourceCol = fact.columnsByNameMap(src)
+              if (!sourceCol.isDerivedColumn) {
+                val name = sourceCol.alias.getOrElse(sourceCol.name)
+                sourceCol match {
+                  case FactCol(_, _, _, rollup, _, _, _) =>
+                    rollup match {
+                      case DruidFilteredRollup(filter, _, re) =>
+                        re match {
+                          case DruidThetaSketchRollup =>
+                            if (queryContext.factBestCandidate.dimColMapping.contains(filter.field)) {
+                              //check if we already added this column
                               if (!aggregatorAliasSet(name)) {
                                 renderColumnWithAlias(fact, sourceCol, name, forPostAggregator = true)
                               }
-                          }
-                        case _ =>
-                          if (!aggregatorAliasSet(name)) {
-                            renderColumnWithAlias(fact, sourceCol, name, forPostAggregator = true)
-                          }
-                      }
-                    case _ =>
-                      if (!aggregatorAliasSet(name)) {
-                        renderColumnWithAlias(fact, sourceCol, name, forPostAggregator = true)
-                      }
-                  }
+                            }
+                          case _ =>
+                            if (!aggregatorAliasSet(name)) {
+                              renderColumnWithAlias(fact, sourceCol, name, forPostAggregator = true)
+                            }
+                        }
+                      case _ =>
+                        if (!aggregatorAliasSet(name)) {
+                          renderColumnWithAlias(fact, sourceCol, name, forPostAggregator = true)
+                        }
+                    }
+                  case _ =>
+                    if (!aggregatorAliasSet(name)) {
+                      renderColumnWithAlias(fact, sourceCol, name, forPostAggregator = true)
+                    }
+                }
               }
-            }
+          }
 
           postAggregatorList += de.render(alias)(alias, aggregatorNameAliasMap.toMap)
 
         case ConstFactCol(_, dt, value, cc, rollup, _, annotations, _) =>
-          //Handling Constant Cols in Post Process step in executor
+        //Handling Constant Cols in Post Process step in executor
         case DruidConstDerFactCol(_, dt, value, _, cc, rollup, _, annotations, _) =>
         //Handling Constant Derived Fact Cols in Post Process step in executor
         case DruidPostResultDerivedFactCol(_, _, dt, cc, de, annotations, rollup, _, prf) =>
@@ -978,6 +1071,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         }
       }
     }
+
     groupedFactCols.get(true).foreach(renderDerivedColumns)
     (aggregatorList, postAggregatorList)
   }
@@ -986,7 +1080,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     val fact = queryContext.factBestCandidate.fact
     val dimensionSpecTupleList = new ArrayBuffer[(DimensionSpec, Option[DimensionSpec])](queryContext.factBestCandidate.dimColMapping.size)
 
-    def getTargetTimeFormat(fact: Fact, dimCol: Column) : String = {
+    def getTargetTimeFormat(fact: Fact, dimCol: Column): String = {
       val targetTimeFormat: String = dimCol.dataType match {
         case DateType(sourceFormat) =>
           sourceFormat.getOrElse(fact.grain.formatString)
@@ -998,7 +1092,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
       targetTimeFormat
     }
 
-    def getTimeDimExtractionSpec(fact: Fact, outputName: String, colName: String, format: String) : (DimensionSpec, Option[DimensionSpec]) = {
+    def getTimeDimExtractionSpec(fact: Fact, outputName: String, colName: String, format: String): (DimensionSpec, Option[DimensionSpec]) = {
       val dimCol = fact.columnsByNameMap(colName)
       val targetTimeFormat: String = getTargetTimeFormat(fact, dimCol)
       val exFn = new TimeDimExtractionFn(targetTimeFormat, format)
@@ -1024,7 +1118,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
             case _ =>
               (new DefaultDimensionSpec(name, alias), Option.empty)
           }
-        case DruidFuncDimCol(outputName, dt, cc, df, _, _, _) =>
+        case DruidFuncDimCol(_, dt, cc, df, _, _, _) =>
           df match {
             case intervalDateFunc@GET_INTERVAL_DATE(filedName, resultFormat) =>
               val dimCol = fact.columnsByNameMap(intervalDateFunc.dimColName)
@@ -1038,7 +1132,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               }
 
               val exFn = new TimeDimExtractionFn(targetTimeFormat, resultFormat)
-              (new ExtractionDimensionSpec(dimCol.alias.getOrElse(dimCol.name), outputName, getDimValueType(column), exFn, null), Option.empty)
+              (new ExtractionDimensionSpec(dimCol.alias.getOrElse(dimCol.name), alias, getDimValueType(column), exFn, null), Option.empty)
             case dayOfWeekFunc@DAY_OF_WEEK(fieldName) =>
               val dimCol = fact.columnsByNameMap(dayOfWeekFunc.dimColName)
               val targetTimeFormat: String = dimCol.dataType match {
@@ -1051,15 +1145,15 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               }
 
               val exFn = new TimeDimExtractionFn(targetTimeFormat, "EEEE")
-              (new ExtractionDimensionSpec(dimCol.alias.getOrElse(dimCol.name), outputName, getDimValueType(column), exFn, null), Option.empty)
+              (new ExtractionDimensionSpec(dimCol.alias.getOrElse(dimCol.name), alias, getDimValueType(column), exFn, null), Option.empty)
 
-            case decodeDimFunction@DECODE_DIM(fieldName, args @ _*) =>
+            case decodeDimFunction@DECODE_DIM(fieldName, args@_*) =>
               dt match {
-                case IntType(_, _, _, _, _) | StrType(_, _, _) if args.length > 1=>
+                case IntType(_, _, _, _, _) | StrType(_, _, _) if args.length > 1 =>
                   val map = args.grouped(2).filter(_.size == 2).map(seq => (seq.head, seq(1))).toMap
                   val lookup = new MapLookupExtractor(map.asJava, false)
                   val exFn = {
-                    if(args.length > 2 && args.length % 2  == 1) {
+                    if (args.length > 2 && args.length % 2 == 1) {
                       new LookupExtractionFn(lookup, false, args(args.length - 1), false, true)
                     } else {
                       new LookupExtractionFn(lookup, true, null, false, true)
@@ -1078,10 +1172,10 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               (new ExtractionDimensionSpec(regex.dimColName, alias, getDimValueType(column), exFn, null), Option.empty)
             case DRUID_TIME_FORMAT(fmt, zone) =>
               val exFn = new TimeFormatExtractionFn(fmt, zone, null, null, false)
-              (new ExtractionDimensionSpec(DRUID_TIME_FORMAT.sourceDimColName, outputName, getDimValueType(column), exFn, null), Option.empty)
+              (new ExtractionDimensionSpec(DRUID_TIME_FORMAT.sourceDimColName, alias, getDimValueType(column), exFn, null), Option.empty)
             case datetimeFormatter@DATETIME_FORMATTER(fieldName, index, length) =>
               val exFn = new SubstringDimExtractionFn(index, length)
-              (new ExtractionDimensionSpec(datetimeFormatter.dimColName, outputName, getDimValueType(column), exFn, null), Option.empty)
+              (new ExtractionDimensionSpec(datetimeFormatter.dimColName, alias, getDimValueType(column), exFn, null), Option.empty)
             case any =>
               throw new UnsupportedOperationException(s"Found unhandled DruidDerivedFunction : $any")
           }
@@ -1113,7 +1207,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               renderColumnWithAlias(fact, column, alias)
             case dayOfWeekFunc@DAY_OF_WEEK(fieldName) =>
               renderColumnWithAlias(fact, column, alias)
-            case decodeDimFunction@DECODE_DIM(fieldName, args @ _*) =>
+            case decodeDimFunction@DECODE_DIM(fieldName, args@_*) =>
               renderColumnWithAlias(fact, column, alias)
             case javascript@JAVASCRIPT(fieldName, function) =>
               renderColumnWithAlias(fact, column, alias)
@@ -1132,7 +1226,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               val primaryColumn = queryContext.factBestCandidate.fact.publicDimToForeignKeyColMap(db.publicDim.name)
               (new ExtractionDimensionSpec(primaryColumn.alias.getOrElse(primaryColumn.name), alias, getDimValueType(column), regExFn, null), Option.empty)
 
-            case lookupFunc@LOOKUP_WITH_DECODE(lookupNamespace, valueColumn, dimensionOverrideMap, args @ _*) =>
+            case lookupFunc@LOOKUP_WITH_DECODE(lookupNamespace, valueColumn, dimensionOverrideMap, args@_*) =>
               val regExFn = new MahaRegisteredLookupExtractionFn(null, null, lookupNamespace, false, lookupFunc.default.getOrElse(DruidQuery.replaceMissingValueWith), false, true, valueColumn, null, dimensionOverrideMap.asJava, useQueryLevelCache)
               val mapLookup = new MapLookupExtractor(lookupFunc.map.asJava, false)
               val mapExFn = new LookupExtractionFn(mapLookup, false, lookupFunc.default.getOrElse(null), false, true)
@@ -1140,7 +1234,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               (new ExtractionDimensionSpec(primaryColumn.alias.getOrElse(primaryColumn.name), alias, getDimValueType(column), regExFn, null),
                 Option.apply(new ExtractionDimensionSpec(alias, alias, getDimValueType(column), mapExFn, null)))
 
-            case lookupFunc@LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE(lookupNamespace, valueColumn, retainMissingValue, injective, dimensionOverrideMap, args @ _*) =>
+            case lookupFunc@LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE(lookupNamespace, valueColumn, retainMissingValue, injective, dimensionOverrideMap, args@_*) =>
               val regExFn = new MahaRegisteredLookupExtractionFn(null, null, lookupNamespace, false, lookupFunc.lookupWithDecode.default.getOrElse(DruidQuery.replaceMissingValueWith), false, true, valueColumn, null, dimensionOverrideMap.asJava, useQueryLevelCache)
               val mapLookup = new MapLookupExtractor(lookupFunc.lookupWithDecode.map.asJava, false)
               val mapExFn = new LookupExtractionFn(mapLookup, retainMissingValue, null, injective, true)
@@ -1158,12 +1252,12 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               val primaryColumn = queryContext.factBestCandidate.fact.publicDimToForeignKeyColMap(db.publicDim.name)
               (new ExtractionDimensionSpec(primaryColumn.alias.getOrElse(primaryColumn.name), alias, getDimValueType(column), regExFn, null), Option.empty)
 
-            case lookupFunc@LOOKUP_WITH_TIMEFORMATTER(lookupNamespace,valueColumn,inputFormat,resultFormat,dimensionOverrideMap) =>
+            case lookupFunc@LOOKUP_WITH_TIMEFORMATTER(lookupNamespace, valueColumn, inputFormat, resultFormat, dimensionOverrideMap) =>
               val regExFn = new MahaRegisteredLookupExtractionFn(null, null, lookupNamespace, false, DruidQuery.replaceMissingValueWith, false, true, valueColumn, null, dimensionOverrideMap.asJava, useQueryLevelCache)
-              val timeFormatFn = new TimeDimExtractionFn(inputFormat,resultFormat)
+              val timeFormatFn = new TimeDimExtractionFn(inputFormat, resultFormat)
               val primaryColumn = queryContext.factBestCandidate.fact.publicDimToForeignKeyColMap(db.publicDim.name)
               (new ExtractionDimensionSpec(primaryColumn.alias.getOrElse(primaryColumn.name), alias, getDimValueType(column), regExFn, null),
-                Option.apply(new ExtractionDimensionSpec(alias,alias,getDimValueType(column), timeFormatFn,null)))
+                Option.apply(new ExtractionDimensionSpec(alias, alias, getDimValueType(column), timeFormatFn, null)))
 
             case DRUID_TIME_FORMAT(fmt, zone) =>
               renderColumnWithAlias(fact, column, alias)
@@ -1176,17 +1270,24 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
       }
     }
 
-    queryContext.factBestCandidate.dimColMapping.collect {
+    queryContext.factBestCandidate.dimColMapping.foreach {
       case (dimCol, alias) if !isUsingDruidLookups || (isUsingDruidLookups && queryContext.requestModel.requestColsSet(alias)) =>
         if (factRequestCols(dimCol)) {
           val column = fact.columnsByNameMap(dimCol)
-          if (Grain.grainFields(alias) && !queryContext.factBestCandidate.publicFact.renderLocalTimeFilter) {
-            //don't include local time
-          } else {
-            if (!column.isInstanceOf[ConstDimCol])
-              dimensionSpecTupleList += renderColumnWithAlias(fact, column, alias)
+          if (!column.isInstanceOf[ConstDimCol]) {
+            dimensionSpecTupleList += renderColumnWithAlias(fact, column, alias)
           }
+          /* local time day filter has to do with filtering by both utc time and local time filter, not rendering columns
+          if (Grain.grainFields(alias) && !queryContext.factBestCandidate.publicFact.renderLocalTimeFilter) {
+            //don't include time
+          } else {
+            if (!column.isInstanceOf[ConstDimCol]) {
+              dimensionSpecTupleList += renderColumnWithAlias(fact, column, alias)
+            }
+          }
+          */
         }
+      case _ => //do nothing
     }
 
     queryContext.factBestCandidate.factColMapping.foreach {
@@ -1194,7 +1295,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         if (factRequestCols(factCol)) {
           val column = fact.columnsByNameMap(factCol)
           column match {
-            case DruidPostResultDerivedFactCol(_,_,_,_,_,_,_,_,prf) =>
+            case DruidPostResultDerivedFactCol(_, _, _, _, _, _, _, _, prf) =>
               prf.sourceColumns.foreach {
                 sc => {
                   for {
@@ -1210,8 +1311,8 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     }
 
     val dimAliasSet = new mutable.TreeSet[String]()
-    val lastDimLevel: DimLevel = if(dims.nonEmpty) dims.last.dim.dimLevel else LevelOne
-    dims.filter(p=> p.dim.engine == DruidEngine).map {
+    val lastDimLevel: DimLevel = if (dims.nonEmpty) dims.last.dim.dimLevel else LevelOne
+    dims.filter(p => p.dim.engine == DruidEngine).map {
       case (db) =>
         val aliasSet = db.fields.filterNot(f => f.equals(db.publicDim.primaryKeyByAlias) || db.publicDim.foreignKeyByAlias(f))
         aliasSet.map {
@@ -1227,11 +1328,11 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     }
 
     // include dimfilter columns also in dimSpecList if not included already as it is required for filters in outer query
-    dims.filter(p=> p.dim.engine == DruidEngine).foreach {
+    dims.filter(p => p.dim.engine == DruidEngine).foreach {
       db => {
         db.filters.filterNot(f => f.field.equals(db.publicDim.primaryKeyByAlias) || db.publicDim.foreignKeyByAlias(f.field)).foreach {
           filter => {
-            if(!dimAliasSet(filter.field)) {
+            if (!dimAliasSet(filter.field)) {
               val name = db.publicDim.aliasToNameMap(filter.field)
               val column = db.dim.dimensionColumnsByNameMap(name)
               if (!column.isInstanceOf[ConstDimCol]) {
@@ -1275,26 +1376,25 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
       }
       */
     }
-    val constantColumnNames:Set[String] = {
+    val constantColumnNames: Set[String] = {
       fact match {
-        case f:FactView =>
+        case f: FactView =>
           f.constantColNameToValueMap.map(_._1).toSet
-        case f:Fact =>
+        case f: Fact =>
           Set.empty
       }
     }
 
 
-    val unique_filters = removeDuplicateIfForced( filters.toSeq, allFilters.toSeq, queryContext )
+    val unique_filters = removeDuplicateIfForced(filters.toSeq, allFilters.toSeq, queryContext)
 
     unique_filters.sorted.foreach {
       filter =>
         val name = publicFact.aliasToNameColumnMap(filter.field)
         val grainOption = Option(fact.grain)
-        if(constantColumnNames.contains(name)) {
+        if (constantColumnNames.contains(name)) {
           // ignoring constant columns
-        } else
-        if (fact.dimColMap.contains(name)) {
+        } else if (fact.dimColMap.contains(name)) {
           whereFilters += FilterDruid.renderFilterDim(
             filter,
             queryContext.factBestCandidate.publicFact.aliasToNameColumnMap,
@@ -1312,15 +1412,16 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     }
 
     queryContext.requestModel.orFilterMeta.foreach {
-      orFilterMeta => if(orFilterMeta.isFactFilters) {
-        havingFilters += FilterDruid.renderOrFactFilters(orFilterMeta.orFliter.filters,
-          queryContext.factBestCandidate.publicFact.aliasToNameColumnMap,
-          fact.columnsByNameMap)
-      } else {
-        whereFilters += FilterDruid.renderOrDimFilters(orFilterMeta.orFliter.filters,
-          queryContext.factBestCandidate.publicFact.aliasToNameColumnMap,
-          fact.columnsByNameMap, Option(fact.grain))
-      }
+      orFilterMeta =>
+        if (orFilterMeta.isFactFilters) {
+          havingFilters += FilterDruid.renderOrFactFilters(orFilterMeta.orFliter.filters,
+            queryContext.factBestCandidate.publicFact.aliasToNameColumnMap,
+            fact.columnsByNameMap)
+        } else {
+          whereFilters += FilterDruid.renderOrDimFilters(orFilterMeta.orFliter.filters,
+            queryContext.factBestCandidate.publicFact.aliasToNameColumnMap,
+            fact.columnsByNameMap, Option(fact.grain))
+        }
     }
 
     (whereFilters, havingFilters)
@@ -1331,7 +1432,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     IndexedSeq.empty[String]
   }
 
-  private[this] def ephemeralAliasColumnMap(queryContext: FactQueryContext) : Map[String, Column] = {
+  private[this] def ephemeralAliasColumnMap(queryContext: FactQueryContext): Map[String, Column] = {
     val aliasColumnMapFromPostResultCols = new mutable.HashMap[String, Column]()
 
     queryContext.factBestCandidate.fact.factColMap.foreach {
@@ -1339,7 +1440,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         factCol.asInstanceOf[PostResultDerivedFactColumn].postResultFunction.sourceColumns.foreach {
           sc => {
             val column: Column = queryContext.factBestCandidate.fact.columnsByNameMap(sc)
-            if(!queryContext.factBestCandidate.requestCols.contains(column.name)){
+            if (!queryContext.factBestCandidate.requestCols.contains(column.name)) {
               aliasColumnMapFromPostResultCols += (sc -> column)
             }
           }

--- a/core/src/test/scala/com/yahoo/maha/core/query/DefaultQueryPipelineFactoryTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/DefaultQueryPipelineFactoryTest.scala
@@ -1596,7 +1596,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
     }.run()
 
     assert(result.isFailure, result)
-    assert(result.failed.get.getMessage === "requirement failed: query execution failed with message : ", result)
+    assert(result.failed.get.getMessage === "query execution failed", result)
   }
 
   test("successfully generate fallback query on async request with force engine and execute it when no joins required") {

--- a/core/src/test/scala/com/yahoo/maha/core/query/MultiEngineQueryTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/MultiEngineQueryTest.scala
@@ -20,13 +20,13 @@ class MultiEngineQueryTest extends FunSuite with Matchers with BaseQueryGenerato
     val qc = new MultiEngineQuery(dimQuery, Set(OracleEngine, DruidEngine), IndexedSeq(factQuery))
     val irlFn = (q : Query) => new DimDrivenPartialRowList("Advertiser ID", q)
     val result = qc.execute(queryExecutorContext, irlFn, QueryAttributes.empty, new EngineQueryStats)
-    result._1.foreach {
+    result.rowList.foreach {
       r =>
         model.requestCols.map(_.alias).foreach {
           col => assert(r.getValue(col) === s"$col-value")
         }
     }
-    val queryAttribute = result._2.getAttribute(QueryAttributes.QueryStats)
+    val queryAttribute = result.queryAttributes.getAttribute(QueryAttributes.QueryStats)
     assert(queryAttribute.isInstanceOf[QueryStatsAttribute] && queryAttribute.asInstanceOf[QueryStatsAttribute].stats.getStats.size > 1)
   }
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/MultiQueryTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/MultiQueryTest.scala
@@ -17,7 +17,7 @@ class MultiQueryTest extends FunSuite with Matchers with BaseQueryGeneratorTest 
     val qc = new MultiQuery(List(dimQuery, dimQuery))
     val irlFn = (q : Query) => new DimDrivenPartialRowList("Advertiser ID", q)
     val result = qc.execute(queryExecutorContext, irlFn, QueryAttributes.empty, new EngineQueryStats)
-    result._1.foreach {
+    result.rowList.foreach {
       r =>
         model.requestCols.map(_.alias).foreach {
           col => assert(r.getValue(col) === s"$col-value")

--- a/core/src/test/scala/com/yahoo/maha/core/query/SingleEngineQueryTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/SingleEngineQueryTest.scala
@@ -17,13 +17,13 @@ class SingleEngineQueryTest extends FunSuite with Matchers with BaseQueryGenerat
     val query = getQuery(OracleEngine, getDimQueryContext(OracleEngine, getRequestModel(dimOnlyQueryJson), None), DimOnlyQuery)
     val qc = new SingleEngineQuery(query)
     val result = qc.execute(queryExecutorContext, (q) => new CompleteRowList(q), QueryAttributes.empty, new EngineQueryStats)
-    result._1.foreach {
+    result.rowList.foreach {
       r =>
         query.queryContext.requestModel.requestCols.filter(_.isInstanceOf[DimColumnInfo]).map(_.asInstanceOf[DimColumnInfo].alias).foreach {
           col => assert(r.getValue(col) === s"$col-value")
         }
     }
-    val queryAttribute = result._2.getAttribute(QueryAttributes.QueryStats)
+    val queryAttribute = result.queryAttributes.getAttribute(QueryAttributes.QueryStats)
     assert(queryAttribute.isInstanceOf[QueryStatsAttribute] && queryAttribute.asInstanceOf[QueryStatsAttribute].stats.getStats.nonEmpty)
   }
 
@@ -31,13 +31,13 @@ class SingleEngineQueryTest extends FunSuite with Matchers with BaseQueryGenerat
     val query = getQuery(OracleEngine, getFactQueryContext(OracleEngine, getRequestModel(factOnlyQueryJson), None, QueryAttributes.empty), FactOnlyQuery)
     val qc = new SingleEngineQuery(query)
     val result = qc.execute(queryExecutorContext, (q) => new CompleteRowList(q), QueryAttributes.empty, new EngineQueryStats)
-    result._1.foreach {
+    result.rowList.foreach {
       r =>
         query.queryContext.requestModel.requestCols.filter(_.isInstanceOf[FactColumnInfo]).map(_.asInstanceOf[FactColumnInfo].alias).foreach {
           col => assert(r.getValue(col) === s"$col-value")
         }
     }
-    val queryAttribute = result._2.getAttribute(QueryAttributes.QueryStats)
+    val queryAttribute = result.queryAttributes.getAttribute(QueryAttributes.QueryStats)
     assert(queryAttribute.isInstanceOf[QueryStatsAttribute] && queryAttribute.asInstanceOf[QueryStatsAttribute].stats.getStats.nonEmpty)
   }
 
@@ -45,13 +45,13 @@ class SingleEngineQueryTest extends FunSuite with Matchers with BaseQueryGenerat
     val query = getQuery(OracleEngine, getCombinedQueryContext(OracleEngine, getRequestModel(combinedQueryJson), None, QueryAttributes.empty), DimFactQuery)
     val qc = new SingleEngineQuery(query)
     val result = qc.execute(queryExecutorContext, (q) => new CompleteRowList(q), QueryAttributes.empty, new EngineQueryStats)
-    result._1.foreach {
+    result.rowList.foreach {
       r =>
         query.queryContext.requestModel.requestCols.filterNot(_.isInstanceOf[ConstantColumnInfo]).map(_.alias).foreach {
           col => assert(r.getValue(col) === s"$col-value")
         }
     }
-    val queryAttribute = result._2.getAttribute(QueryAttributes.QueryStats)
+    val queryAttribute = result.queryAttributes.getAttribute(QueryAttributes.QueryStats)
     assert(queryAttribute.isInstanceOf[QueryStatsAttribute] && queryAttribute.asInstanceOf[QueryStatsAttribute].stats.getStats.nonEmpty)
   }
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
@@ -34,6 +34,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
     registryBuilder.register(pubfact5(forcedFilters))
     registryBuilder.register(pubfact6(forcedFilters))
     registryBuilder.register(pubfact7(forcedFilters))
+    registryBuilder.register(pubfact8(forcedFilters))
   }
 
   private[this] def factBuilder(annotations: Set[FactAnnotation]): FactBuilder = {
@@ -55,7 +56,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
           , DruidFuncDimCol("Derived Pricing Type", IntType(3), DECODE_DIM("{price_type}", "7", "6"))
           , DimCol("start_time", DateType("yyyyMMddHH"))
           , DimCol("landing_page_url", StrType(), annotations = Set(EscapingRequired))
-          , DimCol("Landing URL Translation", StrType(100, (Map("Valid"->"Something"), "Empty")), alias = Option("landing_page_url"))
+          , DimCol("Landing URL Translation", StrType(100, (Map("Valid" -> "Something"), "Empty")), alias = Option("landing_page_url"))
           , DimCol("stats_date", DateType("yyyyMMdd"), Some("statsDate"))
           , DimCol("engagement_type", StrType(3))
           , DruidPostResultFuncDimCol("Month", DateType(), postResultFunction = START_OF_THE_MONTH("{stats_date}"))
@@ -81,9 +82,9 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
           , FactCol("min_bid", DecType(0, "0.0"), MinRollup)
           , FactCol("avg_bid", DecType(0, "0.0"), AverageRollup)
           , FactCol("avg_pos_times_impressions", DecType(0, "0.0"), MaxRollup)
-          , FactCol("engagement_count", IntType(0,0))
-          , ConstFactCol("const_a", IntType(0,0), "0")
-          , ConstFactCol("const_b", IntType(0,0), "0")
+          , FactCol("engagement_count", IntType(0, 0))
+          , ConstFactCol("const_a", IntType(0, 0), "0")
+          , ConstFactCol("const_b", IntType(0, 0), "0")
           , DruidConstDerFactCol("Const Der Fact Col C", DecType(), "{const_a}" / "{const_b}", "0")
           , DruidDerFactCol("Average CPC", DecType(), "{spend}" / "{clicks}")
           , DruidDerFactCol("CTR", DecType(), "{clicks}" /- "{impressions}")
@@ -143,7 +144,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
           , FactCol("min_bid", DecType(0, "0.0"), MinRollup)
           , FactCol("avg_bid", DecType(0, "0.0"), AverageRollup)
           , FactCol("avg_pos_times_impressions", DecType(0, "0.0"), MaxRollup)
-          , FactCol("engagement_count", IntType(0,0))
+          , FactCol("engagement_count", IntType(0, 0))
           , DruidDerFactCol("Average CPC", DecType(), "{spend}" / "{clicks}")
           , DruidDerFactCol("CTR", DecType(), "{clicks}" /- "{impressions}")
           , DruidDerFactCol("derived_avg_pos", DecType(3, "0.0", "0.1", "500"), "{avg_pos_times_impressions}" /- "{impressions}")
@@ -193,7 +194,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
           , FactCol("min_bid", DecType(0, "0.0"), MinRollup)
           , FactCol("avg_bid", DecType(0, "0.0"), AverageRollup)
           , FactCol("avg_pos_times_impressions", DecType(0, "0.0"), MaxRollup)
-          , FactCol("engagement_count", IntType(0,0))
+          , FactCol("engagement_count", IntType(0, 0))
           , DruidDerFactCol("Average CPC", DecType(), "{spend}" / "{clicks}")
           , DruidDerFactCol("CTR", DecType(), "{clicks}" /- "{impressions}")
           , DruidDerFactCol("derived_avg_pos", DecType(3, "0.0", "0.1", "500"), "{avg_pos_times_impressions}" /- "{impressions}")
@@ -465,7 +466,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
   }
 
   private[this] def pubfact_start_time(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
-    factBuilder2(Set(DruidGroupByStrategyV1,DruidGroupByIsSingleThreaded(false)))
+    factBuilder2(Set(DruidGroupByStrategyV1, DruidGroupByIsSingleThreaded(false)))
       .toPublicFact("k_stats_start_time",
         Set(
           PubCol("Day", "Day", InBetweenEquality),
@@ -547,7 +548,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
 
   private[this] def pubfact5(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
 
-    val tableOne  = {
+    val tableOne = {
       ColumnContext.withColumnContext {
         import DruidExpression._
         implicit dc: ColumnContext =>
@@ -572,7 +573,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
       }
     }
 
-    val tableTwo  = {
+    val tableTwo = {
       ColumnContext.withColumnContext {
         import DruidExpression._
         implicit dc: ColumnContext =>
@@ -633,7 +634,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
           PublicFactCol("clicks", "Clicks", InBetweenEquality),
           PublicFactCol("spend", "Spend", Set.empty),
           PublicFactCol("Const Der Fact Col A", "Const Der Fact Col A", InBetweenEquality)
-        ), Set(EqualityFilter("Test Flag", "0", isForceFilter = true)),  getMaxDaysWindow, getMaxDaysLookBack
+        ), Set(EqualityFilter("Test Flag", "0", isForceFilter = true)), getMaxDaysWindow, getMaxDaysLookBack
       )
   }
 
@@ -678,7 +679,45 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
       )
   }
 
-  protected[this] def getDruidQueryGenerator : DruidQueryGenerator = {
+  private[this] def pubfact8(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+    ColumnContext.withColumnContext { implicit dc: ColumnContext =>
+      Fact.newFact(
+        "fact8", HourlyGrain, DruidEngine, Set(AdvertiserSchema),
+        Set(
+          DimCol("id", IntType(), annotations = Set(ForeignKey("keyword")))
+          , DimCol("campaign_id", IntType(), annotations = Set(ForeignKey("campaign")))
+          , DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+          , DimCol("price_type", IntType(3, (Map(1 -> "CPC", 2 -> "CPA", 3 -> "CPM", 6 -> "CPV", 7 -> "CPCV", 8 -> "CPV", -10 -> "CPE", -20 -> "CPF"), "NONE")))
+          , DruidFuncDimCol("Derived Pricing Type", IntType(3), DECODE_DIM("{price_type}", "7", "6", "2", "1", "{price_type}"))
+          , DruidFuncDimCol("My Date", DateType(), DRUID_TIME_FORMAT("YYYY-MM-dd HH"))
+
+        ),
+        Set(
+          FactCol("impressions", IntType(3, 1))
+          , FactCol("clicks", IntType(3, 0, 1, 800))
+        ),
+        annotations = Set(DruidGroupByStrategyV2),
+        underlyingTableName = Some("fact1")
+      )
+    }.toPublicFact("k_stats_select",
+      Set(
+        PubCol("My Date", "Day", InBetweenEquality),
+        PubCol("id", "Keyword ID", InEquality),
+        PubCol("campaign_id", "Campaign ID", InEquality),
+        PubCol("advertiser_id", "Advertiser ID", InEquality),
+        PubCol("price_type", "Pricing Type", In),
+        PubCol("Derived Pricing Type", "Derived Pricing Type", InEquality),
+      ),
+      Set(
+        PublicFactCol("impressions", "Impressions", InBetweenEquality)
+        , PublicFactCol("clicks", "Clicks", InBetweenEquality)
+      ),
+      Set(),
+      getMaxDaysWindow, getMaxDaysLookBack, renderLocalTimeFilter = false, dimRevision = 2
+    )
+  }
+
+  protected[this] def getDruidQueryGenerator: DruidQueryGenerator = {
     new DruidQueryGenerator(new SyncDruidQueryOptimizer(timeout = 5000), 40000)
   }
 }

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/druid/src/main/scala/com/yahoo/maha/executor/druid/DruidQueryExecutor.scala
+++ b/druid/src/main/scala/com/yahoo/maha/executor/druid/DruidQueryExecutor.scala
@@ -5,53 +5,57 @@ package com.yahoo.maha.executor.druid
 import java.io.Closeable
 import java.math.MathContext
 import java.nio.charset.StandardCharsets
+
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 import com.ning.http.client.Response
 import com.yahoo.maha.core._
+import com.yahoo.maha.core.fact.FactColumn
 import com.yahoo.maha.core.query._
-import com.yahoo.maha.core.query.druid.{DruidQuery, GroupByDruidQuery, TimeseriesDruidQuery, TopNDruidQuery}
+import com.yahoo.maha.core.query.druid._
 import grizzled.slf4j.Logging
 import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormatter
+import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods._
+
 import scala.collection.concurrent.TrieMap
 import scala.util.{Failure, Try}
 
 /**
- * Created by hiral on 12/22/15.
- */
+  * Created by hiral on 12/22/15.
+  */
 
 trait AuthHeaderProvider {
-  def getAuthHeaders : Map[String, String]
+  def getAuthHeaders: Map[String, String]
 }
 
 class NoopAuthHeaderProvider extends AuthHeaderProvider {
   override def getAuthHeaders = Map.empty
 }
 
-case class DruidQueryExecutorConfig(maxConnectionsPerHost:Int
-                                    , maxConnections:Int
-                                    , connectionTimeout:Int
-                                    , timeoutRetryInterval:Int
-                                    , timeoutThreshold:Int
-                                    , degradationConfigName:String
-                                    , url: String ,headers : Option[Map[String, String]] = None
-                                    , readTimeout:Int
-                                    , requestTimeout:Int
-                                    , pooledConnectionIdleTimeout:Int
-                                    , timeoutMaxResponseTimeInMs:Int
-                                    , enableRetryOn500:Boolean
-                                    , retryDelayMillis:Int
+case class DruidQueryExecutorConfig(maxConnectionsPerHost: Int
+                                    , maxConnections: Int
+                                    , connectionTimeout: Int
+                                    , timeoutRetryInterval: Int
+                                    , timeoutThreshold: Int
+                                    , degradationConfigName: String
+                                    , url: String, headers: Option[Map[String, String]] = None
+                                    , readTimeout: Int
+                                    , requestTimeout: Int
+                                    , pooledConnectionIdleTimeout: Int
+                                    , timeoutMaxResponseTimeInMs: Int
+                                    , enableRetryOn500: Boolean
+                                    , retryDelayMillis: Int
                                     , maxRetry: Int
                                     , enableFallbackOnUncoveredIntervals: Boolean = false
                                     , sslContextVersion: String = "TLSv1.2"
                                     , commaSeparatedCipherSuitesList: String = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA"
-                                     )
+                                   )
 
 object DruidQueryExecutor extends Logging {
 
+  val timeStampFormatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZoneUTC()
   val DRUID_RESPONSE_CONTEXT = "X-Druid-Response-Context"
   val UNCOVERED_INTERVAL_VALUE = "uncoveredIntervals"
 
@@ -69,51 +73,72 @@ object DruidQueryExecutor extends Logging {
       }
     })
 
-  def parseHelper(grain: Grain, row:Row,resultAlias:String,resultValue:JValue,aliasColumnMap:Map[String,Column], transformers: List[ResultSetTransformer]): Unit ={
-    if(aliasColumnMap.contains(resultAlias)) {
-      val column = aliasColumnMap(resultAlias)
+  def parseHelper(grain: Grain, row: Row, outputAlias: String, resultValue: JValue, aliasColumnMap: Map[String, Column], transformers: List[ResultSetTransformer]): Unit = {
+    if (aliasColumnMap.contains(outputAlias)) {
+      val column = aliasColumnMap(outputAlias)
       transformers.foreach(transformer => {
-        if (transformer.canTransform(resultAlias, column)) {
+        if (transformer.canTransform(outputAlias, column)) {
           val transformedValue = extractField(resultValue)
-          if(DruidQuery.replaceMissingValueWith.equals(transformedValue)) {
+          if (DruidQuery.replaceMissingValueWith.equals(transformedValue)) {
             throw new IllegalStateException(DruidQuery.replaceMissingValueWith)
           }
-          val tv = transformer.transform(grain, resultAlias, column, transformedValue)
-          row.addValue(resultAlias, tv)
+          val tv = transformer.transform(grain, outputAlias, column, transformedValue)
+          row.addValue(outputAlias, tv)
         }
       })
     }
   }
 
-  def processResult[T <: QueryRowList](query:Query
-                                  , transformers: List[ResultSetTransformer]
-                                  , getRow: List[JField] => Row
-                                  , getEphemeralRow: List[JField] => Row
-                                  , rowList: T
-                                  , jsonString: String
-                                  , eventObject: List[JField]): Unit = {
+  def processResult[T <: QueryRowList](query: Query
+                                       , transformers: List[ResultSetTransformer]
+                                       , getRow: List[JField] => Row
+                                       , getEphemeralRow: List[JField] => Row
+                                       , rowList: T
+                                       , jsonString: String
+                                       , eventObject: List[JField]
+                                       , factsMappedToAlias: Boolean = true
+                                      ): Unit = {
     val aliasColumnMap = query.aliasColumnMap
     val ephemeralAliasColumnMap = query.ephemeralAliasColumnMap
-    val row =getRow(eventObject)
-    val ephemeralRow: Option[Row] = if(!rowList.ephemeralColumnNames.isEmpty) {
+    val row = getRow(eventObject)
+    val ephemeralRow: Option[Row] = if (!rowList.ephemeralColumnNames.isEmpty) {
       Option(getEphemeralRow(eventObject))
     } else {
       None
     }
-    eventObject.foreach{
+    val resultAliasToOutputAliasMap = if (factsMappedToAlias) {
+      aliasColumnMap.map { case (alias, col) => alias -> alias }
+    } else {
+      aliasColumnMap.map {
+        case (alias, col) =>
+          if (col.isInstanceOf[FactColumn]) {
+            col.alias.getOrElse(col.name) -> alias
+          } else {
+            alias -> alias
+          }
+      }
+    }
+    eventObject.foreach {
       case (resultAlias, resultValue) =>
-        if(rowList.columnNames.contains(resultAlias)) {
-          parseHelper(query.queryContext.requestModel.queryGrain.getOrElse(DailyGrain),
-            row, resultAlias, resultValue, aliasColumnMap, transformers)
-        } else if(rowList.ephemeralColumnNames.contains(resultAlias) && ephemeralRow.isDefined) {
+        if (resultAliasToOutputAliasMap.contains(resultAlias)) {
+          val outputAlias = resultAliasToOutputAliasMap(resultAlias)
+          if (rowList.columnNames.contains(outputAlias)) {
+            parseHelper(query.queryContext.requestModel.queryGrain.getOrElse(DailyGrain),
+              row, outputAlias, resultValue, aliasColumnMap, transformers)
+          } else {
+            if (query.queryContext.requestModel.isDebugEnabled) {
+              info(s"Skipping result from druid which is not in columnNames : $resultAlias : $resultValue")
+            }
+          }
+        } else if (rowList.ephemeralColumnNames.contains(resultAlias) && ephemeralRow.isDefined) {
           parseHelper(query.queryContext.requestModel.queryGrain.getOrElse(DailyGrain),
             ephemeralRow.get, resultAlias, resultValue, ephemeralAliasColumnMap, transformers)
+
         } else {
-          if(query.queryContext.requestModel.isDebugEnabled) {
-            info(s"Skipping result from druid which is not in columnNames : $resultAlias : $resultValue")
+          if (query.queryContext.requestModel.isDebugEnabled) {
+            info(s"Skipping result from druid which could not be mapped to outputAlias or ephemeral column names : $resultAlias : $resultValue")
           }
         }
-      case other => throw new UnsupportedOperationException(s"Unexpected field in GroupByDruidQuery json response : $other")
     }
     try {
       rowList.addRow(row, ephemeralRow)
@@ -124,70 +149,91 @@ object DruidQueryExecutor extends Logging {
     }
   }
 
-  def parseJsonAndPopulateResultSet[T <: QueryRowList](query:Query,response:Response,rowList: T, getRow: List[JField] => Row, getEphemeralRow: List[JField] => Row,
-                                                  transformers: List[ResultSetTransformer]  ) : Unit ={
-    val jsonString : String = response.getResponseBody(StandardCharsets.UTF_8.displayName())
+  def parseJsonAndPopulateResultSet[T <: QueryRowList](query: Query, response: Response, rowList: T, getRow: List[JField] => Row, getEphemeralRow: List[JField] => Row,
+                                                       transformers: List[ResultSetTransformer]): Option[JValue] = {
+    var pagination: Option[JValue] = None
+    val jsonString: String = response.getResponseBody(StandardCharsets.UTF_8.displayName())
 
-    if(query.queryContext.requestModel.isDebugEnabled) {
+    if (query.queryContext.requestModel.isDebugEnabled) {
       info("received http response " + jsonString)
     }
     require(response.getStatusCode == 200, s"received status code from druid is ${response.getStatusCode} instead of 200 : $jsonString")
 
     val si: Int = query.queryContext.requestModel.startIndex
-    val startIndex: Int = if(si < 0) {
+    val startIndex: Int = if (si < 0) {
       0
     } else {
       si
     }
-    if(query.queryContext.requestModel.isDebugEnabled) {
+    if (query.queryContext.requestModel.isDebugEnabled) {
       info(s"starIndex=$startIndex")
     }
 
-    var rowsCount : Int = 0
+    var rowsCount: Int = 0
     query match {
-      case TimeseriesDruidQuery(_,_,_,_,_,_) =>
-        val json =parse(jsonString)
-        json  match {
+      case TimeseriesDruidQuery(_, _, _, _, _, _) =>
+        val json = parse(jsonString)
+        val grainFieldsAliasColumnMap: Map[String, Column] = query.aliasColumnMap.filter { case (alias, col) => Grain.grainFields(alias) }
+        var injectedGrainFields: List[(String, JValue)] = List.empty
+        json match {
           case JArray(rows) =>
-            if(query.queryContext.requestModel.isDebugEnabled) {
+            if (query.queryContext.requestModel.isDebugEnabled) {
               info(s"Timeseries rows.size=${rows.size}")
             }
             rows.foreach {
               case JObject(cols) =>
                 rowsCount += 1
                 cols.foreach {
-                  case (alias, jvalue) if alias == "timestamp" =>  // TODO timestamp support
+                  case (alias, JString(sTimestamp)) if alias == "timestamp" && grainFieldsAliasColumnMap.nonEmpty =>
+                    //need to inject timestamp
+                    injectedGrainFields = grainFieldsAliasColumnMap.map {
+                      case (grainAlias, col) =>
+                        //we already know this grain alias exists
+                        val formattedString: String = col.dataType match {
+                          case DateType(format) if format.isDefined =>
+                            val formatter = DateTransformer.getDateTimeFormatter(format.get)
+                            formatter.print(timeStampFormatter.parseDateTime(sTimestamp))
+                          case _ =>
+                            Grain.getGrainByField(grainAlias).get.toFormattedString(timeStampFormatter.parseDateTime(sTimestamp))
+                        }
+                        (grainAlias, JString(formattedString))
+                    }.toList
                   case (alias, jvalue) if alias == "result" =>
                     jvalue match {
                       case JObject(eventObject) =>
-                        processResult(query, transformers, getRow, getEphemeralRow, rowList, jsonString, eventObject)
+                        processResult(query, transformers, getRow, getEphemeralRow, rowList, jsonString, eventObject ++ injectedGrainFields)
+                        injectedGrainFields = List.empty
                       case unmatched => throw new UnsupportedOperationException(s"Unexpected field in timeseries json response : $unmatched")
                     }
-                  case a => throw new UnsupportedOperationException(s"Unexpected field in timeseries json response : $a")
+                  case other => //ignore
+                    if (query.queryContext.requestModel.isDebugEnabled) {
+                      info(s"unhandled field : $other")
+                    }
+                    throw new UnsupportedOperationException(s"Unexpected field in timeseries json response : $other")
                 }
-              case nonJobject => new UnsupportedOperationException(s"Unexpected field in timeseries json response : $nonJobject")
+              case nonJobject => throw new UnsupportedOperationException(s"Unexpected field in timeseries json response : $nonJobject")
             }
           case other => throw new UnsupportedOperationException(s"Unexpected field in timeseries json response : $other")
         }
 
-      case TopNDruidQuery(_,_,_,_,_,_)=>
+      case TopNDruidQuery(_, _, _, _, _, _) =>
         val json = parse(jsonString)
         json match {
           case JArray(rows) =>
-            if(query.queryContext.requestModel.isDebugEnabled) {
+            if (query.queryContext.requestModel.isDebugEnabled) {
               info(s"TopN rows.size=${rows.size}")
             }
             rows.foreach {
               case JObject(jobject) =>
-                jobject.foreach{
-                  case (alias, jvalue) if alias=="timestamp" =>  // TODO timestamp support
-                  case (alias,jvalue) if alias=="result" =>
-                    jvalue match{
-                      case JArray(resultRows)  =>
-                        if(query.queryContext.requestModel.isDebugEnabled) {
+                jobject.foreach {
+                  case (alias, jvalue) if alias == "timestamp" => // TODO timestamp support
+                  case (alias, jvalue) if alias == "result" =>
+                    jvalue match {
+                      case JArray(resultRows) =>
+                        if (query.queryContext.requestModel.isDebugEnabled) {
                           info(s"results size=${resultRows.size}")
                         }
-                        resultRows.drop(startIndex).foreach{
+                        resultRows.drop(startIndex).foreach {
                           case JObject(eventObject) =>
                             rowsCount += 1
                             processResult(query, transformers, getRow, getEphemeralRow, rowList, jsonString, eventObject)
@@ -195,83 +241,153 @@ object DruidQueryExecutor extends Logging {
                         }
                       case other => throw new UnsupportedOperationException(s"Unexpected field in TopNDruidQuery json response : $other")
                     }
-                  case other => throw new UnsupportedOperationException(s"Unexpected field in TopNDruidQuery json response : $other")
+                  case other => //ignore
+                    if (query.queryContext.requestModel.isDebugEnabled) {
+                      info(s"unhandled field : $other")
+                    }
+                    throw new UnsupportedOperationException(s"Unexpected field in TopNDruidQuery json response : $other")
                 }
               case other => throw new UnsupportedOperationException(s"Unexpected field in TopNDruidQuery json response : $other")
             }
           case other => throw new UnsupportedOperationException(s"Unexpected field in TopNDruidQuery json response : $other")
         }
 
-      case GroupByDruidQuery(_,_,_,_,_,_,_)=>
+      case GroupByDruidQuery(_, _, _, _, _, _, _) =>
         val json = parse(jsonString)
         json match {
           case JArray(rows) =>
-            if(query.queryContext.requestModel.isDebugEnabled) {
+            if (query.queryContext.requestModel.isDebugEnabled) {
               info(s"GroupBy rows.size=${rows.size}")
             }
             rows.drop(startIndex).foreach {
               case JObject(jobject) =>
                 rowsCount += 1
-                jobject.foreach{
-                  case (alias, jvalue) if (alias == "timestamp" || alias == "version") => //TODO timestamp support
-                  case (alias,jvalue) if alias=="event" =>
-                    jvalue match{
-                      case JObject(eventObject)  =>
+                jobject.foreach {
+                  case (alias, jvalue) if alias == "timestamp" || alias == "version" => //TODO timestamp support
+                  case (alias, jvalue) if alias == "event" =>
+                    jvalue match {
+                      case JObject(eventObject) =>
                         processResult(query, transformers, getRow, getEphemeralRow, rowList, jsonString, eventObject)
                       case other => throw new UnsupportedOperationException(s"Unexpected field in GroupByDruidQuery json response : $other")
                     }
-                  case other => throw new UnsupportedOperationException(s"Unexpected field in GroupByDruidQuery json response : $other")
+                  case other => //ignore
+                    if (query.queryContext.requestModel.isDebugEnabled) {
+                      info(s"unhandled field : $other")
+                    }
+                    throw new UnsupportedOperationException(s"Unexpected field in GroupByDruidQuery json response : $other")
                 }
               case other => throw new UnsupportedOperationException(s"Unexpected field in GroupByDruidQuery json response : $other")
             }
           case other => throw new UnsupportedOperationException(s"Unexpected field in GroupByDruidQuery json response : $other")
         }
-      case other => new UnsupportedOperationException(s"Druid Query type not supported $other")
+      case SelectDruidQuery(_, _, _, _, _, _) =>
+        val json = parse(jsonString)
+        json match {
+          case JArray(rows) =>
+            if (query.queryContext.requestModel.isDebugEnabled) {
+              info(s"SelectQuery rows.size=${rows.size}")
+            }
+            rows.foreach {
+              case JObject(jobject) =>
+                jobject.foreach {
+                  case (alias, jvalue) if alias == "timestamp" => // TODO timestamp support
+                  case (alias, jvalue) if alias == "result" =>
+                    jvalue match {
+                      case JObject(resultFields) =>
+                        resultFields.foreach {
+                          case (rfAlias, rfJValue) if rfAlias == "pagingIdentifiers" =>
+                            pagination = Option(JObject((rfAlias, rfJValue)))
+                          case (rfAlias, rfJValue) if rfAlias == "events" =>
+                            rfJValue match {
+                              case JArray(eventsRows) =>
+                                if (query.queryContext.requestModel.isDebugEnabled) {
+                                  info(s"events size=${eventsRows.size}")
+                                }
+                                eventsRows.foreach {
+                                  case JObject(eventsFields) =>
+                                    eventsFields.foreach {
+                                      case (efAlias, efJValue) if efAlias == "event" =>
+                                        efJValue match {
+                                          case JObject(eventObject) =>
+                                            rowsCount += 1
+                                            processResult(query, transformers, getRow, getEphemeralRow, rowList, jsonString, eventObject, factsMappedToAlias = false)
+                                          case other => throw new UnsupportedOperationException(s"Unexpected field in SelectDruidQuery json response : $other")
+                                        }
+                                      case other =>
+                                        if (query.queryContext.requestModel.isDebugEnabled) {
+                                          info(s"ignore field from eventsFields : $other")
+                                        }
+                                    }
+                                  case other => throw new UnsupportedOperationException(s"Unexpected field in SelectDruidQuery json response : $other")
+
+                                }
+
+                              case other => throw new UnsupportedOperationException(s"Unexpected field in SelectDruidQuery json response : $other")
+                            }
+                          case other => //ignore
+                            if (query.queryContext.requestModel.isDebugEnabled) {
+                              info(s"ignoring unhandled field : $other")
+                            }
+                        }
+                      case other => throw new UnsupportedOperationException(s"Unexpected field in SelectDruidQuery json response : $other")
+                    }
+                  case other => //ignore
+                    if (query.queryContext.requestModel.isDebugEnabled) {
+                      info(s"unhandled field : $other")
+                    }
+                    throw new UnsupportedOperationException(s"Unexpected field in SelectDruidQuery json response : $other")
+                }
+              case other => throw new UnsupportedOperationException(s"Unexpected field in SelectDruidQuery json response : $other")
+            }
+          case other => throw new UnsupportedOperationException(s"Unexpected field in SelectDruidQuery json response : $other")
+        }
+      case other => throw new UnsupportedOperationException(s"Druid Query type not supported $other")
     }
-    if(query.queryContext.requestModel.isDebugEnabled) {
+    if (query.queryContext.requestModel.isDebugEnabled) {
       info(s"rowsCount=$rowsCount")
     }
-    if(query.isInstanceOf[DruidQuery[_]]) {
+    if (query.isInstanceOf[DruidQuery[_]]) {
       val druidQuery = query.asInstanceOf[DruidQuery[_]]
-      if(!druidQuery.isPaginated) {
+      if (!druidQuery.isPaginated) {
         require(rowsCount < druidQuery.maxRows
           , s"Non paginated query fails rowsCount < maxRows, partial result possible : rowsCount=$rowsCount maxRows=${druidQuery.maxRows}")
       }
     }
+    pagination
   }
 
-  def extractField[T<:JValue](field:T):Any ={
-    field match{
+  def extractField[T <: JValue](field: T): Any = {
+    field match {
       case JBool(boolean) => boolean
       case JString(_) => field.values
       case JDecimal(_) => field.values
       case JInt(_) => field.values
       case JDouble(_) => field.values
       case JLong(_) => field.values
-      case JNull|JNothing => null
-      case _ => throw new  UnsupportedOperationException("unsupported field type")
+      case JNull | JNothing => null
+      case _ => throw new UnsupportedOperationException("unsupported field type")
     }
   }
 }
 
-class DruidQueryExecutor(config:DruidQueryExecutorConfig , lifecycleListener: ExecutionLifecycleListener,
+class DruidQueryExecutor(config: DruidQueryExecutorConfig, lifecycleListener: ExecutionLifecycleListener,
                          transformers: List[ResultSetTransformer] = ResultSetTransformer.DEFAULT_TRANSFORMS,
                          authHeaderProvider: AuthHeaderProvider = new NoopAuthHeaderProvider) extends QueryExecutor with Logging with Closeable {
   val engine: Engine = DruidEngine
   val httpUtils = new HttpUtils(ClientConfig
     .getConfig(
       config.maxConnectionsPerHost
-      ,config.maxConnections
-      ,config.connectionTimeout
-      ,config.timeoutRetryInterval
-      ,config.timeoutThreshold
-      ,config.degradationConfigName
-      ,config.readTimeout
-      ,config.requestTimeout
-      ,config.pooledConnectionIdleTimeout
-      ,config.timeoutMaxResponseTimeInMs
-      ,config.sslContextVersion
-      ,config.commaSeparatedCipherSuitesList
+      , config.maxConnections
+      , config.connectionTimeout
+      , config.timeoutRetryInterval
+      , config.timeoutThreshold
+      , config.degradationConfigName
+      , config.readTimeout
+      , config.requestTimeout
+      , config.pooledConnectionIdleTimeout
+      , config.timeoutMaxResponseTimeInMs
+      , config.sslContextVersion
+      , config.commaSeparatedCipherSuitesList
     )
     , config.enableRetryOn500
     , config.retryDelayMillis
@@ -281,9 +397,9 @@ class DruidQueryExecutor(config:DruidQueryExecutorConfig , lifecycleListener: Ex
 
   override def close(): Unit = httpUtils.close()
 
-  def checkUncoveredIntervals(query : Query, response : Response, config: DruidQueryExecutorConfig) : Unit = {
+  def checkUncoveredIntervals(query: Query, response: Response, config: DruidQueryExecutorConfig): Unit = {
     val requestModel = query.queryContext.requestModel
-    val latestDate : DateTime = FilterDruid.getMaxDate(requestModel.utcTimeDayFilter, DailyGrain)
+    val latestDate: DateTime = FilterDruid.getMaxDate(requestModel.utcTimeDayFilter, DailyGrain)
     if (config.enableFallbackOnUncoveredIntervals
       && latestDate.isBeforeNow()
       && response.getHeaders().containsKey(DruidQueryExecutor.DRUID_RESPONSE_CONTEXT)
@@ -294,13 +410,13 @@ class DruidQueryExecutor(config:DruidQueryExecutorConfig , lifecycleListener: Ex
     }
   }
 
-  def execute[T <: RowList](query: Query, rowList: T, queryAttributes: QueryAttributes) : QueryResult[T] = {
+  def execute[T <: RowList](query: Query, rowList: T, queryAttributes: QueryAttributes): QueryResult[T] = {
     val acquiredQueryAttributes = lifecycleListener.acquired(query, queryAttributes)
     val debugEnabled = query.queryContext.requestModel.isDebugEnabled
-    if(!acceptEngine(query.engine)) {
+    if (!acceptEngine(query.engine)) {
       throw new UnsupportedOperationException(s"DruidQueryExecutor does not support query with engine=${query.engine}")
-    }else {
-      val headersWithAuthHeader = if(config.headers.isDefined) {
+    } else {
+      val headersWithAuthHeader = if (config.headers.isDefined) {
         Some(config.headers.get ++ authHeaderProvider.getAuthHeaders)
       } else {
         Some(authHeaderProvider.getAuthHeaders)
@@ -314,17 +430,18 @@ class DruidQueryExecutor(config:DruidQueryExecutorConfig , lifecycleListener: Ex
           val irl = rl.asInstanceOf[IndexedRowList]
           val isFactDriven = query.queryContext.requestModel.isFactDriven
           val performJoin = irl.size > 0
+          var pagination: Option[JValue] = null
           val result = Try {
-            val response : Response= httpUtils.post(url,httpUtils.POST,headersWithAuthHeader,Some(query.asString))
+            val response: Response = httpUtils.post(url, httpUtils.POST, headersWithAuthHeader, Some(query.asString))
 
-            val temp = checkUncoveredIntervals(query, response, config)
+            checkUncoveredIntervals(query, response, config)
 
-            DruidQueryExecutor.parseJsonAndPopulateResultSet(query,response,irl,(fieldList:List[JField] ) =>{
-              val indexName =irl.indexAlias
+            pagination = DruidQueryExecutor.parseJsonAndPopulateResultSet(query, response, irl, (fieldList: List[JField]) => {
+              val indexName = irl.indexAlias
               val fieldListMap = fieldList.toMap
-              val rowSet = if(performJoin) {
-                if(fieldListMap.contains(indexName)) {
-                  val indexValue =fieldListMap.get(indexName).get
+              val rowSet = if (performJoin) {
+                if (fieldListMap.contains(indexName)) {
+                  val indexValue = fieldListMap.get(indexName).get
                   val field = DruidQueryExecutor.extractField(indexValue)
                   if (field == null) {
                     error(s"Druid has null value : ${response.getResponseBody()}")
@@ -338,52 +455,50 @@ class DruidQueryExecutor(config:DruidQueryExecutorConfig , lifecycleListener: Ex
               } else {
                 Set(irl.newRow)
               }
-              if(rowSet.size > 0) {
+              if (rowSet.size > 0) {
                 rowSet.head
               }
               else irl.newRow
-            }, (fieldList: List[JField]) =>{
+            }, (fieldList: List[JField]) => {
               irl.newEphemeralRow
             }, transformers)
 
 
           }
-          result match{
+          result match {
             case Failure(e) =>
-              error(s"Exception occurred while executing druid query", e)
               Try(lifecycleListener.failed(query, acquiredQueryAttributes, e))
-              throw e
+              error(s"Exception occurred while executing druid query", e)
+              QueryResult(rl, acquiredQueryAttributes, QueryResultStatus.FAILURE, Option(e))
             case _ =>
               if (debugEnabled) {
                 info(s"rowList.size=${irl.size}, rowList.updatedSet=${irl.updatedSize}")
               }
-              QueryResult(rl, lifecycleListener.completed(query, acquiredQueryAttributes), QueryResultStatus.SUCCESS)
+              QueryResult(rl, acquiredQueryAttributes, QueryResultStatus.SUCCESS, pagination = pagination)
           }
 
         case rl if rl.isInstanceOf[QueryRowList] =>
           val qrl = rl.asInstanceOf[QueryRowList]
+          var pagination: Option[JValue] = None
           val result = Try {
-            val response = httpUtils.post(url,httpUtils.POST,headersWithAuthHeader,Some(query.asString))
+            val response = httpUtils.post(url, httpUtils.POST, headersWithAuthHeader, Some(query.asString))
 
-            val temp = checkUncoveredIntervals(query, response, config)
+            checkUncoveredIntervals(query, response, config)
 
-            DruidQueryExecutor.parseJsonAndPopulateResultSet(query,response,qrl,(fieldList: List[JField]) =>{
+            pagination = DruidQueryExecutor.parseJsonAndPopulateResultSet(query, response, qrl, (fieldList: List[JField]) => {
               qrl.newRow
-            }, (fieldList: List[JField]) =>{
+            }, (fieldList: List[JField]) => {
               qrl.newEphemeralRow
             }, transformers)
 
           }
           result match {
             case Failure(e) =>
-              error(s"Exception occurred while executing druid query", e)
               Try(lifecycleListener.failed(query, acquiredQueryAttributes, e))
-              e match {
-                case ise: IllegalStateException => QueryResult(rl, lifecycleListener.completed(query, acquiredQueryAttributes), QueryResultStatus.FAILURE, ise.getMessage)
-                case _ => throw e
-              }
+              error(s"Exception occurred while executing druid query", e)
+              QueryResult(rl, acquiredQueryAttributes, QueryResultStatus.FAILURE, Option(e))
             case _ =>
-              QueryResult(rl, lifecycleListener.completed(query, acquiredQueryAttributes), QueryResultStatus.SUCCESS)
+              QueryResult(rl, lifecycleListener.completed(query, acquiredQueryAttributes), QueryResultStatus.SUCCESS, pagination = pagination)
           }
       }
     }

--- a/druid/src/test/resources/logback-test.xml
+++ b/druid/src/test/resources/logback-test.xml
@@ -31,6 +31,7 @@
     <logger name="com.zaxxer.hikari" level="ERROR"/>
     <logger name="org.http4s.server.blaze" level="ERROR"/>
     <logger name="com.yahoo.maha.core.query" level="ERROR"/>
+    <logger name="com.yahoo.maha.executor.druid.filters" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="ASYNCFILE" />

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
@@ -6,11 +6,10 @@ import java.net.InetSocketAddress
 
 import cats.effect.IO
 import com.yahoo.maha.core.CoreSchema.{AdvertiserLowLatencySchema, AdvertiserSchema, InternalSchema, ResellerSchema}
-import com.yahoo.maha.core.DruidDerivedFunction.{DECODE_DIM, GET_INTERVAL_DATE}
+import com.yahoo.maha.core.DruidDerivedFunction.{DECODE_DIM, DRUID_TIME_FORMAT, GET_INTERVAL_DATE}
 import com.yahoo.maha.core.DruidPostResultFunction.{POST_RESULT_DECODE, START_OF_THE_MONTH, START_OF_THE_WEEK}
 import com.yahoo.maha.core.FilterOperation._
 import com.yahoo.maha.core._
-import com.yahoo.maha.core.query._
 import com.yahoo.maha.core.dimension._
 import com.yahoo.maha.core.fact.{DruidConstDerFactCol, PublicFactCol, _}
 import com.yahoo.maha.core.lookup.LongRangeLookup
@@ -20,14 +19,17 @@ import com.yahoo.maha.core.query.oracle.OracleQueryGenerator
 import com.yahoo.maha.core.registry.RegistryBuilder
 import com.yahoo.maha.core.request.{DebugValue, Parameter, ReportingRequest, SyncRequest}
 import com.yahoo.maha.executor.MockOracleQueryExecutor
+import io.druid.query.Result
+import io.druid.query.select.SelectResultValue
 import org.http4s.server.blaze.BlazeBuilder
 import org.json4s.JsonAST._
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
-
+import org.mockito.Mockito._
+import org.mockito.Matchers._
 
 /**
- * Created by hiral on 2/2/16.
- */
+  * Created by hiral on 2/2/16.
+  */
 
 class TestAuthHeaderProvider extends AuthHeaderProvider {
   override def getAuthHeaders = Map("c" -> "d")
@@ -35,14 +37,15 @@ class TestAuthHeaderProvider extends AuthHeaderProvider {
 
 class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterAll with BaseQueryGeneratorTest with SharedDimSchema with TestWebService {
   var server: org.http4s.server.Server[IO] = null
-  override def beforeAll() : Unit = {
+
+  override def beforeAll(): Unit = {
     super.beforeAll()
-    val builder = BlazeBuilder[IO].mountService(service,"/mock").bindSocketAddress(new InetSocketAddress("localhost",6667) )
+    val builder = BlazeBuilder[IO].mountService(service, "/mock").bindSocketAddress(new InetSocketAddress("localhost", 6667))
     server = builder.start.unsafeRunSync()
     info("Started blaze server")
   }
 
-  override def afterAll{
+  override def afterAll {
     info("Stopping blaze server")
     server.shutdown
   }
@@ -51,24 +54,25 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     registryBuilder.register(pubfact(forcedFilters))
     registryBuilder.register(pubfact2())
     registryBuilder.register(pubfact3())
+    registryBuilder.register(pubfact4())
   }
 
   val siteNameMap = Map(
-    1  ->  "SITE_1"
-    ,     2  ->  "SITE_2"
-    ,    3  ->  "SITE_3"
-    ,    4  ->  "SITE_4"
-    ,    5  ->  "SITE_5"
-    ,    6  ->  "SITE_6"
-    ,    7  ->  "SITE_7"
-    ,    8  ->  "SITE_8"
-    ,    9  ->  "SITE_9"
-    ,    10  ->  "SITE_10"
-    ,    11  ->  "SITE_11"
-    ,    12  ->  "SITE_12"
-    ,    13  ->  "SITE_13"
-    ,    14  ->  "SITE_14"
-    ,    15  ->  "SITE_15"
+    1 -> "SITE_1"
+    , 2 -> "SITE_2"
+    , 3 -> "SITE_3"
+    , 4 -> "SITE_4"
+    , 5 -> "SITE_5"
+    , 6 -> "SITE_6"
+    , 7 -> "SITE_7"
+    , 8 -> "SITE_8"
+    , 9 -> "SITE_9"
+    , 10 -> "SITE_10"
+    , 11 -> "SITE_11"
+    , 12 -> "SITE_12"
+    , 13 -> "SITE_13"
+    , 14 -> "SITE_14"
+    , 15 -> "SITE_15"
   )
 
   private[this] def pubfact3(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
@@ -87,15 +91,15 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
           , DimCol("age_group", IntType(10))
           , DimCol("rule_id", IntType(10))
           , DimCol("device", IntType(8, (Map(1 -> "SmartPhone", 2 -> "Tablet", 3 -> "Desktop", -1 -> "UNKNOWN"), "UNKNOWN")))
-          , DimCol("bidding_strategy", StrType(32),annotations = Set(EscapingRequired))
+          , DimCol("bidding_strategy", StrType(32), annotations = Set(EscapingRequired))
           , DimCol("install_type", IntType(10))
-          , DimCol("campaign_objective",StrType(40))
+          , DimCol("campaign_objective", StrType(40))
           , DimCol("publisher_id", IntType(10), annotations = Set(ForeignKey("publishers")))
           , DimCol("internal_bucket_id", StrType())
           , DimCol("winss", StrType())
           , DimCol("os", StrType())
-          , DimCol("gender",StrType())
-          , DimCol("traffic_type",StrType())
+          , DimCol("gender", StrType())
+          , DimCol("traffic_type", StrType())
         ),
         Set(
           FactCol("impressions", IntType(10, 0))
@@ -107,12 +111,12 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
           , FactCol("spend", DecType(0, "0.0"))
           , FactCol("spend_usd", DecType(0, "0.0"))
           , FactCol("click_probability", DecType(0, "0.0"))
-          , FactCol("conversions_probability", DecType(0,"0.0"))
-          , FactCol("ecpa_goal_usd", DecType(0,"0.0"))
-          , FactCol("rank_score", DecType(0,"0.0"))
-          , FactCol("alpha", DecType(0,"0.0"))
-          , FactCol("mappi_boost", DecType(0,"0.0"))
-          , FactCol("marketplace_floor", DecType(0,"0.0"))
+          , FactCol("conversions_probability", DecType(0, "0.0"))
+          , FactCol("ecpa_goal_usd", DecType(0, "0.0"))
+          , FactCol("rank_score", DecType(0, "0.0"))
+          , FactCol("alpha", DecType(0, "0.0"))
+          , FactCol("mappi_boost", DecType(0, "0.0"))
+          , FactCol("marketplace_floor", DecType(0, "0.0"))
           , DruidDerFactCol("Total in App Conv", DecType(), "{post_click_inapp_conv}" ++ "{post_install_inapp_conv}")
           , DruidDerFactCol("CTR", DecType(), "{clicks}" /- "{impressions}" * "100")
           , DruidDerFactCol("Average CPM", DecType(), "{spend}" /- "{impressions}" * "1000")
@@ -151,10 +155,10 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
           PubCol("publisher_id", "Publisher ID", InEqualityNotEquals),
           PubCol("internal_bucket_id", "Internal Bucket ID", InEqualityNotEquals),
           PubCol("campaign_objective", "Campaign Objective", InNotInEquality),
-          PubCol("winss","Winss", InNotInEquality),
-          PubCol("os","Os", InNotInEquality),
-          PubCol("gender","Gender", InNotInEquality),
-          PubCol("traffic_type","Traffic Type", InNotInEquality)
+          PubCol("winss", "Winss", InNotInEquality),
+          PubCol("os", "Os", InNotInEquality),
+          PubCol("gender", "Gender", InNotInEquality),
+          PubCol("traffic_type", "Traffic Type", InNotInEquality)
         )
         , Set(
           PublicFactCol("impressions", "Impressions", Set.empty),
@@ -177,15 +181,15 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
           PublicFactCol("Average PICPA", "Average PICPA", Set.empty),
           PublicFactCol("Average PCPI_CPA", "Average PCPI_CPA", Set.empty),
           PublicFactCol("Average ECPA Goal Usd", "Average ECPA Goal Usd", Set.empty),
-          PublicFactCol("Effective Bid","Effective Bid", Set.empty),
-          PublicFactCol("Efficiency","Efficiency", Set.empty),
-          PublicFactCol("Total in App Conv","Total in App Conv", Set.empty),
-          PublicFactCol("Pi Efficiency","Pi Efficiency", Set.empty)
+          PublicFactCol("Effective Bid", "Effective Bid", Set.empty),
+          PublicFactCol("Efficiency", "Efficiency", Set.empty),
+          PublicFactCol("Total in App Conv", "Total in App Conv", Set.empty),
+          PublicFactCol("Pi Efficiency", "Pi Efficiency", Set.empty)
 
         )
         , Set()
-        , Map((SyncRequest, HourlyGrain) -> 14,(SyncRequest,DailyGrain)->31)
-        , Map((SyncRequest, HourlyGrain) -> 14,(SyncRequest,DailyGrain)->31)
+        , Map((SyncRequest, HourlyGrain) -> 14, (SyncRequest, DailyGrain) -> 31)
+        , Map((SyncRequest, HourlyGrain) -> 14, (SyncRequest, DailyGrain) -> 31)
         , dimRevision = 1
       )
   }
@@ -194,7 +198,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     import DruidExpression._
     val factBuilder = ColumnContext.withColumnContext { implicit dc: ColumnContext =>
       Fact.newFact(
-        "fact_s_term", DailyGrain, DruidEngine, Set(AdvertiserSchema,  AdvertiserLowLatencySchema),
+        "fact_s_term", DailyGrain, DruidEngine, Set(AdvertiserSchema, AdvertiserLowLatencySchema),
         Set(
           DimCol("id", IntType(), annotations = Set(ForeignKey("keyword")))
           , DimCol("ad_id", IntType(), annotations = Set(ForeignKey("ad")))
@@ -210,7 +214,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
           , DimCol("show_sov_flag", IntType())
           , DimCol("device_id", IntType())
           , DimCol("site_id", IntType(10, (siteNameMap, "Others")))
-          , DruidFuncDimCol("device_type", StrType(), DECODE_DIM("{device_id}",  "1", "'Desktop'", "'SmartPhone'"))
+          , DruidFuncDimCol("device_type", StrType(), DECODE_DIM("{device_id}", "1", "'Desktop'", "'SmartPhone'"))
           , DruidPostResultFuncDimCol("Week", DateType(), postResultFunction = START_OF_THE_WEEK("{stats_date}"))
           , DruidPostResultFuncDimCol("Month", DateType(), postResultFunction = START_OF_THE_MONTH("{stats_date}"))
         ),
@@ -229,10 +233,10 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
           , DruidDerFactCol("Average Bid", DecType(8, "0.0"), "{weighted_bid_usd}" /- "{impresssions}")
           , DruidDerFactCol("Average CPC", DecType(), "{spend}" / "{clicks}")
           , DruidDerFactCol("CTR", DecType(), "{clicks}" /- "{impresssions}")
-          , DruidDerFactCol("Bid Mod", DecType(8, 5, "0.0"), "{weighted_bid_modifier}" /-"{bid_mod_impressions}")
+          , DruidDerFactCol("Bid Mod", DecType(8, 5, "0.0"), "{weighted_bid_modifier}" /- "{bid_mod_impressions}")
           , DruidDerFactCol("derived_avg_pos", DecType(8, 2, "0.0", "0.1", "500"), "{avg_pos_times_impressions}" /- "{impresssions}")
-          , DruidDerFactCol("Bid Modifier", DecType(0, 5, "0.0"), "{weighted_bid_modifier}" /-"{bid_mod_impressions}")
-          , DruidPostResultDerivedFactCol("Modified Bid", DecType(8, 5, "0.0"), "{Bid Modifier}" * "{Average Bid}", postResultFunction =POST_RESULT_DECODE("{Bid Mod}", "0", "{Average Bid}"))
+          , DruidDerFactCol("Bid Modifier", DecType(0, 5, "0.0"), "{weighted_bid_modifier}" /- "{bid_mod_impressions}")
+          , DruidPostResultDerivedFactCol("Modified Bid", DecType(8, 5, "0.0"), "{Bid Modifier}" * "{Average Bid}", postResultFunction = POST_RESULT_DECODE("{Bid Mod}", "0", "{Average Bid}"))
           , DruidPostResultDerivedFactCol("Impression Share", StrType(), "{impresssions}" /- "{sov_impresssions}", postResultFunction = POST_RESULT_DECODE("{show_sov_flag}", "0", "N/A"))
         ),
         annotations = Set()
@@ -244,52 +248,52 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     }
 
     factBuilder.toPublicFact("k_stats",
-        Set(
-          PubCol("stats_date", "Day", InBetweenEquality),
-          PubCol("id", "Keyword ID", InEquality),
-          PubCol("ad_id", "Ad ID", InEquality),
-          PubCol("ad_group_id", "Ad Group ID", InEquality),
-          PubCol("campaign_id", "Campaign ID", InEquality),
-          PubCol("advertiser_id", "Advertiser ID", InEquality),
-          PubCol("country_woeid", "Country WOEID", InEquality),
-          PubCol("stats_source", "Source", Equality),
-          PubCol("price_type", "Pricing Type", In),
-          PubCol("landing_page_url", "Destination URL", Set.empty),
-          PubCol("Week", "Week", InBetweenEquality),
-          PubCol("device_type", "Device Type", InNotInEquality),
-          PubCol("site_id", "External Site Name", InBetweenEquality),
-          PubCol("Month", "Month", InBetweenEquality)
-        ),
-        Set(
-          PublicFactCol("impresssions", "Impressions", InBetweenEquality),
-          PublicFactCol("Impression Share", "Impression Share", InBetweenEquality),
-          PublicFactCol("conversions", "Conversions", InBetweenEquality),
-          PublicFactCol("clicks", "Clicks", InBetweenEquality),
-          PublicFactCol("spend", "Spend", Set.empty),
-          PublicFactCol("derived_avg_pos", "Average Position", Set.empty),
-          PublicFactCol("max_bid", "Max Bid", Set.empty),
-          PublicFactCol("min_bid", "Min Bid", Set.empty),
-          PublicFactCol("Average Bid", "Average Bid", Set.empty),
-          PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
-          PublicFactCol("Bid Modifier", "Bid Modifier", InBetweenEquality),
-          PublicFactCol("Modified Bid", "Modified Bid", InBetweenEquality),
-          PublicFactCol("CTR", "CTR", InBetweenEquality)
-        ),
-        Set(),
-        getMaxDaysWindow, getMaxDaysLookBack, renderLocalTimeFilter = false
-      )
+      Set(
+        PubCol("stats_date", "Day", InBetweenEquality),
+        PubCol("id", "Keyword ID", InEquality),
+        PubCol("ad_id", "Ad ID", InEquality),
+        PubCol("ad_group_id", "Ad Group ID", InEquality),
+        PubCol("campaign_id", "Campaign ID", InEquality),
+        PubCol("advertiser_id", "Advertiser ID", InEquality),
+        PubCol("country_woeid", "Country WOEID", InEquality),
+        PubCol("stats_source", "Source", Equality),
+        PubCol("price_type", "Pricing Type", In),
+        PubCol("landing_page_url", "Destination URL", Set.empty),
+        PubCol("Week", "Week", InBetweenEquality),
+        PubCol("device_type", "Device Type", InNotInEquality),
+        PubCol("site_id", "External Site Name", InBetweenEquality),
+        PubCol("Month", "Month", InBetweenEquality)
+      ),
+      Set(
+        PublicFactCol("impresssions", "Impressions", InBetweenEquality),
+        PublicFactCol("Impression Share", "Impression Share", InBetweenEquality),
+        PublicFactCol("conversions", "Conversions", InBetweenEquality),
+        PublicFactCol("clicks", "Clicks", InBetweenEquality),
+        PublicFactCol("spend", "Spend", Set.empty),
+        PublicFactCol("derived_avg_pos", "Average Position", Set.empty),
+        PublicFactCol("max_bid", "Max Bid", Set.empty),
+        PublicFactCol("min_bid", "Min Bid", Set.empty),
+        PublicFactCol("Average Bid", "Average Bid", Set.empty),
+        PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
+        PublicFactCol("Bid Modifier", "Bid Modifier", InBetweenEquality),
+        PublicFactCol("Modified Bid", "Modified Bid", InBetweenEquality),
+        PublicFactCol("CTR", "CTR", InBetweenEquality)
+      ),
+      Set(),
+      getMaxDaysWindow, getMaxDaysLookBack, renderLocalTimeFilter = false
+    )
   }
 
   def pubfact2(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
 
-    val tableOne  = {
+    val tableOne = {
       ColumnContext.withColumnContext {
         import DruidExpression._
         implicit dc: ColumnContext =>
           Fact.newFactForView(
             "account_stats", DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
             Set(
-               DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+              DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
               , ConstDimCol("is_adjustment", StrType(1), "N")
               , DimCol("stats_date", DateType("YYYY-MM-DD"))
               , DimCol("test_flag", IntType())
@@ -307,14 +311,14 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
       }
     }
 
-    val tableTwo  = {
+    val tableTwo = {
       ColumnContext.withColumnContext {
         import DruidExpression._
         implicit dc: ColumnContext =>
           Fact.newFactForView(
             "a_adjustments", DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
             Set(
-               DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+              DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
               , ConstDimCol("is_adjustment", StrType(1), "Y")
               , DimCol("stats_date", DateType("YYYY-MM-DD"))
               , DimCol("test_flag", IntType())
@@ -339,7 +343,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
       implicit dc: ColumnContext =>
         Fact.newUnionView(view, DailyGrain, DruidEngine, Set(AdvertiserSchema, ResellerSchema),
           Set(
-             DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+            DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
             , DimCol("stats_date", DateType("YYYY-MM-DD"))
             , DimCol("test_flag", IntType())
             , DimCol("Test Flag", IntType(), alias = Option("{test_flag}"))
@@ -369,24 +373,68 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
           PublicFactCol("clicks", "Clicks", InBetweenEquality),
           PublicFactCol("spend", "Spend", Set.empty),
           PublicFactCol("Der Fact Col A", "Der Fact Col A", InBetweenEquality)
-        ), Set(EqualityFilter("Test Flag", "0", isForceFilter = true)),  getMaxDaysWindow, getMaxDaysLookBack
+        ), Set(EqualityFilter("Test Flag", "0", isForceFilter = true)), getMaxDaysWindow, getMaxDaysLookBack
       )
   }
 
+  private[this] def pubfact4(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+    ColumnContext.withColumnContext { implicit dc: ColumnContext =>
+      Fact.newFact(
+        "fact4", HourlyGrain, DruidEngine, Set(AdvertiserSchema),
+        Set(
+          DimCol("id", IntType(), annotations = Set(ForeignKey("keyword")))
+          , DimCol("campaign_id", IntType(), annotations = Set(ForeignKey("campaign")))
+          , DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+          , DimCol("price_type", IntType(3, (Map(1 -> "CPC", 2 -> "CPA", 3 -> "CPM", 6 -> "CPV", 7 -> "CPCV", 8 -> "CPV", -10 -> "CPE", -20 -> "CPF"), "NONE")))
+          , DruidFuncDimCol("Derived Pricing Type", IntType(3), DECODE_DIM("{price_type}", "7", "6", "2", "1", "{price_type}"))
+          , DruidFuncDimCol("My Date", DateType(), DRUID_TIME_FORMAT("YYYY-MM-dd HH"))
 
-  private[this] def getDruidQueryExecutor(url: String, enableFallbackOnUncoveredIntervals: Boolean = false) : DruidQueryExecutor = {
-    new DruidQueryExecutor(new DruidQueryExecutorConfig(50,500,5000,5000, 5000,"config",url,None,3000,3000,3000,3000,
-      true, 500, 3, enableFallbackOnUncoveredIntervals), new NoopExecutionLifecycleListener, ResultSetTransformer.DEFAULT_TRANSFORMS)
+        ),
+        Set(
+          FactCol("impressions", IntType(3, 1))
+          , FactCol("clicks", IntType(3, 0, 1, 800))
+        ),
+        annotations = Set(DruidGroupByStrategyV2),
+        underlyingTableName = Some("fact1")
+      )
+    }.toPublicFact("k_stats_select",
+      Set(
+        PubCol("My Date", "Day", InBetweenEquality),
+        PubCol("id", "Keyword ID", InEquality),
+        PubCol("campaign_id", "Campaign ID", InEquality),
+        PubCol("advertiser_id", "Advertiser ID", InEquality),
+        PubCol("price_type", "Pricing Type", In),
+        PubCol("Derived Pricing Type", "Derived Pricing Type", InEquality),
+      ),
+      Set(
+        PublicFactCol("impressions", "Impressions", InBetweenEquality)
+        , PublicFactCol("clicks", "Clicks", InBetweenEquality)
+      ),
+      Set(),
+      getMaxDaysWindow, getMaxDaysLookBack, renderLocalTimeFilter = false, dimRevision = 2
+    )
   }
 
-  private[this] def getDruidQueryGenerator(maximumMaxRowsAsync: Int = 100) : DruidQueryGenerator = {
+
+  private[this] def withDruidQueryExecutor(url: String, enableFallbackOnUncoveredIntervals: Boolean = false)(fn: DruidQueryExecutor => Unit): Unit ={
+    val executor = new DruidQueryExecutor(new DruidQueryExecutorConfig(50, 500, 5000, 5000, 5000, "config", url, None, 3000, 3000, 3000, 3000,
+      true, 500, 3, enableFallbackOnUncoveredIntervals), new NoopExecutionLifecycleListener, ResultSetTransformer.DEFAULT_TRANSFORMS)
+    try {
+      fn(executor)
+    } finally {
+      executor.close()
+    }
+  }
+
+  private[this] def getDruidQueryGenerator(maximumMaxRowsAsync: Int = 100): DruidQueryGenerator = {
     new DruidQueryGenerator(new SyncDruidQueryOptimizer(), 40000, maximumMaxRowsAsync = maximumMaxRowsAsync)
   }
 
   lazy val defaultRegistry = getDefaultRegistry()
 
-  test("success case for TimeSeries query"){
-    val jsonString = s"""{
+  test("success case for TimeSeries query") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -399,7 +447,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":20,
                           "rowsPerPage":100
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -409,24 +457,38 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/timeseries")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query,rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
-    result.rowList.foreach{
-      row=> 
-    }
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key) != null)
-      }
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/timeseries"){
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
+
+            str = str + s"$row"
+          }
+        }
+
+        assert(count == 3)
+        val expected = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 15))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 16))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-03, 17))"
+
+        str should equal(expected)(after being whiteSpaceNormalised)
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
-  test("success case for TimeSeries query with debugging"){
-    val jsonString = s"""{
+  test("success case for TimeSeries query with debugging") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -450,24 +512,38 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/timeseries_debug")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query,rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
-    result.rowList.foreach{
-      row=> 
-    }
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key) != null)
-      }
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/timeseries_debug"){
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
+
+            str = str + s"$row"
+          }
+        }
+
+        assert(count == 3)
+        val expected = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 15))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 16))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-03, 17))"
+
+        str should equal(expected)(after being whiteSpaceNormalised)
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
-  test("Test TimeSeries query with response with missing result field"){
-    val jsonString = s"""{
+  test("Test TimeSeries query with response with missing result field") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -480,7 +556,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":20,
                           "rowsPerPage":100
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -490,19 +566,25 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/faultytimeseries")
-    val rowList= new CompleteRowList(query)
-    val thrown = intercept[UnsupportedOperationException]{
-      executor.execute(query,rowList, QueryAttributes.empty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+
+    List("1", "2", "3", "4").foreach {
+      idx =>
+        withDruidQueryExecutor(s"http://localhost:6667/mock/timeseriesunsupported$idx") {
+          executor =>
+            val rowList = new CompleteRowList(query)
+            val result = executor.execute(query, rowList, QueryAttributes.empty)
+            assert(result.isFailure, s"idx=$idx result=${result.toString}")
+            val thrown = result.exception.get
+            assert(thrown.getMessage.contains("Unexpected field in timeseries json response"))
+        }
     }
-    assert(thrown.getMessage.contains("Unexpected field in timeseries json response"))
   }
 
 
-
-  test("success case for TopN query"){
-    val jsonString = s"""{
+  test("success case for TopN query") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -518,7 +600,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -528,25 +610,27 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/topn")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
-    result.rowList.foreach{
-      row=> 
-    }
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key) != null)
-      }
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/topn"){
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
+        result.rowList.foreach {
+          row =>
+        }
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
-
-  test("TopN query with invalid response"){
-    val jsonString = s"""{
+  test("TopN query with unhandled field") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -562,7 +646,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -572,15 +656,63 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/timeseries")
-    val rowList= new CompleteRowList(query)
-    intercept[Exception]{  executor.execute(query, rowList, QueryAttributes.empty)}
-
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    List("1", "2", "3", "4", "5").foreach {
+      idx =>
+        withDruidQueryExecutor(s"http://localhost:6667/mock/topnunsupported$idx") {
+          executor =>
+            val rowList = new CompleteRowList(query)
+            val result = executor.execute(query, rowList, QueryAttributes.empty)
+            assert(result.isFailure, s"idx=$idx result=${result.toString}")
+            val thrown = result.exception.get
+            assert(thrown.getMessage.contains("""Unexpected field in TopNDruidQuery json response"""))
+        }
+    }
   }
 
-  test("Test Response code other than 200"){
-    val jsonString = s"""{
+
+  test("TopN query with invalid response") {
+    val jsonString =
+      s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                            {"field": "Keyword ID"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "=", "value": "$fromDate"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "213"}
+                          ],
+                          "sortBy": [
+                            {"field": "Impressions", "order": "Asc"}
+                          ],
+                          "paginationStartIndex":0,
+                          "rowsPerPage":2
+                        }"""
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
+    val registry = defaultRegistry
+    val requestModel = RequestModel.from(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val altQueryGeneratorRegistry = new QueryGeneratorRegistry
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator()) //do not include local time filter
+    val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
+    val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/timeseries"){
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage.contains("""Unexpected field in TopNDruidQuery json response"""))
+    }
+  }
+
+  test("Test Response code other than 200") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -596,7 +728,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":20,
                           "rowsPerPage":100
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -606,16 +738,21 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/faultyn")
-    val rowList= new CompleteRowList(query)
-    val thrown = intercept[IllegalArgumentException]{executor.execute(query, rowList, QueryAttributes.empty)}
-    assert(thrown.getMessage().contains("received status code from druid is"))
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/faultyn"){
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage().contains("received status code from druid is"))
+    }
   }
 
   test("success case for groupby query execution") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -640,7 +777,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -651,39 +788,96 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/groupby")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
 
-    var str: String = ""
-    var count: Int = 0
-    result.rowList.foreach{
-      row => {
-        count += 1
-        
-        str= str+s"$row"
-      }
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby"){
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
+
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
+
+            str = str + s"$row"
+          }
+        }
+
+        assert(count == 2)
+        val expected = "Row(Map(Pricing Type -> 4, Impression Share -> 10, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Day -> 0, Advertiser Status -> 9, Impressions -> 7, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2012-01-01, 10, 163, 184, 11, 9, 205, 175, 15, ON, N/A))Row(Map(Pricing Type -> 4, Impression Share -> 10, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Day -> 0, Advertiser Status -> 9, Impressions -> 7, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2012-01-01, 14, 16, 18, 13, 15, 20, 17, 2, ON, 0.0123))"
+
+        str should equal(expected)(after being whiteSpaceNormalised)
+
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
+  }
 
-    assert(count==2)
-    val expected = "Row(Map(Pricing Type -> 4, Impression Share -> 10, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Day -> 0, Advertiser Status -> 9, Impressions -> 7, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2012-01-01, 10, 163, 184, 11, 9, 205, 175, 15, ON, N/A))Row(Map(Pricing Type -> 4, Impression Share -> 10, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Day -> 0, Advertiser Status -> 9, Impressions -> 7, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2012-01-01, 14, 16, 18, 13, 15, 20, 17, 2, ON, 0.0123))"
-    
-    str should equal (expected) (after being whiteSpaceNormalised)
+  test("fail to execute groupby query type with unhandled json") {
 
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
+    val jsonString =
+      s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Keyword ID"},
+                            {"field": "Max Bid"},
+                            {"field": "Min Bid"},
+                            {"field": "Pricing Type"},
+                            {"field": "Average Bid"},
+                            {"field": "Average Position"},
+                            {"field": "Impressions"},
+                            {"field": "Conversions"},
+                            {"field": "Advertiser Status"},
+                            {"field": "Impression Share"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "in", "values": ["$fromDate", "$toDate"]},
+                            {"field": "Advertiser ID", "operator": "=", "value": "5485"}
+                          ],
+                          "sortBy": [
+                            {"field": "Impressions", "order": "Asc"}
+                          ],
+                          "paginationStartIndex":0,
+                          "rowsPerPage":2
+                        }""".stripMargin
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
+    val registry = defaultRegistry
+    val requestModel = RequestModel.from(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val altQueryGeneratorRegistry = new QueryGeneratorRegistry
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator()) //do not include local time filter
+    val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
+    val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+
+    List("1", "2", "3", "4").foreach {
+      idx =>
+        withDruidQueryExecutor(s"http://localhost:6667/mock/groupbyunsupported$idx") {
+          executor =>
+            val rowList = new CompleteRowList(query)
+            val result = executor.execute(query, rowList, QueryAttributes.empty)
+            assert(result.isFailure, s"idx=$idx result=${result.toString}")
+            val thrown = result.exception.get
+            assert(thrown.getMessage.contains("""Unexpected field in GroupByDruidQuery json response"""))
+        }
     }
   }
 
   test("failure case for query execution when non paginated query returns max rows") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -708,7 +902,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -719,19 +913,22 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/groupby")
-    val rowList= new CompleteRowList(query)
-    val error = intercept[IllegalArgumentException] {
-      executor.execute(query, rowList, QueryAttributes.empty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage === "requirement failed: Non paginated query fails rowsCount < maxRows, partial result possible : rowsCount=2 maxRows=2")
     }
-    assert(error.getMessage === "requirement failed: Non paginated query fails rowsCount < maxRows, partial result possible : rowsCount=2 maxRows=2")
   }
 
   test("test fallback to oracle when druid fails with empty lookup value") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -749,7 +946,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -761,73 +958,76 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/groupby_empty_lookup")
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
 
-    val oracleExecutor = new MockOracleQueryExecutor(
-      { rl =>
-        
-        val expected =
-          s"""
-            |SELECT *
-            |FROM (SELECT to_char(ffst0.stats_date, 'YYYYMMdd') "Day", ffst0.id "Keyword ID", coalesce(ffst0."impresssions", 1) "Impressions", ao1."Advertiser Status" "Advertiser Status"
-            |      FROM (SELECT
-            |                   advertiser_id, id, stats_date, SUM(impresssions) AS "impresssions"
-            |            FROM fd_fact_s_term FactAlias
-            |            WHERE (advertiser_id = 5485) AND (stats_date IN (to_date('${fromDate}', 'YYYYMMdd'),to_date('${toDate}', 'YYYYMMdd')))
-            |            GROUP BY advertiser_id, id, stats_date
-            |
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby_empty_lookup") {
+      executor =>
+
+        val oracleExecutor = new MockOracleQueryExecutor(
+          { rl =>
+
+            val expected =
+              s"""
+                 |SELECT *
+                 |FROM (SELECT to_char(ffst0.stats_date, 'YYYYMMdd') "Day", ffst0.id "Keyword ID", coalesce(ffst0."impresssions", 1) "Impressions", ao1."Advertiser Status" "Advertiser Status"
+                 |      FROM (SELECT
+                 |                   advertiser_id, id, stats_date, SUM(impresssions) AS "impresssions"
+                 |            FROM fd_fact_s_term FactAlias
+                 |            WHERE (advertiser_id = 5485) AND (stats_date IN (to_date('${fromDate}', 'YYYYMMdd'),to_date('${toDate}', 'YYYYMMdd')))
+                 |            GROUP BY advertiser_id, id, stats_date
+                 |
             |           ) ffst0
-            |           LEFT OUTER JOIN
-            |           (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
-            |            FROM advertiser_oracle
-            |            WHERE (id = 5485)
-            |             )
-            |           ao1 ON (ffst0.advertiser_id = ao1.id)
-            |
+                 |           LEFT OUTER JOIN
+                 |           (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
+                 |            FROM advertiser_oracle
+                 |            WHERE (id = 5485)
+                 |             )
+                 |           ao1 ON (ffst0.advertiser_id = ao1.id)
+                 |
             |)
-            |   ORDER BY "Impressions" ASC NULLS LAST""".stripMargin
+                 |   ORDER BY "Impressions" ASC NULLS LAST""".stripMargin
 
-        rl.query.asString should equal (expected) (after being whiteSpaceNormalised)
+            rl.query.asString should equal(expected)(after being whiteSpaceNormalised)
 
-        val row = rl.newRow
-        row.addValue("Keyword ID", 14)
-        row.addValue("Advertiser Status", "ON")
-        row.addValue("Impressions", 10)
-        rl.addRow(row)
-        val row2 = rl.newRow
-        row2.addValue("Keyword ID", 13)
-        row2.addValue("Advertiser Status", "ON")
-        row2.addValue("Impressions", 20)
-        rl.addRow(row2)
-      })
+            val row = rl.newRow
+            row.addValue("Keyword ID", 14)
+            row.addValue("Advertiser Status", "ON")
+            row.addValue("Impressions", 10)
+            rl.addRow(row)
+            val row2 = rl.newRow
+            row2.addValue("Keyword ID", 13)
+            row2.addValue("Advertiser Status", "ON")
+            row2.addValue("Impressions", 20)
+            rl.addRow(row2)
+          })
 
-    val queryExecContext: QueryExecutorContext = new QueryExecutorContext
-    queryExecContext.register(executor)
-    queryExecContext.register(oracleExecutor)
+        val queryExecContext: QueryExecutorContext = new QueryExecutorContext
+        queryExecContext.register(executor)
+        queryExecContext.register(oracleExecutor)
 
-    val result = queryPipelineTry.toOption.get.execute(queryExecContext)
-    assert(result.isSuccess)
+        val result = queryPipelineTry.toOption.get.execute(queryExecContext)
+        assert(result.isSuccess)
 
-    var str: String = ""
-    var count: Int = 0
-    result.get.rowList.foreach{
-      row => {
-        count += 1
-        str= str+s"$row"
-      }
+        var str: String = ""
+        var count: Int = 0
+        result.get.rowList.foreach {
+          row => {
+            count += 1
+            str = str + s"$row"
+          }
+        }
+
+        assert(count == 2)
+        val expected = "Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2, Advertiser Status -> 3),ArrayBuffer(null, 14, 10, ON))Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2, Advertiser Status -> 3),ArrayBuffer(null, 13, 20, ON))"
+
+        str should equal(expected)(after being whiteSpaceNormalised)
     }
-
-    assert(count==2)
-    val expected = "Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2, Advertiser Status -> 3),ArrayBuffer(null, 14, 10, ON))Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2, Advertiser Status -> 3),ArrayBuffer(null, 13, 20, ON))"
-    
-    str should equal (expected) (after being whiteSpaceNormalised)
   }
 
   test("success case for Bid Modifier and Modified Bid post results") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -849,7 +1049,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -860,39 +1060,42 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/groupbybidmod")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
 
-    var str: String = ""
-    var count: Int = 0
-    result.rowList.foreach{
-      row => {
-        count += 1
-        
-        str= str+s"$row"
-      }
-    }
+    withDruidQueryExecutor("http://localhost:6667/mock/groupbybidmod") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
 
-    assert(count==4)
-    val expected = "Row(Map(Bid Modifier -> 5, Average Bid -> 4, Day -> 0, Modified Bid -> 6, Device Type -> 7, Impressions -> 3, Advertiser ID -> 1, Spend -> 2),ArrayBuffer(2017-08-07, 5430, 5793.1630783081, 2884485, 0.30467536, 9, 2.74208, 'Desktop'))Row(Map(Bid Modifier -> 5, Average Bid -> 4, Day -> 0, Modified Bid -> 6, Device Type -> 7, Impressions -> 3, Advertiser ID -> 1, Spend -> 2),ArrayBuffer(2017-08-08, 5430, 5237.0206726193, 2701909, 0.30023782, 8.99726, 2.70132, 'Desktop'))Row(Map(Bid Modifier -> 5, Average Bid -> 4, Day -> 0, Modified Bid -> 6, Device Type -> 7, Impressions -> 3, Advertiser ID -> 1, Spend -> 2),ArrayBuffer(2017-08-07, 5430, 1.4580000341, 2250, 0.30307999, 0, 0.30307999, 'SmartPhone'))Row(Map(Bid Modifier -> 5, Average Bid -> 4, Day -> 0, Modified Bid -> 6, Device Type -> 7, Impressions -> 3, Advertiser ID -> 1, Spend -> 2),ArrayBuffer(2017-08-08, 5430, 1.0800000392, 2138, 0.30110852, 0.2, 0.06022, 'SmartPhone'))"
-    
-    str should equal (expected) (after being whiteSpaceNormalised)
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
 
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
+            str = str + s"$row"
+          }
+        }
+
+        assert(count == 4)
+        val expected = "Row(Map(Bid Modifier -> 5, Average Bid -> 4, Day -> 0, Modified Bid -> 6, Device Type -> 7, Impressions -> 3, Advertiser ID -> 1, Spend -> 2),ArrayBuffer(2017-08-07, 5430, 5793.1630783081, 2884485, 0.30467536, 9, 2.74208, 'Desktop'))Row(Map(Bid Modifier -> 5, Average Bid -> 4, Day -> 0, Modified Bid -> 6, Device Type -> 7, Impressions -> 3, Advertiser ID -> 1, Spend -> 2),ArrayBuffer(2017-08-08, 5430, 5237.0206726193, 2701909, 0.30023782, 8.99726, 2.70132, 'Desktop'))Row(Map(Bid Modifier -> 5, Average Bid -> 4, Day -> 0, Modified Bid -> 6, Device Type -> 7, Impressions -> 3, Advertiser ID -> 1, Spend -> 2),ArrayBuffer(2017-08-07, 5430, 1.4580000341, 2250, 0.30307999, 0, 0.30307999, 'SmartPhone'))Row(Map(Bid Modifier -> 5, Average Bid -> 4, Day -> 0, Modified Bid -> 6, Device Type -> 7, Impressions -> 3, Advertiser ID -> 1, Spend -> 2),ArrayBuffer(2017-08-08, 5430, 1.0800000392, 2138, 0.30110852, 0.2, 0.06022, 'SmartPhone'))"
+
+        str should equal(expected)(after being whiteSpaceNormalised)
+
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
   test("success case for groupby query execution with Start of the week field") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Week"},
@@ -913,7 +1116,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -924,39 +1127,42 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/groupby_start_of_week")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
 
-    var str: String = ""
-    var count: Int = 0
-    result.rowList.foreach{
-      row => {
-        count += 1
-        
-        str= str+s"$row"
-      }
-    }
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby_start_of_week") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
 
-    assert(count==2)
-    val expected = "Row(Map(Pricing Type -> 4, Impression Share -> 9, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Impressions -> 7, Week -> 0, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2017-06-26, 10, 163, 184, 11, 9, 205, 175, 15, N/A))Row(Map(Pricing Type -> 4, Impression Share -> 9, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Impressions -> 7, Week -> 0, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2017-07-10, 14, 16, 18, 13, 15, 20, 17, 2, 0.0123))"
-    
-    str should equal (expected) (after being whiteSpaceNormalised)
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
 
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
+            str = str + s"$row"
+          }
+        }
+
+        assert(count == 2)
+        val expected = "Row(Map(Pricing Type -> 4, Impression Share -> 9, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Impressions -> 7, Week -> 0, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2017-06-26, 10, 163, 184, 11, 9, 205, 175, 15, N/A))Row(Map(Pricing Type -> 4, Impression Share -> 9, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Impressions -> 7, Week -> 0, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2017-07-10, 14, 16, 18, 13, 15, 20, 17, 2, 0.0123))"
+
+        str should equal(expected)(after being whiteSpaceNormalised)
+
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
   test("success case for groupby query execution with Start of the month field") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Month"},
@@ -977,7 +1183,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -988,39 +1194,42 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/groupby_start_of_month")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
 
-    var str: String = ""
-    var count: Int = 0
-    result.rowList.foreach{
-      row => {
-        count += 1
-        
-        str= str+s"$row"
-      }
-    }
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby_start_of_month") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
 
-    assert(count==2)
-    val expected = "Row(Map(Month -> 0, Pricing Type -> 4, Impression Share -> 9, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Impressions -> 7, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2017-06-01, 10, 163, 184, 11, 9, 205, 175, 15, N/A))Row(Map(Month -> 0, Pricing Type -> 4, Impression Share -> 9, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Impressions -> 7, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2017-07-01, 14, 16, 18, 13, 15, 20, 17, 2, 0.0123))"
-    
-    str should equal (expected) (after being whiteSpaceNormalised)
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
 
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
+            str = str + s"$row"
+          }
+        }
+
+        assert(count == 2)
+        val expected = "Row(Map(Month -> 0, Pricing Type -> 4, Impression Share -> 9, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Impressions -> 7, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2017-06-01, 10, 163, 184, 11, 9, 205, 175, 15, N/A))Row(Map(Month -> 0, Pricing Type -> 4, Impression Share -> 9, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Impressions -> 7, Min Bid -> 3, Average Position -> 6, Conversions -> 8),ArrayBuffer(2017-07-01, 14, 16, 18, 13, 15, 20, 17, 2, 0.0123))"
+
+        str should equal(expected)(after being whiteSpaceNormalised)
+
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
   test("success case for groupby query execution with startIndex < 0") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1042,7 +1251,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":-1,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1053,37 +1262,40 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/groupby")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
 
-    var str: String = ""
-    var count: Int = 0
-    result.rowList.foreach{
-      row => {
-        count += 1
-        
-        str= str+s"$row"
-      }
-    }
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
 
-    assert(count==2)
-    val expected = "Row(Map(Pricing Type -> 4, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Day -> 0, Impressions -> 7, Min Bid -> 3, Average Position -> 6),ArrayBuffer(2012-01-01, 10, 163, 184, 11, 9, 205, 175))Row(Map(Pricing Type -> 4, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Day -> 0, Impressions -> 7, Min Bid -> 3, Average Position -> 6),ArrayBuffer(2012-01-01, 14, 16, 18, 13, 15, 20, 17))"
-    str should equal(expected) (after being whiteSpaceNormalised)
+            str = str + s"$row"
+          }
+        }
 
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
+        assert(count == 2)
+        val expected = "Row(Map(Pricing Type -> 4, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Day -> 0, Impressions -> 7, Min Bid -> 3, Average Position -> 6),ArrayBuffer(2012-01-01, 10, 163, 184, 11, 9, 205, 175))Row(Map(Pricing Type -> 4, Keyword ID -> 1, Average Bid -> 5, Max Bid -> 2, Day -> 0, Impressions -> 7, Min Bid -> 3, Average Position -> 6),ArrayBuffer(2012-01-01, 14, 16, 18, 13, 15, 20, 17))"
+        str should equal(expected)(after being whiteSpaceNormalised)
+
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
   test("success case for groupby query execution with startIndex = 1") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1106,7 +1318,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":1,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1117,39 +1329,42 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/3rowsgroupby")
-    val rowList= new CompleteRowList(query)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
-    
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/3rowsgroupby") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
 
-    var str: String = ""
-    var count: Int = 0
-    result.rowList.foreach{
-      row => {
-        count += 1
-        
-        str= str+s"$row"
-      }
-    }
-    
 
-    assert(count==2)
-    val expected = "Row(Map(Pricing Type -> 5, Keyword ID -> 1, Average Bid -> 6, Max Bid -> 3, Day -> 0, Impressions -> 8, Min Bid -> 4, Average Position -> 7, Country Name -> 2),ArrayBuffer(2016-01-01, 2, US, 16, 18, 13, 15, 20, 17))Row(Map(Pricing Type -> 5, Keyword ID -> 1, Average Bid -> 6, Max Bid -> 3, Day -> 0, Impressions -> 8, Min Bid -> 4, Average Position -> 7, Country Name -> 2),ArrayBuffer(2016-01-01, 3, US, 160123456, 18, 13, 10, 20.12, 127))"
-    str should equal(expected) (after being whiteSpaceNormalised)
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
 
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
+            str = str + s"$row"
+          }
+        }
+
+
+        assert(count == 2)
+        val expected = "Row(Map(Pricing Type -> 5, Keyword ID -> 1, Average Bid -> 6, Max Bid -> 3, Day -> 0, Impressions -> 8, Min Bid -> 4, Average Position -> 7, Country Name -> 2),ArrayBuffer(2016-01-01, 2, US, 16, 18, 13, 15, 20, 17))Row(Map(Pricing Type -> 5, Keyword ID -> 1, Average Bid -> 6, Max Bid -> 3, Day -> 0, Impressions -> 8, Min Bid -> 4, Average Position -> 7, Country Name -> 2),ArrayBuffer(2016-01-01, 3, US, 160123456, 18, 13, 10, 20.12, 127))"
+        str should equal(expected)(after being whiteSpaceNormalised)
+
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
   test("groupby query execution with invalid url") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1171,7 +1386,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1182,15 +1397,21 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/topn")
-    val rowList= new CompleteRowList(query)
-    intercept[Exception]{  executor.execute(query, rowList, QueryAttributes.empty)}
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/topn") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage.contains("""Unexpected field in GroupByDruidQuery json response : """))
+    }
   }
 
 
-  test("success case for Partial TimeSeries query"){
-    val jsonString = s"""{
+  test("success case for Partial TimeSeries query") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1203,7 +1424,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":20,
                           "rowsPerPage":100
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1213,33 +1434,36 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/timeseries")
-    val rowList : DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Impressions", query)
-    val row = rowList.newRow
-    row.addValue("Impressions",java.lang.Integer.valueOf(15))
-    row.addValue("Day",null)
-    rowList.addRow(row)
-    rowList.foreach{
-      row=> 
-    }
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
-    result.rowList.foreach{
-      row=> 
-    }
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key) != null)
-      }
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/timeseries") {
+      executor =>
+        val rowList: DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Impressions", query)
+        val row = rowList.newRow
+        row.addValue("Impressions", java.lang.Integer.valueOf(15))
+        row.addValue("Day", null)
+        rowList.addRow(row)
+        rowList.foreach {
+          row =>
+        }
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
+        result.rowList.foreach {
+          row =>
+        }
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
 
   test("success case for partial groupby query execution with no non fk dim filters") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1262,7 +1486,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }""".stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1276,38 +1500,43 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     //val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
     val executorContext = new QueryExecutorContext
-    executorContext.register(getDruidQueryExecutor("http://localhost:6667/mock/groupby"))
-    executorContext.register(new MockOracleQueryExecutor({
-      rowList =>
-        rowList match {
-          case irl: IndexedRowList =>
-            
-            val rowSet = irl.getRowByIndex("10")
-            rowSet.map(_.addValue("Keyword Value", "ten"))
-            val rowSet2 = irl.getRowByIndex("14")
-              rowSet2.map(_.addValue("Keyword Value", "fourteen"))
-          case any => throw new IllegalArgumentException("unexptected row list type")
+
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby") {
+      executor =>
+        executorContext.register(executor)
+        executorContext.register(new MockOracleQueryExecutor({
+          rowList =>
+            rowList match {
+              case irl: IndexedRowList =>
+
+                val rowSet = irl.getRowByIndex("10")
+                rowSet.map(_.addValue("Keyword Value", "ten"))
+                val rowSet2 = irl.getRowByIndex("14")
+                rowSet2.map(_.addValue("Keyword Value", "fourteen"))
+              case any => throw new IllegalArgumentException("unexptected row list type")
+            }
+
+        }))
+        val result = queryPipelineTry.toOption.get.execute(executorContext, QueryAttributes.empty).toOption.get
+
+        assert(!result.rowList.isEmpty)
+        result.rowList.foreach {
+          row =>
         }
-
-    }))
-    val result =  queryPipelineTry.toOption.get.execute(executorContext, QueryAttributes.empty).toOption.get
-
-    assert(!result.rowList.isEmpty)
-    result.rowList.foreach {
-      row=> 
-    }
-    result.rowList.foreach {
-      row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
+        result.rowList.foreach {
+          row =>
+            val map = row.aliasMap
+            for ((key, value) <- map) {
+              assert(row.getValue(key) != null)
+            }
+        }
     }
   }
 
   test("success case for partial groupby query execution with non fk dim filters") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1348,54 +1577,58 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
     val executorContext = new QueryExecutorContext
-    executorContext.register(getDruidQueryExecutor("http://localhost:6667/mock/groupby"))
-    executorContext.register(new MockOracleQueryExecutor({
-      rowList =>
-        rowList match {
-          case irl: IndexedRowList =>
-            
-            for {
-              row <- irl.getRowByIndex("10")
-            } {
-              row.addValue("Keyword Value", "ten")
-              row.addValue("Advertiser Name", "advertiser-ten")
-              row.addValue("Campaign Name", "campaign-ten")
-            }
-            for {
-              row <- irl.getRowByIndex("14")
-            } {
-              row.addValue("Keyword Value", "fourteen")
-              row.addValue("Advertiser Name", "advertiser-fourteen")
-              row.addValue("Campaign Name", "campaign-fourteen")
-            }
-          case any => throw new IllegalArgumentException("unexptected row list type")
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby") {
+      executor =>
+        executorContext.register(executor)
+        executorContext.register(new MockOracleQueryExecutor({
+          rowList =>
+            rowList match {
+              case irl: IndexedRowList =>
 
+                for {
+                  row <- irl.getRowByIndex("10")
+                } {
+                  row.addValue("Keyword Value", "ten")
+                  row.addValue("Advertiser Name", "advertiser-ten")
+                  row.addValue("Campaign Name", "campaign-ten")
+                }
+                for {
+                  row <- irl.getRowByIndex("14")
+                } {
+                  row.addValue("Keyword Value", "fourteen")
+                  row.addValue("Advertiser Name", "advertiser-fourteen")
+                  row.addValue("Campaign Name", "campaign-fourteen")
+                }
+              case any => throw new IllegalArgumentException("unexptected row list type")
+
+            }
+
+        }))
+        val resultTry = queryPipelineTry.toOption.get.execute(executorContext, QueryAttributes.empty)
+        assert(resultTry.isSuccess, resultTry.errorMessage("Fail to execute pipeline"))
+
+        val result = resultTry.toOption.get
+        assert(!result.rowList.isEmpty)
+        result.rowList.foreach {
+          row =>
         }
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
+        val sql = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head.asString
 
-    }))
-    val resultTry =  queryPipelineTry.toOption.get.execute(executorContext, QueryAttributes.empty)
-    assert(resultTry.isSuccess, resultTry.errorMessage("Fail to execute pipeline"))
-
-    val result =  resultTry.toOption.get
-    assert(!result.rowList.isEmpty)
-    result.rowList.foreach{
-      row=> 
+        assert(sql contains "ROWNUM")
+        assert(!sql.contains("TotalRows"))
     }
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
-    }
-    val sql = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head.asString
-    
-    assert(sql contains "ROWNUM")
-    assert(!sql.contains("TotalRows"))
   }
 
   test("success case for groupby fact driven query execution") {
 
-    val jsonString =  s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1434,55 +1667,58 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
     val executorContext = new QueryExecutorContext
-    executorContext.register(getDruidQueryExecutor("http://localhost:6667/mock/groupby"))
-    executorContext.register(new MockOracleQueryExecutor({
-      rowList =>
-        rowList match {
-          case irl: IndexedRowList =>
-            
-            for {
-              row <- irl.getRowByIndex("10")
-            } {
-              row.addValue("Keyword Value", "ten")
-            }
-            for {
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby") {
+      executor =>
+        executorContext.register(executor)
+        executorContext.register(new MockOracleQueryExecutor({
+          rowList =>
+            rowList match {
+              case irl: IndexedRowList =>
 
-              row <- irl.getRowByIndex("14")
-            }
-            {
-              row.addValue("Keyword Value", "fourteen")
-            }
-            val newRow = irl.newRow
-            newRow.addValue(irl.indexAlias, "11")
-            newRow.addValue("Keyword Value", "eleven")
-            irl.updateRow(newRow)
-          case any => throw new IllegalArgumentException("unexptected row list type")
+                for {
+                  row <- irl.getRowByIndex("10")
+                } {
+                  row.addValue("Keyword Value", "ten")
+                }
+                for {
 
+                  row <- irl.getRowByIndex("14")
+                } {
+                  row.addValue("Keyword Value", "fourteen")
+                }
+                val newRow = irl.newRow
+                newRow.addValue(irl.indexAlias, "11")
+                newRow.addValue("Keyword Value", "eleven")
+                irl.updateRow(newRow)
+              case any => throw new IllegalArgumentException("unexptected row list type")
+
+            }
+
+        }))
+        val resultTry = queryPipelineTry.toOption.get.execute(executorContext, QueryAttributes.empty)
+        assert(resultTry.isSuccess, resultTry.errorMessage("Fail to execute pipeline"))
+
+        val result = resultTry.toOption.get
+        assert(!result.rowList.isEmpty)
+        var rowCount = 0
+        result.rowList.foreach(row => rowCount = rowCount + 1)
+        assert(rowCount == 2)
+        result.rowList.foreach {
+          row =>
         }
-
-    }))
-    val resultTry =  queryPipelineTry.toOption.get.execute(executorContext, QueryAttributes.empty)
-    assert(resultTry.isSuccess, resultTry.errorMessage("Fail to execute pipeline"))
-
-    val result =  resultTry.toOption.get
-    assert(!result.rowList.isEmpty)
-    var rowCount = 0
-    result.rowList.foreach( row => rowCount = rowCount + 1)
-    assert(rowCount == 2)
-    result.rowList.foreach {
-      row=> 
-    }
-    result.rowList.foreach {
-      row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key)!=null)
-      }
+        result.rowList.foreach {
+          row =>
+            val map = row.aliasMap
+            for ((key, value) <- map) {
+              assert(row.getValue(key) != null)
+            }
+        }
     }
   }
 
-  test("success case for TopN query with partial result set"){
-    val jsonString = s"""{
+  test("success case for TopN query with partial result set") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1498,7 +1734,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1508,32 +1744,35 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/topn")
-    val rowList : DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Keyword ID", query)
-    val row1 = rowList.newRow
-    row1.addValue("Keyword ID",14)
-    row1.addValue("Impressions",null)
-    rowList.addRow(row1)
-    val row2 = rowList.newRow
-    row2.addValue("Keyword ID",13)
-    row2.addValue("Impressions",null)
-    rowList.addRow(row2)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(!result.rowList.isEmpty)
-    result.rowList.foreach{
-      row=> 
-    }
-    result.rowList.foreach{row =>
-      val map = row.aliasMap
-      for((key,value)<-map) {
-        assert(row.getValue(key) != null)
-      }
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/topn") {
+      executor =>
+        val rowList: DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Keyword ID", query)
+        val row1 = rowList.newRow
+        row1.addValue("Keyword ID", 14)
+        row1.addValue("Impressions", null)
+        rowList.addRow(row1)
+        val row2 = rowList.newRow
+        row2.addValue("Keyword ID", 13)
+        row2.addValue("Impressions", null)
+        rowList.addRow(row2)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
+        result.rowList.foreach {
+          row =>
+        }
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
     }
   }
 
-  test("Handle null values from druid gracefully"){
-    val jsonString = s"""{
+  test("Handle null values from druid gracefully") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1549,7 +1788,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":2
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1559,25 +1798,27 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/topnWithNull")
-    val rowList : DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Keyword ID", query)
-    val row1 = rowList.newRow
-    row1.addValue("Keyword ID",14)
-    row1.addValue("Impressions",null)
-    rowList.addRow(row1)
-    val row2 = rowList.newRow
-    row2.addValue("Keyword ID",13)
-    row2.addValue("Impressions",null)
-    rowList.addRow(row2)
-    val result=  executor.execute(query, rowList, QueryAttributes.empty)
-    assert(result.rowList.isEmpty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/topnWithNull") {
+      executor =>
+        val rowList: DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Keyword ID", query)
+        val row1 = rowList.newRow
+        row1.addValue("Keyword ID", 14)
+        row1.addValue("Impressions", null)
+        rowList.addRow(row1)
+        val row2 = rowList.newRow
+        row2.addValue("Keyword ID", 13)
+        row2.addValue("Impressions", null)
+        rowList.addRow(row2)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.rowList.isEmpty)
+    }
   }
 
 
-  test("success case for TopN query with partial result set: MultiEngine")
-  {
-    val jsonString = s"""{
+  test("success case for TopN query with partial result set: MultiEngine") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1594,7 +1835,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":100
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1605,62 +1846,63 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val druidExecutor =  getDruidQueryExecutor("http://localhost:6667/mock/topn")
-    val oracleExecutor = new MockOracleQueryExecutor(
-    { rl =>
-      val row = rl.newRow
-      row.addValue("Keyword ID", 14)
-      row.addValue("Keyword Value", "one")
-      rl.addRow(row)
-      val row2 = rl.newRow
-      row2.addValue("Keyword ID", 13)
-      row2.addValue("Keyword Value", "two")
-      rl.addRow(row2)
-    })
-    val queryExecContext: QueryExecutorContext = new QueryExecutorContext
-    queryExecContext.register(druidExecutor)
-    queryExecContext.register(oracleExecutor)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/topn") {
+      druidExecutor =>
+        val oracleExecutor = new MockOracleQueryExecutor(
+          { rl =>
+            val row = rl.newRow
+            row.addValue("Keyword ID", 14)
+            row.addValue("Keyword Value", "one")
+            rl.addRow(row)
+            val row2 = rl.newRow
+            row2.addValue("Keyword ID", 13)
+            row2.addValue("Keyword Value", "two")
+            rl.addRow(row2)
+          })
+        val queryExecContext: QueryExecutorContext = new QueryExecutorContext
+        queryExecContext.register(druidExecutor)
+        queryExecContext.register(oracleExecutor)
 
-    val result = queryPipelineTry.toOption.get.execute(queryExecContext)
-    assert(result.isSuccess)
+        val result = queryPipelineTry.toOption.get.execute(queryExecContext)
+        assert(result.isSuccess)
 
-    //var result = oracleExecutor.execute(oraclQuery.head, rowList, QueryAttributes.empty)
-    val oracleQuery = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head
-    //require(result.rowList, "Failed to execute MultiEngine Query")
-    
-    val expected =
-    """
-       | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
-       |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
-       |            FROM
-       |                (SELECT  value, id, advertiser_id
-       |            FROM targetingattribute
-       |            WHERE (advertiser_id = 213) AND (id IN (14,13))
-       |             ) t0
-       |
-       |
-       |           )
-       |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
-       |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
-       |            FROM
-       |                (SELECT  value, id, advertiser_id
-       |            FROM targetingattribute
-       |            WHERE (advertiser_id = 213) AND (id NOT IN (14,13))
-       |             ) t0
-       |
-       |
-       |           )
-       |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)
-       |  """.stripMargin
+        //var result = oracleExecutor.execute(oraclQuery.head, rowList, QueryAttributes.empty)
+        val oracleQuery = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head
+        //require(result.rowList, "Failed to execute MultiEngine Query")
 
-    oracleQuery.asString should equal (expected) (after being whiteSpaceNormalised)
+        val expected =
+          """
+            | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
+            |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
+            |            FROM
+            |                (SELECT  value, id, advertiser_id
+            |            FROM targetingattribute
+            |            WHERE (advertiser_id = 213) AND (id IN (14,13))
+            |             ) t0
+            |
+            |
+            |           )
+            |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+            |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
+            |            FROM
+            |                (SELECT  value, id, advertiser_id
+            |            FROM targetingattribute
+            |            WHERE (advertiser_id = 213) AND (id NOT IN (14,13))
+            |             ) t0
+            |
+            |
+            |           )
+            |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)
+            |  """.stripMargin
 
+        oracleQuery.asString should equal(expected)(after being whiteSpaceNormalised)
+    }
   }
 
-  test("success case for TopN query with partial result set: MultiEngine with 2 sorts")
-  {
-    val jsonString = s"""{
+  test("success case for TopN query with partial result set: MultiEngine with 2 sorts") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
 
@@ -1679,7 +1921,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":0,
                           "rowsPerPage":100
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1690,59 +1932,62 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val druidExecutor = getDruidQueryExecutor("http://localhost:6667/mock/druidPlusOraclegroupby")
-    val oracleExecutor = new MockOracleQueryExecutor(
-    { rl =>
-      val row = rl.newRow
-      row.addValue("Keyword ID", 14)
-      row.addValue("Keyword Value", "one")
-      rl.addRow(row)
-      val row2 = rl.newRow
-      row2.addValue("Keyword ID", 13)
-      row2.addValue("Keyword Value", "two")
-      rl.addRow(row2)
-    })
-    val queryExecContext: QueryExecutorContext = new QueryExecutorContext
-    queryExecContext.register(druidExecutor)
-    queryExecContext.register(oracleExecutor)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
 
-    val result = queryPipelineTry.toOption.get.execute(queryExecContext)
-    assert(result.isSuccess)
+    withDruidQueryExecutor("http://localhost:6667/mock/druidPlusOraclegroupby") {
+      druidExecutor =>
+        val oracleExecutor = new MockOracleQueryExecutor(
+          { rl =>
+            val row = rl.newRow
+            row.addValue("Keyword ID", 14)
+            row.addValue("Keyword Value", "one")
+            rl.addRow(row)
+            val row2 = rl.newRow
+            row2.addValue("Keyword ID", 13)
+            row2.addValue("Keyword Value", "two")
+            rl.addRow(row2)
+          })
+        val queryExecContext: QueryExecutorContext = new QueryExecutorContext
+        queryExecContext.register(druidExecutor)
+        queryExecContext.register(oracleExecutor)
 
-    val oracleQuery = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head
-    
-    val expected = s"""
-                       | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
-                       |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
-                       |            FROM
-                       |                (SELECT  id, value, advertiser_id
-                       |            FROM targetingattribute
-                       |            WHERE (advertiser_id = 213) AND (id IN (14,13))
-                       |            ORDER BY 1 ASC  ) t0
-                       |
-                       |
-                       |           )
-                       |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
-                       |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
-                       |            FROM
-                       |                (SELECT  id, value, advertiser_id
-                       |            FROM targetingattribute
-                       |            WHERE (advertiser_id = 213) AND (id NOT IN (14,13))
-                       |            ORDER BY 1 ASC  ) t0
-                       |
+        val result = queryPipelineTry.toOption.get.execute(queryExecContext)
+        assert(result.isSuccess)
+
+        val oracleQuery = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head
+
+        val expected =
+          s"""
+             | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
+             |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
+             |            FROM
+             |                (SELECT  id, value, advertiser_id
+             |            FROM targetingattribute
+             |            WHERE (advertiser_id = 213) AND (id IN (14,13))
+             |            ORDER BY 1 ASC  ) t0
+             |
                        |
                        |           )
-                       |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)  """
-      .stripMargin
+             |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+             |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
+             |            FROM
+             |                (SELECT  id, value, advertiser_id
+             |            FROM targetingattribute
+             |            WHERE (advertiser_id = 213) AND (id NOT IN (14,13))
+             |            ORDER BY 1 ASC  ) t0
+             |
+                       |
+                       |           )
+             |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)  """
+            .stripMargin
 
-    oracleQuery.asString should equal (expected) (after being whiteSpaceNormalised)
-
+        oracleQuery.asString should equal(expected)(after being whiteSpaceNormalised)
+    }
   }
 
-  test("Invalid field extraction failure"){
-    val jsonString = s"""{
+  test("Invalid field extraction failure") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1769,15 +2014,20 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/faultytopn")
-    val rowList= new CompleteRowList(query)
-    val thrown = intercept[UnsupportedOperationException]{  executor.execute(query, rowList, QueryAttributes.empty)}
-    assert(thrown.getMessage.contains("unsupported field type"))
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/faultytopn") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage.contains("unsupported field type"))
+    }
   }
 
-  test("TopN query with partial result set and request code not 200"){
-    val jsonString = s"""{
+  test("TopN query with partial result set and request code not 200") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1793,7 +2043,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":20,
                           "rowsPerPage":100
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1803,25 +2053,28 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/bh")
-    val rowList : DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Keyword ID", query)
-    val row1 = rowList.newRow
-    row1.addValue("Keyword ID",14)
-    row1.addValue("Impressions",null)
-    rowList.addRow(row1)
-    val row2 = rowList.newRow
-    row2.addValue("Keyword ID",13)
-    row2.addValue("Impressions",null)
-    rowList.addRow(row2)
-    val thrown=  intercept[IllegalArgumentException] {
-    executor.execute(query, rowList, QueryAttributes.empty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/bh") {
+      executor =>
+        val rowList: DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Keyword ID", query)
+        val row1 = rowList.newRow
+        row1.addValue("Keyword ID", 14)
+        row1.addValue("Impressions", null)
+        rowList.addRow(row1)
+        val row2 = rowList.newRow
+        row2.addValue("Keyword ID", 13)
+        row2.addValue("Impressions", null)
+        rowList.addRow(row2)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage().contains("received status code from druid is"))
     }
-    assert(thrown.getMessage().contains("received status code from druid is"))
   }
 
-  test("Test TimeSeries query with partial result set with missing result field"){
-    val jsonString = s"""{
+  test("Test TimeSeries query with partial result set with missing result field") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1834,7 +2087,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "paginationStartIndex":20,
                           "rowsPerPage":100
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1844,38 +2097,40 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/faultytimeseries")
-    val rowList : DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Impressions", query)
-    val row = rowList.newRow
-    row.addValue("Impressions",java.lang.Integer.valueOf(15))
-    row.addValue("Day",null)
-    val thrown = intercept[UnsupportedOperationException]{
-      executor.execute(query, rowList, QueryAttributes.empty)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    withDruidQueryExecutor("http://localhost:6667/mock/timeseriesunsupported1") {
+      executor =>
+        val rowList: DimDrivenFactOrderedPartialRowList = new DimDrivenFactOrderedPartialRowList("Impressions", query)
+        val row = rowList.newRow
+        row.addValue("Impressions", java.lang.Integer.valueOf(15))
+        row.addValue("Day", null)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage.contains("Unexpected field in timeseries json response"))
     }
-    assert(thrown.getMessage.contains("Unexpected field in timeseries json response"))
   }
 
 
-  test("testing extract field"){
-   val bool =JBool(true)
-   val boolVal = DruidQueryExecutor.extractField(bool)
-    assert(true==boolVal)
+  test("testing extract field") {
+    val bool = JBool(true)
+    val boolVal = DruidQueryExecutor.extractField(bool)
+    assert(true == boolVal)
     val string = JString("s")
     val stringVal = DruidQueryExecutor.extractField(string)
-    assert("s"==stringVal)
-    val dec =JDecimal(1.0)
+    assert("s" == stringVal)
+    val dec = JDecimal(1.0)
     val decVal = DruidQueryExecutor.extractField(dec)
-    assert(1.0==decVal)
-    val int =JInt(1)
+    assert(1.0 == decVal)
+    val int = JInt(1)
     val intVal = DruidQueryExecutor.extractField(int)
-    assert(1==intVal)
-    val double =JDouble(1112.23)
+    assert(1 == intVal)
+    val double = JDouble(1112.23)
     val doubleVal = DruidQueryExecutor.extractField(double)
-    assert(1112.23==doubleVal)
-    val long =JLong(1112)
+    assert(1112.23 == doubleVal)
+    val long = JLong(1112)
     val longVal = DruidQueryExecutor.extractField(long)
-    assert(1112==longVal)
+    assert(1112 == longVal)
   }
 
   test("Fact View Query Tests Adjustment Stats without Filter") {
@@ -1917,7 +2172,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
          |}
       """.stripMargin
 
-    val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSyncWithFactBias(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -1929,28 +2184,30 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val druidExecutor = getDruidQueryExecutor("http://localhost:6667/mock/adjustmentStatsGroupBy")
+    withDruidQueryExecutor("http://localhost:6667/mock/adjustmentStatsGroupBy") {
+      druidExecutor =>
 
-    val queryExecContext: QueryExecutorContext = new QueryExecutorContext
-    queryExecContext.register(druidExecutor)
+        val queryExecContext: QueryExecutorContext = new QueryExecutorContext
+        queryExecContext.register(druidExecutor)
 
-    val result = queryPipelineTry.toOption.get.execute(queryExecContext)
-    assert(result.isSuccess)
+        val result = queryPipelineTry.toOption.get.execute(queryExecContext)
+        assert(result.isSuccess)
 
-    val expectedSet = Set(
-    "Row(Map(Is Adjustment -> 2, Der Fact Col A -> 5, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(184, 2012-01-01, N, 100, 15, 1))"
-    ,"Row(Map(Is Adjustment -> 2, Der Fact Col A -> 5, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(199, 2012-01-01, N, 100, 10, 1))"
-    ,"Row(Map(Is Adjustment -> 2, Der Fact Col A -> 5, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(184, 2012-01-01, Y, 100, 15, 0))"
-    ,"Row(Map(Is Adjustment -> 2, Der Fact Col A -> 5, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(199, 2012-01-01, Y, 100, 10, 0))"
-    )
-    var count = 0
-    result.get.rowList.foreach {
-      row =>
-        
-        assert(expectedSet.contains(row.toString))
-        count+=1
+        val expectedSet = Set(
+          "Row(Map(Is Adjustment -> 2, Der Fact Col A -> 5, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(184, 2012-01-01, N, 100, 15, 1))"
+          , "Row(Map(Is Adjustment -> 2, Der Fact Col A -> 5, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(199, 2012-01-01, N, 100, 10, 1))"
+          , "Row(Map(Is Adjustment -> 2, Der Fact Col A -> 5, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(184, 2012-01-01, Y, 100, 15, 0))"
+          , "Row(Map(Is Adjustment -> 2, Der Fact Col A -> 5, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(199, 2012-01-01, Y, 100, 10, 0))"
+        )
+        var count = 0
+        result.get.rowList.foreach {
+          row =>
+
+            assert(expectedSet.contains(row.toString))
+            count += 1
+        }
+        assert(expectedSet.size == count)
     }
-    assert(expectedSet.size == count)
   }
 
   test("Fact View Query Tests Adjustment Stats with constant column filter") {
@@ -1994,7 +2251,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
          |}
       """.stripMargin
 
-    val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSyncWithFactBias(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -2006,33 +2263,35 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val druidExecutor = getDruidQueryExecutor("http://localhost:6667/mock/adjustmentStatsGroupBy")
+    withDruidQueryExecutor("http://localhost:6667/mock/adjustmentStatsGroupBy") {
+      druidExecutor =>
 
-    val queryExecContext: QueryExecutorContext = new QueryExecutorContext
-    queryExecContext.register(druidExecutor)
+        val queryExecContext: QueryExecutorContext = new QueryExecutorContext
+        queryExecContext.register(druidExecutor)
 
-    val queryList = queryPipelineTry.toOption.get.queryChain.asInstanceOf[MultiQuery].unionQueryList
+        val queryList = queryPipelineTry.toOption.get.queryChain.asInstanceOf[MultiQuery].unionQueryList
 
-    queryList.foreach {
-      query=>
-        
+        queryList.foreach {
+          query =>
+
+        }
+
+        val result = queryPipelineTry.toOption.get.execute(queryExecContext)
+        assert(result.isSuccess)
+
+        val expectedSet = Set(
+          "Row(Map(Is Adjustment -> 2, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(184, 2012-01-01, Y, 100, 15))"
+          , "Row(Map(Is Adjustment -> 2, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(199, 2012-01-01, Y, 100, 10))"
+        )
+        var count = 0
+        result.get.rowList.foreach {
+          row =>
+
+            assert(expectedSet.contains(row.toString))
+            count += 1
+        }
+        assert(expectedSet.size == count)
     }
-
-    val result = queryPipelineTry.toOption.get.execute(queryExecContext)
-    assert(result.isSuccess)
-
-    val expectedSet = Set(
-      "Row(Map(Is Adjustment -> 2, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(184, 2012-01-01, Y, 100, 15))"
-      ,"Row(Map(Is Adjustment -> 2, Day -> 1, Impressions -> 3, Advertiser ID -> 0, Spend -> 4),ArrayBuffer(199, 2012-01-01, Y, 100, 10))"
-    )
-    var count = 0
-    result.get.rowList.foreach {
-      row =>
-        
-        assert(expectedSet.contains(row.toString))
-        count+=1
-    }
-    assert(expectedSet.size == count)
   }
 
   test("Exectue Hourly grain query with day field") {
@@ -2070,7 +2329,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
          |   "rowsPerPage":1000
          |}
        """.stripMargin
-    val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString, InternalSchema))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -2082,71 +2341,73 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val druidExecutor = getDruidQueryExecutor("http://localhost:6667/mock/whiteGloveGroupBy")
+    withDruidQueryExecutor("http://localhost:6667/mock/whiteGloveGroupBy") {
+      druidExecutor =>
 
-    val queryExecContext: QueryExecutorContext = new QueryExecutorContext
-    queryExecContext.register(druidExecutor)
+        val queryExecContext: QueryExecutorContext = new QueryExecutorContext
+        queryExecContext.register(druidExecutor)
 
-    val result = queryPipelineTry.toOption.get.execute(queryExecContext)
-    assert(result.isSuccess)
-    val expectedSet = Set(
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 12, 100702.5269201994))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 10, 100105.4773756862))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 11, 99452.796035409))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 12, 99278.7537128925))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 11, 97812.4866646528))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 10, 97590.620177567))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 13, 97567.9216952436))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 13, 96825.4939264059))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 14, 94937.976395607))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 15, 93734.2041929066))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 14, 93478.0812258236))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 15, 93372.6298325285))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 16, 92731.1196420193))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 09, 92407.9271872044))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 16, 92231.0408502519))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 09, 91216.1552691944))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 17, 86134.2663560882))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 17, 83792.8106330931))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 08, 81854.4767573178))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 08, 80682.3556755185))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 18, 78679.2603152394))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 18, 78148.13511765))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 19, 74984.7429508232))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 19, 74374.6146068573))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 20, 70020.2893772125))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 20, 69916.2466526032))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 07, 68890.5210767388))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 07, 67616.8263101578))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 21, 64026.7750177383))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 21, 61437.9518136978))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 22, 54657.0613212585))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 00, 54380.0269228816))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 06, 52897.4322437644))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 00, 52755.8068522811))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 06, 52233.0503473878))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 22, 50291.442117691))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 23, 41530.911318697))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 01, 41114.4911497831))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 01, 40357.949185878))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 05, 39912.345539093))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 23, 39016.8020768166))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 05, 39015.8409667015))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 02, 35015.9358971715))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 02, 34740.9374386966))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 04, 33221.9400693774))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 04, 32514.7562770247))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 03, 31368.6910836697))",
-        "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 03, 31223.5407607555))"
-    )
-    var count = 0
-    result.get.rowList.foreach {
-      row =>
-        assert(expectedSet.contains(row.toString))
-        count+=1
+        val result = queryPipelineTry.toOption.get.execute(queryExecContext)
+        assert(result.isSuccess)
+        val expectedSet = Set(
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 12, 100702.5269201994))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 10, 100105.4773756862))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 11, 99452.796035409))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 12, 99278.7537128925))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 11, 97812.4866646528))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 10, 97590.620177567))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 13, 97567.9216952436))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 13, 96825.4939264059))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 14, 94937.976395607))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 15, 93734.2041929066))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 14, 93478.0812258236))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 15, 93372.6298325285))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 16, 92731.1196420193))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 09, 92407.9271872044))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 16, 92231.0408502519))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 09, 91216.1552691944))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 17, 86134.2663560882))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 17, 83792.8106330931))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 08, 81854.4767573178))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 08, 80682.3556755185))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 18, 78679.2603152394))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 18, 78148.13511765))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 19, 74984.7429508232))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 19, 74374.6146068573))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 20, 70020.2893772125))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 20, 69916.2466526032))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 07, 68890.5210767388))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 07, 67616.8263101578))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 21, 64026.7750177383))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 21, 61437.9518136978))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 22, 54657.0613212585))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 00, 54380.0269228816))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 06, 52897.4322437644))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 00, 52755.8068522811))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 06, 52233.0503473878))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 22, 50291.442117691))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 23, 41530.911318697))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 01, 41114.4911497831))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 01, 40357.949185878))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 05, 39912.345539093))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 23, 39016.8020768166))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 05, 39015.8409667015))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 02, 35015.9358971715))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 02, 34740.9374386966))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 04, 33221.9400693774))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 04, 32514.7562770247))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-02, 03, 31368.6910836697))",
+          "Row(Map(Day -> 0, Hour -> 1, Spend Usd -> 2),ArrayBuffer(2017-05-01, 03, 31223.5407607555))"
+        )
+        var count = 0
+        result.get.rowList.foreach {
+          row =>
+            assert(expectedSet.contains(row.toString))
+            count += 1
+        }
+        assert(expectedSet.size == count)
+
     }
-    assert(expectedSet.size == count)
-
   }
 
   test("Uncovered Interval response: should not fall back") {
@@ -2172,7 +2433,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
          |                          "rowsPerPage":2
          |}
        """.stripMargin
-    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -2184,68 +2445,70 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val executor = getDruidQueryExecutor("http://localhost:6667/mock/uncoveredNonempty", true)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
 
-    val oracleExecutor = new MockOracleQueryExecutor(
-      { rl =>
-        
-        val expected =
-          s"""
-             |SELECT *
-             |FROM (SELECT to_char(ffst0.stats_date, 'YYYYMMdd') "Day", ffst0.id "Keyword ID", coalesce(ffst0."impresssions", 1) "Impressions", ao1."Advertiser Status" "Advertiser Status"
-             |      FROM (SELECT
-             |                   advertiser_id, id, stats_date, SUM(impresssions) AS "impresssions"
-             |            FROM fd_fact_s_term FactAlias
-             |            WHERE (advertiser_id = 5485) AND (stats_date IN (to_date('${fromDate}', 'YYYYMMdd'),to_date('${toDate}', 'YYYYMMdd')))
-             |            GROUP BY advertiser_id, id, stats_date
-             |
+    withDruidQueryExecutor("http://localhost:6667/mock/uncoveredNonempty", true) {
+      executor =>
+
+        val oracleExecutor = new MockOracleQueryExecutor(
+          { rl =>
+
+            val expected =
+              s"""
+                 |SELECT *
+                 |FROM (SELECT to_char(ffst0.stats_date, 'YYYYMMdd') "Day", ffst0.id "Keyword ID", coalesce(ffst0."impresssions", 1) "Impressions", ao1."Advertiser Status" "Advertiser Status"
+                 |      FROM (SELECT
+                 |                   advertiser_id, id, stats_date, SUM(impresssions) AS "impresssions"
+                 |            FROM fd_fact_s_term FactAlias
+                 |            WHERE (advertiser_id = 5485) AND (stats_date IN (to_date('${fromDate}', 'YYYYMMdd'),to_date('${toDate}', 'YYYYMMdd')))
+                 |            GROUP BY advertiser_id, id, stats_date
+                 |
             |           ) ffst0
-             |           LEFT OUTER JOIN
-             |           (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
-             |            FROM advertiser_oracle
-             |            WHERE (id = 5485)
-             |             )
-             |           ao1 ON (ffst0.advertiser_id = ao1.id)
-             |
+                 |           LEFT OUTER JOIN
+                 |           (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
+                 |            FROM advertiser_oracle
+                 |            WHERE (id = 5485)
+                 |             )
+                 |           ao1 ON (ffst0.advertiser_id = ao1.id)
+                 |
             |)
-             |   ORDER BY "Impressions" ASC NULLS LAST""".stripMargin
+                 |   ORDER BY "Impressions" ASC NULLS LAST""".stripMargin
 
-        rl.query.asString should equal (expected) (after being whiteSpaceNormalised)
+            rl.query.asString should equal(expected)(after being whiteSpaceNormalised)
 
-        val row = rl.newRow
-        row.addValue("Keyword ID", 14)
-        row.addValue("Advertiser Status", "ON")
-        row.addValue("Impressions", 10)
-        rl.addRow(row)
-        val row2 = rl.newRow
-        row2.addValue("Keyword ID", 13)
-        row2.addValue("Advertiser Status", "ON")
-        row2.addValue("Impressions", 20)
-        rl.addRow(row2)
-      })
+            val row = rl.newRow
+            row.addValue("Keyword ID", 14)
+            row.addValue("Advertiser Status", "ON")
+            row.addValue("Impressions", 10)
+            rl.addRow(row)
+            val row2 = rl.newRow
+            row2.addValue("Keyword ID", 13)
+            row2.addValue("Advertiser Status", "ON")
+            row2.addValue("Impressions", 20)
+            rl.addRow(row2)
+          })
 
-    val queryExecContext: QueryExecutorContext = new QueryExecutorContext
-    queryExecContext.register(executor)
-    queryExecContext.register(oracleExecutor)
+        val queryExecContext: QueryExecutorContext = new QueryExecutorContext
+        queryExecContext.register(executor)
+        queryExecContext.register(oracleExecutor)
 
-    val result = queryPipelineTry.toOption.get.execute(queryExecContext)
-    assert(result.isSuccess)
+        val result = queryPipelineTry.toOption.get.execute(queryExecContext)
+        assert(result.isSuccess)
 
-    val expected = List("Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2, Advertiser Status -> 3),ArrayBuffer(null, 10, 175, null))"
-    , "Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2, Advertiser Status -> 3),ArrayBuffer(null, 14, 17, null))")
+        val expected = List("Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2, Advertiser Status -> 3),ArrayBuffer(null, 10, 175, null))"
+          , "Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2, Advertiser Status -> 3),ArrayBuffer(null, 14, 17, null))")
 
-    result.get.rowList.foreach {
-      row =>
-        
-        assert(expected.contains(row.toString))
+        result.get.rowList.foreach {
+          row =>
+
+            assert(expected.contains(row.toString))
+        }
     }
   }
 
-  test("successfully generate the dim only INNER JOIN query if request has hasNonDrivingDimNonFKNonPKFilter in MultiEngine Case")
-  {
-    val jsonString = s"""{
+  test("successfully generate the dim only INNER JOIN query if request has hasNonDrivingDimNonFKNonPKFilter in MultiEngine Case") {
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Ad Group ID"},
@@ -2266,7 +2529,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           "rowsPerPage":100,
                           "isDimDriven" : true
                         }"""
-    val request: ReportingRequest = getReportingRequestSync(jsonString, AdvertiserLowLatencySchema)
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString, AdvertiserLowLatencySchema))
     val registry = defaultRegistry
     val requestModel = RequestModel.from(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -2277,73 +2540,318 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
-    
-    val druidExecutor =  getDruidQueryExecutor("http://localhost:6667/mock/topnUiQuery")
-    val oracleExecutor = new MockOracleQueryExecutor(
-      { rl =>
-        val row = rl.newRow
-        row.addValue("Ad Group ID", 114)
-        row.addValue("Campaign ID", 14)
-        row.addValue("Campaign Name", "Fourteen")
-        rl.addRow(row)
-        val row2 = rl.newRow
-        row2.addValue("Ad Group ID", 113)
-        row2.addValue("Campaign ID", 13)
-        row2.addValue("Campaign Name", "Thirteen")
-        rl.addRow(row2)
-      })
-    val queryExecContext: QueryExecutorContext = new QueryExecutorContext
-    queryExecContext.register(druidExecutor)
-    queryExecContext.register(oracleExecutor)
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
 
-    val result = queryPipelineTry.toOption.get.execute(queryExecContext)
-    assert(result.isSuccess)
+    withDruidQueryExecutor("http://localhost:6667/mock/topnUiQuery") {
+      druidExecutor =>
+        val oracleExecutor = new MockOracleQueryExecutor(
+          { rl =>
+            val row = rl.newRow
+            row.addValue("Ad Group ID", 114)
+            row.addValue("Campaign ID", 14)
+            row.addValue("Campaign Name", "Fourteen")
+            rl.addRow(row)
+            val row2 = rl.newRow
+            row2.addValue("Ad Group ID", 113)
+            row2.addValue("Campaign ID", 13)
+            row2.addValue("Campaign Name", "Thirteen")
+            rl.addRow(row2)
+          })
+        val queryExecContext: QueryExecutorContext = new QueryExecutorContext
+        queryExecContext.register(druidExecutor)
+        queryExecContext.register(oracleExecutor)
 
-    //var result = oracleExecutor.execute(oraclQuery.head, rowList, QueryAttributes.empty)
-    val oracleQuery = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head
-    //require(result.rowList, "Failed to execute MultiEngine Query")
-    
-    val expected =
-      """
-        |
-        | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
-        |      FROM (SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"
-        |            FROM
-        |               ( (SELECT  campaign_id, id, advertiser_id
-        |            FROM ad_group_oracle
-        |            WHERE (advertiser_id = 213) AND (id IN (113,114)) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
-        |             ) ago1
-        |          INNER JOIN
-        |            (SELECT /*+ CampaignHint */ campaign_name, id, advertiser_id
-        |            FROM campaign_oracle
-        |            WHERE (advertiser_id = 213) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
-        |             ) co0
-        |              ON( ago1.advertiser_id = co0.advertiser_id AND ago1.campaign_id = co0.id )
-        |               )
-        |
-        |           )
-        |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
-        |      FROM (SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"
-        |            FROM
-        |               ( (SELECT  campaign_id, id, advertiser_id
-        |            FROM ad_group_oracle
-        |            WHERE (advertiser_id = 213) AND (id NOT IN (113,114)) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
-        |             ) ago1
-        |          INNER JOIN
-        |            (SELECT /*+ CampaignHint */ campaign_name, id, advertiser_id
-        |            FROM campaign_oracle
-        |            WHERE (advertiser_id = 213) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
-        |             ) co0
-        |              ON( ago1.advertiser_id = co0.advertiser_id AND ago1.campaign_id = co0.id )
-        |               )
-        |
-        |           )
-        |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)
-        |  """.stripMargin
+        val result = queryPipelineTry.toOption.get.execute(queryExecContext)
+        assert(result.isSuccess)
 
-    oracleQuery.asString should equal (expected) (after being whiteSpaceNormalised)
+        //var result = oracleExecutor.execute(oraclQuery.head, rowList, QueryAttributes.empty)
+        val oracleQuery = queryPipelineTry.toOption.get.queryChain.subsequentQueryList.head
+        //require(result.rowList, "Failed to execute MultiEngine Query")
+
+        val expected =
+          """
+            |
+            | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
+            |      FROM (SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"
+            |            FROM
+            |               ( (SELECT  campaign_id, id, advertiser_id
+            |            FROM ad_group_oracle
+            |            WHERE (advertiser_id = 213) AND (id IN (113,114)) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
+            |             ) ago1
+            |          INNER JOIN
+            |            (SELECT /*+ CampaignHint */ campaign_name, id, advertiser_id
+            |            FROM campaign_oracle
+            |            WHERE (advertiser_id = 213) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
+            |             ) co0
+            |              ON( ago1.advertiser_id = co0.advertiser_id AND ago1.campaign_id = co0.id )
+            |               )
+            |
+            |           )
+            |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+            |      FROM (SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"
+            |            FROM
+            |               ( (SELECT  campaign_id, id, advertiser_id
+            |            FROM ad_group_oracle
+            |            WHERE (advertiser_id = 213) AND (id NOT IN (113,114)) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
+            |             ) ago1
+            |          INNER JOIN
+            |            (SELECT /*+ CampaignHint */ campaign_name, id, advertiser_id
+            |            FROM campaign_oracle
+            |            WHERE (advertiser_id = 213) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
+            |             ) co0
+            |              ON( ago1.advertiser_id = co0.advertiser_id AND ago1.campaign_id = co0.id )
+            |               )
+            |
+            |           )
+            |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)
+            |  """.stripMargin
+
+        oracleQuery.asString should equal(expected)(after being whiteSpaceNormalised)
+    }
 
   }
 
+  test("successfully execute select query type") {
+
+    val jsonString =
+      s"""{
+                          "queryType": "select",
+                          "cube": "k_stats_select",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Keyword ID"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "in", "values": ["$fromDate", "$toDate"]},
+                            {"field": "Advertiser ID", "operator": "=", "value": "5485"}
+                          ],
+                          "paginationStartIndex":0,
+                          "rowsPerPage":5
+                        }""".stripMargin
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
+    val registry = defaultRegistry
+    val requestModel = RequestModel.from(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val altQueryGeneratorRegistry = new QueryGeneratorRegistry
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator()) //do not include local time filter
+    val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
+    val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    println(query.asString)
+
+    withDruidQueryExecutor("http://localhost:6667/mock/select") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(!result.rowList.isEmpty)
+
+        var str: String = ""
+        var count: Int = 0
+        result.rowList.foreach {
+          row => {
+            count += 1
+
+            str = str + s"$row"
+          }
+        }
+
+        assert(count == 5)
+        val expected = "Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2),ArrayBuffer(2013-01-01 00, id1, 1))Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2),ArrayBuffer(2013-01-01 00, id2, 2))Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2),ArrayBuffer(2013-01-01 00, id3, 3))Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2),ArrayBuffer(2013-01-01 00, id4, 4))Row(Map(Day -> 0, Keyword ID -> 1, Impressions -> 2),ArrayBuffer(2013-01-01 00, id5, 5))"
+
+        str should equal(expected)(after being whiteSpaceNormalised)
+
+        result.rowList.foreach { row =>
+          val map = row.aliasMap
+          for ((key, value) <- map) {
+            assert(row.getValue(key) != null)
+          }
+        }
+
+        assert(result.pagination.isDefined)
+    }
+  }
+
+  test("fail to execute select query type with unhandled json") {
+
+    val jsonString =
+      s"""{
+                          "queryType": "select",
+                          "cube": "k_stats_select",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Keyword ID"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "in", "values": ["$fromDate", "$toDate"]},
+                            {"field": "Advertiser ID", "operator": "=", "value": "5485"}
+                          ],
+                          "paginationStartIndex":0,
+                          "rowsPerPage":5
+                        }""".stripMargin
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
+    val registry = defaultRegistry
+    val requestModel = RequestModel.from(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val altQueryGeneratorRegistry = new QueryGeneratorRegistry
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator()) //do not include local time filter
+    val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
+    val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+
+    List("1", "2", "3", "4", "5", "6", "7").foreach {
+      idx =>
+        withDruidQueryExecutor(s"http://localhost:6667/mock/selectunsupported$idx") {
+          executor =>
+            val rowList = new CompleteRowList(query)
+            val result = executor.execute(query, rowList, QueryAttributes.empty)
+            assert(result.isFailure, s"idx=$idx result=${result.toString}")
+            val thrown = result.exception.get
+            assert(thrown.getMessage.contains("""Unexpected field in SelectDruidQuery json response"""))
+        }
+    }
+  }
+
+  test("fail to execute query when rowList throws exception") {
+
+    val jsonString =
+      s"""{
+                          "queryType": "select",
+                          "cube": "k_stats_select",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Keyword ID"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "in", "values": ["$fromDate", "$toDate"]},
+                            {"field": "Advertiser ID", "operator": "=", "value": "5485"}
+                          ],
+                          "paginationStartIndex":0,
+                          "rowsPerPage":5
+                        }""".stripMargin
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
+    val registry = defaultRegistry
+    val requestModel = RequestModel.from(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val altQueryGeneratorRegistry = new QueryGeneratorRegistry
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator()) //do not include local time filter
+    val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
+    val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    println(query.asString)
+
+    withDruidQueryExecutor("http://localhost:6667/mock/select") {
+      executor =>
+        val rowList = spy(new CompleteRowList(query))
+        when(rowList.addRow(anyObject(), anyObject())).thenThrow(new UnsupportedOperationException("fail"))
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage.contains("""fail"""))
+    }
+  }
+
+  test("fail to execute query which is unknown type") {
+
+    val jsonString =
+      s"""{
+                          "queryType": "select",
+                          "cube": "k_stats_select",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Keyword ID"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "in", "values": ["$fromDate", "$toDate"]},
+                            {"field": "Advertiser ID", "operator": "=", "value": "5485"}
+                          ],
+                          "paginationStartIndex":0,
+                          "rowsPerPage":5
+                        }""".stripMargin
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = RequestModel.from(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val altQueryGeneratorRegistry = new QueryGeneratorRegistry
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator()) //do not include local time filter
+    val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
+    val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    val actualQuery = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+
+    val query = new DruidQuery[Result[SelectResultValue]] {
+      override def query: io.druid.query.Query[Result[SelectResultValue]] = actualQuery.query.asInstanceOf[io.druid.query.Query[Result[SelectResultValue]]]
+
+      override def maxRows: Int = actualQuery.maxRows
+
+      override def isPaginated: Boolean = actualQuery.isPaginated
+
+      override def queryContext: QueryContext = actualQuery.queryContext
+
+      override def aliasColumnMap: Map[String, Column] = actualQuery.aliasColumnMap
+
+      override def additionalColumns: IndexedSeq[String] = actualQuery.additionalColumns
+    }
+
+    withDruidQueryExecutor("http://localhost:6667/mock/select") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val result = executor.execute(query, rowList, QueryAttributes.empty)
+        assert(result.isFailure, result.toString)
+        val thrown = result.exception.get
+        assert(thrown.getMessage.contains("Druid Query type not supported"))
+    }
+  }
+
+  test("fail to execute oracle query") {
+
+    val jsonString =
+      s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Keyword ID"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "in", "values": ["$fromDate", "$toDate"]},
+                            {"field": "Advertiser ID", "operator": "=", "value": "5485"}
+                          ],
+                          "paginationStartIndex":0,
+                          "rowsPerPage":5
+                        }""".stripMargin
+    val request: ReportingRequest = ReportingRequest.forceOracle(getReportingRequestSync(jsonString))
+    val registry = defaultRegistry
+    val requestModel = RequestModel.from(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val altQueryGeneratorRegistry = new QueryGeneratorRegistry
+    altQueryGeneratorRegistry.register(OracleEngine, new OracleQueryGenerator(DefaultPartitionColumnRenderer))
+    val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory()(altQueryGeneratorRegistry)
+    val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery]
+
+    withDruidQueryExecutor("http://localhost:6667/mock/groupby") {
+      executor =>
+        val rowList = new CompleteRowList(query)
+        val thrown = intercept[UnsupportedOperationException] {
+          executor.execute(query, rowList, QueryAttributes.empty)
+        }
+        assert(thrown.getMessage.contains("DruidQueryExecutor does not support query with engine=Oracle"))
+    }
+  }
 }

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/TestWebService.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/TestWebService.scala
@@ -385,22 +385,42 @@ trait TestWebService {
                      |  ]""".stripMargin
       Ok(groupby)
 
-    case POST -> Root / ("faultygroupby")=>
-
-      val groupby="""{
-                    |    "timestamp" : "2012-01-01T00:00:12.000Z",
-                    |    "event" : {
-                    |    "Pricing Type" : 13,
-                    |     "Keyword ID": 14,
-                    |     "Average Bid": 15,
-                    |     "Max Bid": 16,
-                    |     "Impressions":17.00,
-                    |     "Min Bid":18,
-                    |     "Keyword Value": 19,
-                    |     "Average Position":20,
-                    |     "Day":"20160101"
-                    |    }
-                    |  }""".stripMargin
+    case POST -> Root /"groupbyunsupported1"=>
+      val groupby ="""[
+                     |  {
+                     |    "timestamp" : "2012-01-01T00:00:00.000Z",
+                     |    "unsupported" : "field",
+                     |    "event" : {
+                     |      "Pricing Type" : 11,
+                     |      "Keyword ID": "10",
+                     |      "Average Bid": 9,
+                     |     "Max Bid": 163,
+                     |     "Impressions":175,
+                     |     "Conversions":15.0,
+                     |     "Min Bid":184,
+                     |     "Keyword Value": 419,
+                     |     "Average Position":205,
+                     |     "Day":"20120101",
+                     |     "Advertiser Status": "ON",
+                     |     "show_sov_flag": "0",
+                     |     "Impression Share": 0.4567
+                     |    }
+                     |  }
+                     |  ]""".stripMargin
+      Ok(groupby)
+    case POST -> Root /"groupbyunsupported2"=>
+      val groupby ="""[
+                     |  {
+                     |    "timestamp" : "2012-01-01T00:00:00.000Z",
+                     |    "event" : "unsupported"
+                     |  }
+                     |  ]""".stripMargin
+      Ok(groupby)
+    case POST -> Root /"groupbyunsupported3"=>
+      val groupby ="""["unsupported"]""".stripMargin
+      Ok(groupby)
+    case POST -> Root /"groupbyunsupported4"=>
+      val groupby ="""{}""".stripMargin
       Ok(groupby)
 
     case POST -> Root / ("timeseries") =>
@@ -409,15 +429,15 @@ trait TestWebService {
         """[
           |  {
           |    "timestamp": "2012-01-01T00:00:00.000Z",
-          |    "result": { "Impressions": 15,"Day": "20160111" }
+          |    "result": { "Impressions": 15 }
           |  },
           |  {
           |   "timestamp": "2012-01-02T00:00:00.000Z",
-          |   "result": { "Impressions": 16 ,"Day": "20160112"}
+          |   "result": { "Impressions": 16 }
           |  },
           |  {
           |    "timestamp": "2012-01-03T00:00:00.000Z",
-          |    "result": { "Impressions": 17,"Day":"20160113" }
+          |    "result": { "Impressions": 17 }
           |  }
           |]""".stripMargin
       Ok(timeSeries)
@@ -428,38 +448,46 @@ trait TestWebService {
         """[
           |  {
           |    "timestamp": "2012-01-01T00:00:00.000Z",
-          |    "result": { "Impressions": 15,"Day": "20160111", "Intentions": 55 }
+          |    "result": { "Impressions": 15, "Intentions": 55 }
           |  },
           |  {
           |   "timestamp": "2012-01-02T00:00:00.000Z",
-          |   "result": { "Impressions": 16 ,"Day": "20160112"}
+          |   "result": { "Impressions": 16 }
           |  },
           |  {
           |    "timestamp": "2012-01-03T00:00:00.000Z",
-          |    "result": { "Impressions": 17,"Day":"20160113" }
+          |    "result": { "Impressions": 17 }
           |  }
           |]""".stripMargin
       Ok(timeSeries)
 
-    case POST -> Root/("faultytimeseries") =>
-
+    case POST -> Root/"timeseriesunsupported1" =>
       val timeSeries =
         """[
           |  {
           |    "timestamp": "2012-01-01T00:00:00.000Z",
-          |    "re": { "Impressions": 15,"Day": "20160111" }
-          |  },
-          |  {
-          |   "timestamp": "2012-01-02T00:00:00.000Z",
-          |   "res": { "Impressions": 16 ,"Day": "20160112"}
-          |  },
-          |  {
-          |    "timestamp": "2012-01-03T00:00:00.000Z",
-          |    "re": { "Impressions": 17,"Day":"20160113" }
+          |    "result": { "Impressions": 15 },
+          |    "unsupported":"field"
           |  }
           |]""".stripMargin
       Ok(timeSeries)
-
+    case POST -> Root/"timeseriesunsupported2" =>
+      val timeSeries =
+        """[
+          |  {
+          |    "timestamp": "2012-01-01T00:00:00.000Z",
+          |    "result": "unsupported"
+          |  }
+          |]""".stripMargin
+      Ok(timeSeries)
+    case POST -> Root/"timeseriesunsupported3" =>
+      val timeSeries =
+        """["unsupported"]""".stripMargin
+      Ok(timeSeries)
+    case POST -> Root/"timeseriesunsupported4" =>
+      val timeSeries =
+        """{}""".stripMargin
+      Ok(timeSeries)
 
     case POST -> Root /("topn") =>
       val topN = """[{
@@ -554,6 +582,40 @@ trait TestWebService {
                    |    "Keyword Value":30
                    |	}]
                    |}]""".stripMargin
+      Ok(topN)
+
+    case POST -> Root /"topnunsupported1"=>
+      val topN = """[{
+                   |	"timestamp": "2013-08-31T00:00:00.000Z",
+                   |	"result": [{
+                   |		"Keyword ID": 14,
+                   |    "Keyword Value":1,
+                   |		"Impressions": 10669
+                   |	},{
+                   |		"Keyword ID": 13,
+                   |		"Impressions": 106,
+                   |    "Keyword Value":30
+                   |	}],
+                   | "unsupported": "field"
+                   |}]""".stripMargin
+      Ok(topN)
+    case POST -> Root /"topnunsupported2"=>
+      val topN = """[{
+                   |	"timestamp": "2013-08-31T00:00:00.000Z",
+                   |	"result": ["unsupported"]
+                   |}]""".stripMargin
+      Ok(topN)
+    case POST -> Root /"topnunsupported3"=>
+      val topN = """[{
+                   |	"timestamp": "2013-08-31T00:00:00.000Z",
+                   |	"result": "unsupported"
+                   |}]""".stripMargin
+      Ok(topN)
+    case POST -> Root /"topnunsupported4"=>
+      val topN = """["unsupported"]""".stripMargin
+      Ok(topN)
+    case POST -> Root /"topnunsupported5"=>
+      val topN = """{}""".stripMargin
       Ok(topN)
 
     case GET -> Root /("topn") =>
@@ -1043,6 +1105,144 @@ trait TestWebService {
       }
     case POST -> Root / "fail" =>
       InternalServerError("always fail!")
+
+    case POST -> Root /"select" =>
+      val select = """ [{
+                   | 	"timestamp": "2013-01-01T00:00:00.000Z",
+                   | 	"result": {
+                   | 		"pagingIdentifiers": {
+                   | 			"wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9": 4
+                   | 		},
+                   |    "dimensons": ["Keyword ID", "Day"],
+                   |    "metrics": ["impressions"],
+                   | 		"events": [{
+                   | 			"segmentId": "wikipedia_editstream_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9",
+                   | 			"offset": 0,
+                   | 			"event": {
+                   | 				"timestamp": "2013-01-01T00:00:00.000Z",
+                   | 				"Keyword ID": "id1",
+                   |        "Day": "2013-01-01 00",
+                   | 				"impressions": "1"
+                   | 			}
+                   | 		}, {
+                   | 			"segmentId": "wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9",
+                   | 			"offset": 1,
+                   | 			"event": {
+                   | 				"timestamp": "2013-01-01T00:00:00.000Z",
+                   | 				"Keyword ID": "id2",
+                   |        "Day": "2013-01-01 00",
+                   | 				"impressions": "2"
+                   | 			}
+                   | 		}, {
+                   | 			"segmentId": "wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9",
+                   | 			"offset": 2,
+                   | 			"event": {
+                   | 				"timestamp": "2013-01-01T00:00:00.000Z",
+                   | 				"Keyword ID": "id3",
+                   |        "Day": "2013-01-01 00",
+                   | 				"impressions": "3"
+                   | 			}
+                   | 		}, {
+                   | 			"segmentId": "wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9",
+                   | 			"offset": 3,
+                   | 			"event": {
+                   | 				"timestamp": "2013-01-01T00:00:00.000Z",
+                   | 				"Keyword ID": "id4",
+                   |        "Day": "2013-01-01 00",
+                   | 				"impressions": "4"
+                   | 			}
+                   | 		}, {
+                   | 			"segmentId": "wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9",
+                   | 			"offset": 4,
+                   | 			"event": {
+                   | 				"timestamp": "2013-01-01T00:00:00.000Z",
+                   | 				"Keyword ID": "id5",
+                   |        "Day": "2013-01-01 00",
+                   | 				"impressions": "5"
+                   | 			}
+                   | 		}]
+                   | 	}
+                   | }]""".stripMargin
+      Ok(select)
+    case POST -> Root /"selectunsupported1" =>
+      val select = """ [{
+                     | 	"timestamp": "2013-01-01T00:00:00.000Z",
+                     |  "unsupported": "field",
+                     | 	"result": {
+                     | 		"pagingIdentifiers": {
+                     | 			"wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9": 4
+                     | 		},
+                     |    "dimensons": ["Keyword ID", "Day"],
+                     |    "metrics": ["impressions"],
+                     | 		"events": [{
+                     | 			"segmentId": "wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9",
+                     | 			"offset": 4,
+                     | 			"event": {
+                     | 				"timestamp": "2013-01-01T00:00:00.000Z",
+                     | 				"Keyword ID": "id5",
+                     |        "Day": "2013-01-01 00",
+                     | 				"impressions": "5"
+                     | 			}
+                     | 		}]
+                     | 	}
+                     | }]""".stripMargin
+      Ok(select)
+    case POST -> Root /"selectunsupported2" =>
+      val select = """ [{
+                     | 	"timestamp": "2013-01-01T00:00:00.000Z",
+                     | 	"result": {
+                     | 		"pagingIdentifiers": {
+                     | 			"wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9": 4
+                     | 		},
+                     |    "dimensons": ["Keyword ID", "Day"],
+                     |    "metrics": ["impressions"],
+                     | 		"events": [{
+                     | 			"segmentId": "wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9",
+                     | 			"offset": 4,
+                     | 			"event": "unsupported"
+                     | 		}]
+                     | 	}
+                     | }]""".stripMargin
+      Ok(select)
+    case POST -> Root /"selectunsupported3" =>
+      val select = """ [{
+                     | 	"timestamp": "2013-01-01T00:00:00.000Z",
+                     | 	"result": {
+                     | 		"pagingIdentifiers": {
+                     | 			"wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9": 4
+                     | 		},
+                     |    "dimensons": ["Keyword ID", "Day"],
+                     |    "metrics": ["impressions"],
+                     | 		"events": ["unsupported"]
+                     | 	}
+                     | }]""".stripMargin
+      Ok(select)
+    case POST -> Root /"selectunsupported4" =>
+      val select = """ [{
+                     | 	"timestamp": "2013-01-01T00:00:00.000Z",
+                     | 	"result": {
+                     | 		"pagingIdentifiers": {
+                     | 			"wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9": 4
+                     | 		},
+                     |    "dimensons": ["Keyword ID", "Day"],
+                     |    "metrics": ["impressions"],
+                     | 		"events": "unsupported"
+                     | 	}
+                     | }]""".stripMargin
+      Ok(select)
+    case POST -> Root /"selectunsupported5" =>
+      val select = """ [{
+                     | 	"timestamp": "2013-01-01T00:00:00.000Z",
+                     | 	"result": "unsupported"
+                     | }]""".stripMargin
+      Ok(select)
+
+    case POST -> Root /"selectunsupported6" =>
+      val select = """ ["unsupported"]""".stripMargin
+      Ok(select)
+    case POST -> Root /"selectunsupported7" =>
+      val select = """{}""".stripMargin
+      Ok(select)
   }
 
 }

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/oracle/src/main/scala/com/yahoo/maha/executor/oracle/OracleQueryExecutor.scala
+++ b/oracle/src/main/scala/com/yahoo/maha/executor/oracle/OracleQueryExecutor.scala
@@ -110,7 +110,7 @@ class OracleQueryExecutor(jdbcConnection: JdbcConnection, lifecycleListener: Exe
             case Failure(e) =>
               Try(lifecycleListener.failed(query, acquiredQueryAttributes, e))
               error(s"Failed query : ${query.asString}")
-              throw e
+              QueryResult(rl, acquiredQueryAttributes, QueryResultStatus.FAILURE, Option(e))
             case _ =>
               QueryResult(rl, lifecycleListener.completed(query, acquiredQueryAttributes), QueryResultStatus.SUCCESS)
           }
@@ -164,7 +164,7 @@ class OracleQueryExecutor(jdbcConnection: JdbcConnection, lifecycleListener: Exe
             case Failure(e) =>
               Try(lifecycleListener.failed(query, acquiredQueryAttributes, e))
               error(s"Failed query : ${query.asString}")
-              throw e
+              QueryResult(rl, acquiredQueryAttributes, QueryResultStatus.FAILURE, Option(e))
             case _ =>
               QueryResult(rl, lifecycleListener.completed(query, acquiredQueryAttributes), QueryResultStatus.SUCCESS)
           }

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.240-SNAPSHOT</version>
+    <version>5.241-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/presto/src/main/scala/com/yahoo/maha/executor/presto/PrestoQueryExecutor.scala
+++ b/presto/src/main/scala/com/yahoo/maha/executor/presto/PrestoQueryExecutor.scala
@@ -88,7 +88,8 @@ class PrestoQueryExecutor(jdbcConnection: JdbcConnection,
           result match {
             case Failure(e) =>
               Try(lifecycleListener.failed(query, acquiredQueryAttributes, e))
-              throw e
+              error(s"Failed query : ${query.asString}")
+              QueryResult(rl, acquiredQueryAttributes, QueryResultStatus.FAILURE, Option(e))
             case _ =>
               if (debugEnabled) {
                 info(s"Successfully retrieved results from Presto: $rowCount")

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/test/scala/com/yahoo/maha/service/output/JsonOutputFormatTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/output/JsonOutputFormatTest.scala
@@ -118,7 +118,7 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
 
     rowList.addRow(row)
 
-    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty)
+    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty, Map.empty)
     val requestResult = pse.immediateResult("label", new Right(RequestResult(queryPipelineResult)))
     val parRequestResult = ParRequestResult(Try(queryPipeline), requestResult, None)
     val requestModelResult = RequestModelResult(query.queryContext.requestModel, None)
@@ -154,7 +154,7 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     row.addValue("Total Marks", 99)
     rowList.addRow(row)
 
-    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty)
+    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty, Map.empty)
     val requestResult = pse.immediateResult("label", new Right(RequestResult(queryPipelineResult)))
     val parRequestResult = ParRequestResult(Try(queryPipeline), requestResult, None)
     val requestModelResult = RequestModelResult(query.queryContext.requestModel, None)
@@ -195,7 +195,7 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     row.addValue("Total Marks", 99)
     rowList.addRow(row)
 
-    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty)
+    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty, Map.empty)
     val requestResult = pse.immediateResult("label", new Right(RequestResult(queryPipelineResult)))
     val parRequestResult = ParRequestResult(Try(queryPipeline), requestResult, None)
     val requestModelResult = RequestModelResult(query.queryContext.requestModel, None)
@@ -236,7 +236,7 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     row.addValue(QueryRowList.ROW_COUNT_ALIAS, 101)
     rowList.addRow(row)
 
-    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty)
+    val queryPipelineResult = QueryPipelineResult(queryPipeline, queryChain, rowList, QueryAttributes.empty, Map.empty)
     val requestResult = pse.immediateResult("label", new Right(RequestResult(queryPipelineResult)))
     val parRequestResult = ParRequestResult(Try(queryPipeline), requestResult, None)
     val requestModelResult = RequestModelResult(query.queryContext.requestModel, None)
@@ -273,7 +273,7 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     row.addValue("Total Marks", 99)
     rowList.addRow(row)
 
-    val queryPipelineResult = QueryPipelineResult(fd_queryPipeline, fd_queryChain, rowList, QueryAttributes.empty)
+    val queryPipelineResult = QueryPipelineResult(fd_queryPipeline, fd_queryChain, rowList, QueryAttributes.empty, Map.empty)
     val requestResult = pse.immediateResult("label", new Right(RequestResult(queryPipelineResult)))
     val parRequestResult = ParRequestResult(Try(fd_queryPipeline), requestResult, None)
     val requestModelResult = RequestModelResult(fd_query.queryContext.requestModel, None)

--- a/service/src/test/scala/com/yahoo/maha/service/output/JsonOutputFormatTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/output/JsonOutputFormatTest.scala
@@ -7,12 +7,13 @@ import java.util.Date
 import com.yahoo.maha.core.bucketing.{BucketParams, UserInfo}
 import com.yahoo.maha.core.query.{CompleteRowList, QueryAttributes, QueryPipelineResult, QueryRowList}
 import com.yahoo.maha.core.request.ReportingRequest
-import com.yahoo.maha.core.{Engine, OracleEngine, RequestModelResult}
+import com.yahoo.maha.core.{DruidEngine, Engine, OracleEngine, RequestModelResult}
 import com.yahoo.maha.service.curators._
 import com.yahoo.maha.service.datasource.IngestionTimeUpdater
 import com.yahoo.maha.service.example.ExampleSchema.StudentSchema
 import com.yahoo.maha.service.utils.MahaRequestLogHelper
 import com.yahoo.maha.service.{BaseMahaServiceTest, CuratorInjector, MahaRequestContext, ParRequestResult, RequestCoordinatorResult, RequestResult}
+import org.json4s.JsonAST.{JInt, JObject, JString}
 import org.scalatest.BeforeAndAfterAll
 
 import scala.util.Try
@@ -273,7 +274,7 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     row.addValue("Total Marks", 99)
     rowList.addRow(row)
 
-    val queryPipelineResult = QueryPipelineResult(fd_queryPipeline, fd_queryChain, rowList, QueryAttributes.empty, Map.empty)
+    val queryPipelineResult = QueryPipelineResult(fd_queryPipeline, fd_queryChain, rowList, QueryAttributes.empty, Map(DruidEngine -> JObject("pagingIdentifiers" -> JObject("wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9" -> JInt(4)))))
     val requestResult = pse.immediateResult("label", new Right(RequestResult(queryPipelineResult)))
     val parRequestResult = ParRequestResult(Try(fd_queryPipeline), requestResult, None)
     val requestModelResult = RequestModelResult(fd_query.queryContext.requestModel, None)
@@ -296,6 +297,6 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     jsonStreamingOutput.writeStream(stringStream)
     val result = stringStream.toString()
     stringStream.close()
-    assert(result === """{"header":{"cube":"student_performance","fields":[{"fieldName":"Student ID","fieldType":"DIM"},{"fieldName":"Class ID","fieldType":"DIM"},{"fieldName":"Section ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"},{"fieldName":"Sample Constant Field","fieldType":"CONSTANT"},{"fieldName":"ROW_COUNT","fieldType":"CONSTANT"}],"maxRows":200,"debug":{"testName":"test1","labels":["lb1","lb2","lb3"]}},"rows":[[123,234,345,99,"Test Result",1]],"curators":{}}""")
+    assert(result === """{"header":{"cube":"student_performance","fields":[{"fieldName":"Student ID","fieldType":"DIM"},{"fieldName":"Class ID","fieldType":"DIM"},{"fieldName":"Section ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"},{"fieldName":"Sample Constant Field","fieldType":"CONSTANT"},{"fieldName":"ROW_COUNT","fieldType":"CONSTANT"}],"maxRows":200,"debug":{"testName":"test1","labels":["lb1","lb2","lb3"]},"pagination":{"Druid":{"pagingIdentifiers":{"wikipedia_2012-12-29T00:00:00.000Z_2013-01-10T08:00:00.000Z_2013-01-10T08:13:47.830Z_v9":4}}}},"rows":[[123,234,345,99,"Test Result",1]],"curators":{}}""")
   }
 }

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.240-SNAPSHOT</version>
+        <version>5.241-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Addresses issue #393 

Changes:

- ReportingRequest
  - add support for query type
  - add support for engine specific pagination

- DruidQueryGenerator
  - add support for select query

- DruidQueryExecutor
  - add support for select query
  - fix timeseries query execution
  - increase code coverage
  - standardize execution result, no longer throw exception, return it as part of result

- OracleQueryExecutor
  - standardize execution result, no longer throw exception, return it as part of result

- PrestoQueryExecutor
  - standardize execution result, no longer throw exception, return it as part of result

- QueryPipeline
  - standardize handling of execution result, check result is success, on failure, check result exception

- JsonOutputFormat
  - add support for rendering pagination by engine
