### PR TITLE
Fix ogb row count

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryBuilder.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryBuilder.scala
@@ -143,6 +143,10 @@ class QueryBuilder(val initSize: Int, val orderBySize: Int) {
     whereClause
   }
 
+  def containsFactViewColumns(s: String): Boolean = {
+    factViewColumns.contains(s)
+  }
+
   def setWhereClause(whereClause: String) {
     this.whereClause = whereClause
   }

--- a/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresOuterGroupByQueryGenerator.scala
@@ -511,7 +511,7 @@ abstract class PostgresOuterGroupByQueryGenerator(partitionColumnRenderer:Partit
       }
 
       if (queryContext.requestModel.includeRowCount) {
-        queryBuilder.addOuterColumn(PostgresQueryGenerator.ROW_COUNT_ALIAS)
+        queryBuilder.addOuterColumn(s""""${PostgresQueryGenerator.ROW_COUNT_ALIAS}"""")
         aliasColumnMapOfRequestCols += (PostgresQueryGenerator.ROW_COUNT_ALIAS -> PAGINATION_ROW_COUNT_COL)
       }
 
@@ -614,6 +614,10 @@ abstract class PostgresOuterGroupByQueryGenerator(partitionColumnRenderer:Partit
           } else col.alias.getOrElse(col.name)
           renderPreOuterFactCol(qualifiedColInnerAlias, colInnerAlias, alias, col)
         case _=> // ignore as it col is already rendered
+      }
+
+      if(queryBuilder.containsFactViewColumns(PAGINATION_ROW_COUNT)) {
+        queryBuilder.addPreOuterColumn(PAGINATION_ROW_COUNT)
       }
 
       def renderPreOuterFactCol(qualifiedColInnerAlias: String, colInnerAlias: String, finalAlias: String, innerSelectCol: Column): Unit = {

--- a/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
@@ -774,7 +774,7 @@ b. Dim Driven
 
       if (queryContext.requestModel.includeRowCount && !queryContext.requestModel.hasFactSortBy) {
         if(dimensionSql.hasTotalRows) {
-          outerColumns += PostgresQueryGenerator.ROW_COUNT_ALIAS
+          outerColumns += s""""${PostgresQueryGenerator.ROW_COUNT_ALIAS}""""
         } else {
           outerColumns += PAGINATION_ROW_COUNT
         }


### PR DESCRIPTION
Fix outer group by postgresql generator bug when includeRowCount is true.  Outer select needs to quote TOTALROWS, the outer group by needs to include Count(*) OVER "TOTALROWS" so it can have the correct count after second grouping.

@pranavbhole You may want to check this for Oracle query generator.  I don't have an instance of oracle to play with.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
