### PR TITLE
Move expensive datetime filters to outer groupBy

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.268-SNAPSHOT</version>
+    <version>5.269-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.268-SNAPSHOT</version>
+        <version>5.269-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
**Issue:**
Currently, timeFormat extraction filtering is included as part of druid filter. This is very expensive and doesn't use any indexes as transformation has to happen for filter to work.
```json
{
	"queryType": "groupBy",
	"dataSource": {
		"type": "table",
		"name": "fact1"
	},
	"intervals": {
		"type": "intervals",
		"intervals": ["2019-06-12T00:00:00.000Z/2019-06-13T00:00:00.000Z"]
	},
	"filter": {
		"type": "and",
		"fields": [{
			"type": "or",
			"fields": [{
				"type": "selector",
				"dimension": "__time",
				"value": "20190612",
				"extractionFn": {
					"type": "timeFormat",
					"format": "YYYYMMdd",
					"timeZone": "America/Los_Angeles",
					"locale": null,
					"granularity": {
						"type": "none"
					},
					"asMillis": false
				}
			}]
		}, {
			"type": "selector",
			"dimension": "advertiser_id",
			"value": "12345"
		}]
	},
	"granularity": {
		"type": "all"
	},
	"dimensions": [{
		"type": "extraction",
		"dimension": "__time",
		"outputName": "Day",
		"outputType": "STRING",
		"extractionFn": {
			"type": "timeFormat",
			"format": "YYYYMMdd",
			"timeZone": "America/Los_Angeles",
			"locale": null,
			"granularity": {
				"type": "none"
			},
			"asMillis": false
		}
	}],
	"aggregations": [{
		"type": "longSum",
		"name": "Clicks",
		"fieldName": "clicks",
		"expression": null
	}]

}
```

**Fix:**
Move the expensive dateTime filter to outer groupBy. With this, no timeFormat transformation is required in historicals filter rather normal selector filter will be applied in the broker.

```json
{
	"queryType": "groupBy",
	"dataSource": {
		"type": "query",
		"query": {
			"queryType": "groupBy",
			"dataSource": {
				"type": "table",
				"name": "fact1"
			},
			"intervals": {
				"type": "intervals",
				"intervals": ["2019-06-12T00:00:00.000Z/2019-06-13T00:00:00.000Z"]
			},
			"filter": {
				"type": "and",
				"fields": [{
					"type": "selector",
					"dimension": "advertiser_id",
					"value": "12345"
				}]
			},
			"granularity": {
				"type": "all"
			},
			"dimensions": [{
				"type": "extraction",
				"dimension": "__time",
				"outputName": "Day",
				"outputType": "STRING",
				"extractionFn": {
					"type": "timeFormat",
					"format": "YYYY-MM-dd HH",
					"timeZone": "America/Los_Angeles",
					"granularity": {
						"type": "none"
					},
					"asMillis": false
				}
			}],
			"aggregations": [{
				"type": "longSum",
				"name": "Clicks",
				"fieldName": "clicks"
			}]
		}
	},
	"intervals": {
		"type": "intervals",
		"intervals": ["2019-06-12T00:00:00.000Z/2019-06-13T00:00:00.000Z"]
	},
	"filter": {
		"type": "and",
		"fields": [{
			"type": "or",
			"fields": [{
				"type": "selector",
				"dimension": "Day",
				"value": "2019-06-12"
			}]
		}]
	},
	"granularity": {
		"type": "all"
	},
	"dimensions": [{
		"type": "default",
		"dimension": "Day",
		"outputName": "Day",
		"outputType": "STRING"
	}],
	"aggregations": [{
		"type": "longSum",
		"name": "Clicks",
		"fieldName": "Clicks"
	}]
}
```

**Result:**
Tested the fix in production where query time reduced from **30 seconds** to **1 second**




<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
