### PR TITLE
Fix maha resource, debug info

### DIFF
--- a/api-jersey/src/main/scala/com/yahoo/maha/api/jersey/MahaResource.scala
+++ b/api-jersey/src/main/scala/com/yahoo/maha/api/jersey/MahaResource.scala
@@ -167,7 +167,7 @@ class MahaResource(mahaService: MahaService, baseRequest: BaseRequest, requestVa
                                      , testName: String
                                      , labels: java.util.List[String]) : (ReportingRequest, Array[Byte]) = {
     val rawJson = IOUtils.toByteArray(httpServletRequest.getInputStream)
-    val reportingRequestResult = baseRequest.deserializeSync(rawJson, schema)
+    val reportingRequestResult = baseRequest.deserializeSyncWithFactBias(rawJson, schema)
     require(reportingRequestResult.isSuccess, reportingRequestResult.toString)
     val originalRequest = reportingRequestResult.toOption.get
     val request = {

--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -283,6 +283,7 @@ case class RequestModel(cube: String
        hasLowCardinalityDimFilters=$hasLowCardinalityDimFilters
        isFactDriven=$isFactDriven
        forceDimDriven=$forceDimDriven
+       forceFactDriven=$forceFactDriven
        schema=$schema
        utcTimeDayFilter=$utcTimeDayFilter
        localTimeDayFilter=$localTimeDayFilter

--- a/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownCurator.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownCurator.scala
@@ -321,15 +321,19 @@ class DrilldownCurator (override val requestModelValidator: CuratorRequestModelV
                           , mahaRequestContext
                         )
 
+                        if (mahaRequestContext.reportingRequest.isDebugEnabled) {
+                          logger.info(s"drilldown most granular field alias: ${fieldAlias}")
+                          logger.info(s"drilldown most granular field alias values : ${values}")
+                        }
                         val newRequestWithInsertedFilter = insertValuesIntoDrilldownRequest(newReportingRequest
                           , fieldAlias, values.toList)
-
-                        require(newRequestWithInsertedFilter.filterExpressions.nonEmpty || curatorConfig.asInstanceOf[DrilldownConfig].enforceFilters
-                          , "Request must apply filters or enforce ReportingRequest input filters!  Check enforceFilters parameter value.")
 
                         if (mahaRequestContext.reportingRequest.isDebugEnabled) {
                           logger.info(s"drilldown request : ${new String(ReportingRequest.serialize(newRequestWithInsertedFilter))}")
                         }
+
+                        require(newRequestWithInsertedFilter.filterExpressions.nonEmpty || curatorConfig.asInstanceOf[DrilldownConfig].enforceFilters
+                          , "Request must apply filters or enforce ReportingRequest input filters!  Check enforceFilters parameter value.")
 
                         val requestModelResultTry = mahaService.generateRequestModel(
                           mahaRequestContext.registryName, newRequestWithInsertedFilter, mahaRequestContext.bucketParams.copy(forceRevision = None))


### PR DESCRIPTION
Change maha resource to use fact bias deserialize, otherwise one of the force flags must be true or else the generator may not properly render all filters (e.g. when id fact filters are present, and both force flags are false, the query generator does not render all filters in where clause).

Add more debug info to drilldown curator and move require after printing of debug info.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
