### PR TITLE
Restricted-schema cols from dimensions shouldn't be allowed for other schemas 

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -434,8 +434,22 @@ object RequestModel extends Logging {
               }
           }
 
+
+          val requestedDimAliasesToPublicDimMap: Map[String, PublicDimension] =
+            requestedAliasList
+            .filter(reqCol => registry.getDimColIdentity(reqCol).isDefined && registry.dimMap.contains(registry.getDimColIdentity(reqCol).get.publcDimName, publicFact.dimRevision))
+            .map(reqCol => reqCol -> registry.dimMap(registry.getDimColIdentity(reqCol).get.publcDimName, publicFact.dimRevision))
+            .toMap
+
           val colsWithRestrictedSchema: IndexedSeq[String] = requestedAliasList.collect {
-            case reqCol if (publicFact.restrictedSchemasMap.contains(reqCol) && !publicFact.restrictedSchemasMap(reqCol)(request.schema)) => reqCol
+            case reqCol if (publicFact.restrictedSchemasMap.contains(reqCol)
+              && !publicFact.restrictedSchemasMap(reqCol)(request.schema))
+              => reqCol
+            case reqCol if (requestedDimAliasesToPublicDimMap.contains(reqCol)
+              && requestedDimAliasesToPublicDimMap(reqCol).restrictedSchemasMap.contains(reqCol)
+              && !requestedDimAliasesToPublicDimMap(reqCol).restrictedSchemasMap(reqCol)(request.schema)
+              )
+            => reqCol
           }
           require(colsWithRestrictedSchema.isEmpty, RestrictedSchemaError(colsWithRestrictedSchema, request.schema.entryName, publicFact.name))
 

--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -445,11 +445,11 @@ object RequestModel extends Logging {
             case reqCol if (publicFact.restrictedSchemasMap.contains(reqCol)
               && !publicFact.restrictedSchemasMap(reqCol)(request.schema))
               => reqCol
-            case reqCol if (requestedDimAliasesToPublicDimMap.contains(reqCol)
-              && requestedDimAliasesToPublicDimMap(reqCol).restrictedSchemasMap.contains(reqCol)
-              && !requestedDimAliasesToPublicDimMap(reqCol).restrictedSchemasMap(reqCol)(request.schema)
+            case dimReqCol if (requestedDimAliasesToPublicDimMap.contains(dimReqCol)
+              && requestedDimAliasesToPublicDimMap(dimReqCol).restrictedSchemasMap.contains(dimReqCol)
+              && !requestedDimAliasesToPublicDimMap(dimReqCol).restrictedSchemasMap(dimReqCol)(request.schema)
               )
-            => reqCol
+            => dimReqCol
           }
           require(colsWithRestrictedSchema.isEmpty, RestrictedSchemaError(colsWithRestrictedSchema, request.schema.entryName, publicFact.name))
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.279-SNAPSHOT</version>
+    <version>5.280-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.279-SNAPSHOT</version>
+        <version>5.280-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Currently, restricted-schema check is performed only on columns present in the public fact. This change will include columns from public dimensions referenced by foreign keys.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
