### PR TITLE
Remove decodeUDF (inexistent in Presto) in favor of case statement.

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
@@ -207,10 +207,10 @@ class PrestoQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, udfS
             s"CASE ${whenClauses.mkString(" ")} ELSE '$defaultValue' END"
           case StrType(_, sm, _) if sm.isDefined =>
             val defaultValue = sm.get.default
-            val decodeValues = sm.get.tToStringMap.map {
-              case (from, to) => s"'$from', '$to'"
+            val whenClauses = sm.get.tToStringMap.map {
+              case (from, to) => s"WHEN ($nameOrAlias IN ($from)) THEN '$to'"
             }
-            s"""decodeUDF($nameOrAlias, ${decodeValues.mkString(", ")}, '$defaultValue')"""
+            s"CASE ${whenClauses.mkString(" ")} ELSE '$defaultValue' END"
           case _ =>
             s"""COALESCE($nameOrAlias, "NA")"""
         }

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
@@ -208,7 +208,7 @@ class PrestoQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, udfS
           case StrType(_, sm, _) if sm.isDefined =>
             val defaultValue = sm.get.default
             val whenClauses = sm.get.tToStringMap.map {
-              case (from, to) => s"WHEN ($nameOrAlias IN ($from)) THEN '$to'"
+              case (from, to) => s"WHEN ($nameOrAlias IN ('$from')) THEN '$to'"
             }
             s"CASE ${whenClauses.mkString(" ")} ELSE '$defaultValue' END"
           case _ =>

--- a/core/src/test/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorTest.scala
@@ -184,10 +184,10 @@ CAST(ssfu0.campaign_id AS VARCHAR) = CAST(c1.c1_id AS VARCHAR)
     val expected = s"""SELECT advertiser_id, mang_impressions, network_id
                       |FROM(
                       |SELECT CAST(COALESCE(account_id, 0) as VARCHAR) advertiser_id, CAST(COALESCE(impressions, 0) as VARCHAR) mang_impressions, COALESCE(CAST(network_type as VARCHAR), 'NA') network_id
-                      |FROM(SELECT CASE WHEN (network_type IN (TEST_PUBLISHER)) THEN 'Test Publisher' WHEN (network_type IN (CONTENT_S)) THEN 'Content Secured' WHEN (network_type IN (EXTERNAL)) THEN 'External Partners' WHEN (network_type IN (INTERNAL)) THEN 'Internal Properties' ELSE 'NONE' END network_type, account_id, SUM(impressions) impressions
+                      |FROM(SELECT CASE WHEN (network_type IN ('TEST_PUBLISHER')) THEN 'Test Publisher' WHEN (network_type IN ('CONTENT_S')) THEN 'Content Secured' WHEN (network_type IN ('EXTERNAL')) THEN 'External Partners' WHEN (network_type IN ('INTERNAL')) THEN 'Internal Properties' ELSE 'NONE' END network_type, account_id, SUM(impressions) impressions
                       |FROM s_stats_fact_underlying
                       |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
-                      |GROUP BY CASE WHEN (network_type IN (TEST_PUBLISHER)) THEN 'Test Publisher' WHEN (network_type IN (CONTENT_S)) THEN 'Content Secured' WHEN (network_type IN (EXTERNAL)) THEN 'External Partners' WHEN (network_type IN (INTERNAL)) THEN 'Internal Properties' ELSE 'NONE' END, account_id
+                      |GROUP BY CASE WHEN (network_type IN ('TEST_PUBLISHER')) THEN 'Test Publisher' WHEN (network_type IN ('CONTENT_S')) THEN 'Content Secured' WHEN (network_type IN ('EXTERNAL')) THEN 'External Partners' WHEN (network_type IN ('INTERNAL')) THEN 'Internal Properties' ELSE 'NONE' END, account_id
                       |HAVING (SUM(impressions) < 1608) AND (MAX(max_bid) = SUM(spend))
                       |       )
                       |ssfu0

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.265-SNAPSHOT</version>
+    <version>5.266-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.265-SNAPSHOT</version>
+        <version>5.266-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Presto has no decodeUDF definition.  As such, using this logic as it is used in Hive can only cause errors on a generated query.

This is remedied by using simple case matching as is done in the INT case.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
