### PR TITLE
Use druid lookups in dimDriven MultiEngine sync requests

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryContext.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryContext.scala
@@ -67,7 +67,7 @@ case class FactQueryContext private[query](factBestCandidate: FactBestCandidate,
                             requestModel: RequestModel,
                                            indexAliasOption: Option[String],
                                            factGroupByKeys: List[String],
-                            queryAttributes: QueryAttributes) extends FactualQueryContext
+                            queryAttributes: QueryAttributes, dims: Option[SortedSet[DimensionBundle]] = None) extends FactualQueryContext
 case class CombinedQueryContext private[query](dims: SortedSet[DimensionBundle],
                                 factBestCandidate: FactBestCandidate,
                                 requestModel: RequestModel,
@@ -158,7 +158,6 @@ class QueryContextBuilder(queryType: QueryType, requestModel: RequestModel) {
   }
 
   def addDimTable(dimensions: SortedSet[DimensionBundle]) = {
-    require(queryType != FactOnlyQuery, "fact only query should not have dim table")
     dims ++= dimensions
     this
   }
@@ -195,7 +194,7 @@ class QueryContextBuilder(queryType: QueryType, requestModel: RequestModel) {
         DimQueryContext(dims, requestModel, indexAliasOption, factGroupByKeys, queryAttributes)
       case FactOnlyQuery =>
         require(factBestCandidate.isDefined, "fact only query should have fact defined")
-        FactQueryContext(factBestCandidate.get, requestModel, indexAliasOption, factGroupByKeys, queryAttributes)
+        FactQueryContext(factBestCandidate.get, requestModel, indexAliasOption, factGroupByKeys, queryAttributes, Some(dims))
       case DimFactQuery =>
         require(factBestCandidate.isDefined, "dim fact query should have fact defined")
         CombinedQueryContext(dims, factBestCandidate.get, requestModel, queryAttributes)

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -274,8 +274,8 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     queryContext match {
       case CombinedQueryContext(dims, factBestCandidate, requestModel, queryAttributes) =>
         generateFactQuery(dims, new FactQueryContext(factBestCandidate, requestModel, None, List.empty, queryAttributes))
-      case context: FactQueryContext =>
-        generateFactQuery(SortedSet.empty, context)
+      case FactQueryContext(factBestCandidate, requestModel, indexAliasOption, factGroupByKeys, queryAttributes, dimsOption) =>
+        generateFactQuery(dimsOption.getOrElse(SortedSet.empty[DimensionBundle]).filter(f => f.dim.engine == DruidEngine), new FactQueryContext(factBestCandidate, requestModel, indexAliasOption, factGroupByKeys, queryAttributes))
       case any => throw new UnsupportedOperationException(s"query context not supported : $any")
     }
   }

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGenerator.scala
@@ -24,7 +24,7 @@ class HiveQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, udfSta
     queryContext match {
       case context : CombinedQueryContext =>
         generateQuery(context)
-      case FactQueryContext(factBestCandidate, model, indexAliasOption, factGroupByKeys, attributes) =>
+      case FactQueryContext(factBestCandidate, model, indexAliasOption, factGroupByKeys, attributes, _) =>
         generateQuery(CombinedQueryContext(SortedSet.empty, factBestCandidate, model, attributes))
       case DimFactOuterGroupByQueryQueryContext(dims, factBestCandidate, model, attributes) =>
         generateQuery(CombinedQueryContext(dims, factBestCandidate, model, attributes))

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2.scala
@@ -25,7 +25,7 @@ class HiveQueryGeneratorV2(partitionColumnRenderer:PartitionColumnRenderer, udfS
     queryContext match {
       case context : CombinedQueryContext =>
         generateQuery(context)
-      case FactQueryContext(factBestCandidate, model, indexAliasOption, factGroupByKeys, attributes) =>
+      case FactQueryContext(factBestCandidate, model, indexAliasOption, factGroupByKeys, attributes, _) =>
         generateQuery(CombinedQueryContext(SortedSet.empty, factBestCandidate, model, attributes))
       case ogbContext@DimFactOuterGroupByQueryQueryContext(dims, factBestCandidate, model, attributes) =>
         generateOuterGroupByQuery(ogbContext)

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
@@ -28,7 +28,7 @@ class OracleQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, lite
         generateDimOnlyQuery(context)
       case context: CombinedQueryContext =>
         generateDimFactQuery(context)
-      case FactQueryContext(factBestCandidate, model, indexAliasOption, factGroupByKeys, attributes) =>
+      case FactQueryContext(factBestCandidate, model, indexAliasOption, factGroupByKeys, attributes, _) =>
         generateDimFactQuery(CombinedQueryContext(SortedSet.empty, factBestCandidate, model, attributes))
       case context: DimFactOuterGroupByQueryQueryContext =>
         generateDimFactOuterGroupByQuery(context)

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
@@ -19,7 +19,7 @@ class PrestoQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, udfS
     queryContext match {
       case context : CombinedQueryContext =>
         generateQuery(context)
-      case FactQueryContext(factBestCandidate, model, indexAliasOption, factGroupByKeys, attributes) =>
+      case FactQueryContext(factBestCandidate, model, indexAliasOption, factGroupByKeys, attributes, _) =>
         generateQuery(CombinedQueryContext(SortedSet.empty, factBestCandidate, model, attributes))
       case any => throw new UnsupportedOperationException(s"query context not supported : $any")
     }

--- a/core/src/test/scala/com/yahoo/maha/core/query/BaseQueryChainTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/BaseQueryChainTest.scala
@@ -128,7 +128,7 @@ trait BaseQueryChainTest {
 
   def getDimQueryContext(engine: Engine,model: RequestModel, indexOption: Option[String], factGroupByKeys: List[String]) : DimQueryContext = {
     val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(model)
-    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(engine, model.schema, dimMapping, druidMultiQueryEngineList)
+    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(engine, model, dimMapping, druidMultiQueryEngineList)
     DimQueryContext(dims, model, indexOption, factGroupByKeys)
   }
 
@@ -139,7 +139,7 @@ trait BaseQueryChainTest {
 
   def getCombinedQueryContext(engine: Engine,model: RequestModel, indexOption: Option[String], queryAttributes: QueryAttributes) : CombinedQueryContext = {
     val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(model)
-    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(engine, model.schema, dimMapping, druidMultiQueryEngineList)
+    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(engine, model, dimMapping, druidMultiQueryEngineList)
     val fact = DefaultQueryPipelineFactory.findBestFactCandidate(model, dimEngines = Set(engine), queryGeneratorRegistry = new QueryGeneratorRegistry)
     CombinedQueryContext(dims, fact, model, queryAttributes)
   }

--- a/core/src/test/scala/com/yahoo/maha/core/query/QueryContextTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/QueryContextTest.scala
@@ -53,7 +53,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
     {
       val builder = new QueryContextBuilder(DimOnlyQuery, requestModel.get)
       val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
       builder.addDimTable(dims)
       val result = getOracleQuery(builder.build()).asString
       assert(result.contains("""SELECT /*+ CampaignHint */ DECODE(status, 'ON', 'ON', 'OFF') AS "Campaign Status", id"""))
@@ -262,7 +262,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
       val builder = new QueryContextBuilder(DimFactQuery, requestModel.get.copy(additionalParameters = Map(Parameter.QueryEngine -> QueryEngineValue(OracleEngine))))
       val fact = DefaultQueryPipelineFactory.findBestFactCandidate(requestModel.get, dimEngines = Set(OracleEngine), queryGeneratorRegistry = queryGeneratorRegistry )
       val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
       builder.addDimTable(dims)
       builder.addFactBestCandidate(fact)
       val context = builder.build()
@@ -277,7 +277,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
     {
       val builder = new QueryContextBuilder(DimOnlyQuery, requestModel.get)
       val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
       builder.addDimTable(dims)
       val result = getOracleQuery(builder.build()).asString
       assert(result.contains("""SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Ad Group Status", advertiser_id, id"""))
@@ -333,7 +333,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
       val builder = new QueryContextBuilder(DimFactQuery, requestModel.get)
       val fact = DefaultQueryPipelineFactory.findBestFactCandidate(requestModel.get, dimEngines = Set(OracleEngine), queryGeneratorRegistry = queryGeneratorRegistry )
       val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
       builder.addDimTable(dims)
       builder.addFactBestCandidate(fact)
 
@@ -351,7 +351,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
       val builder = new QueryContextBuilder(DimFactQuery, requestModel.get)
       val fact = DefaultQueryPipelineFactory.findBestFactCandidate(requestModel.get, dimEngines = Set(HiveEngine), queryGeneratorRegistry = queryGeneratorRegistry )
       val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(HiveEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(HiveEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
       builder.addDimTable(dims)
       builder.addFactBestCandidate(fact)
       val result = getHiveQuery(builder.build()).asString
@@ -363,7 +363,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
     {
       val builder = new QueryContextBuilder(DimOnlyQuery, requestModel.get)
       val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
       builder.addDimTable(dims)
       val result = getOracleQuery(builder.build()).asString
       assert(result.contains("""SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Ad Group Status", advertiser_id, id"""))
@@ -415,7 +415,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
     intercept[IllegalArgumentException] {
       val builder = new QueryContextBuilder(DimFactQuery, requestModel.get)
       val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+      val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
       builder.addDimTable(dims)
       builder.build()
     }
@@ -443,7 +443,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val builder = new QueryContextBuilder(DimOnlyQuery, requestModel.get)
     val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
     builder.addDimTable(dims)
     require(builder.dims.map(d=> d.dim.name).contains("campaign_oracle"))
 
@@ -562,7 +562,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
     }
     assert(dimThrown.getMessage.contains("dim fact outer group by query should not have dimension empty"))
     val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get.schema, dimMapping, druidMultiQueryEngineList)
+    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(OracleEngine, requestModel.get, dimMapping, druidMultiQueryEngineList)
     builder.addDimTable(dims)
     val result = builder.build()
     assert(result.primaryTableName == "fact_druid")

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
@@ -48,7 +48,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val requestModel = RequestModel.from(request, defaultRegistry)
     val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
-    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(DruidEngine, requestModel.get.schema, dimMapping, DefaultQueryPipelineFactory.druidMultiQueryEngineList)
+    val dims = DefaultQueryPipelineFactory.findBestDimCandidates(DruidEngine, requestModel.get, dimMapping, DefaultQueryPipelineFactory.druidMultiQueryEngineList)
     val queryContext = new QueryContextBuilder(DimOnlyQuery, requestModel.get).addDimTable(dims).build()
     val druidQueryGenerator = getDruidQueryGenerator
     intercept[UnsupportedOperationException] {

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.272-SNAPSHOT</version>
+    <version>5.273-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.272-SNAPSHOT</version>
+        <version>5.273-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
This PR is to start using druid lookups even during dimDriven MultiEngine sync requests.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
