### PR TITLE
Off Heap Row List

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -123,6 +123,10 @@
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>chill_${scala.major.version}</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-smile</artifactId>
         </dependency>

--- a/core/src/main/scala/com/yahoo/maha/core/query/OffHeapRowList.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/OffHeapRowList.scala
@@ -10,7 +10,6 @@ import com.yahoo.maha.rocksdb.{RocksDBAccessor, RocksDBAccessorBuilder}
 import com.yahoo.maha.serde.LongSerDe
 import grizzled.slf4j.Logging
 import org.apache.commons.io.{FileUtils, FilenameUtils}
-import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
@@ -23,8 +22,6 @@ case class OffHeapRowListConfig(tempStoragePathOption:Option[String], inMemRowCo
 case class OffHeapRowList(query: Query, config: OffHeapRowListConfig) extends QueryRowList with AutoCloseable with Logging {
 
   private[this] val tempStoragePath = OffHeapRowList.getAndValidateTempStorage(config.tempStoragePathOption)
-
-  private val logger = LoggerFactory.getLogger(classOf[OffHeapRowList])
 
   private[this] var rocksDBAccessorOption: Option[RocksDBAccessor[Long, Row]] = None
 
@@ -128,7 +125,7 @@ case class OffHeapRowList(query: Query, config: OffHeapRowListConfig) extends Qu
     }
 
     if (!listAttempt.isSuccess) {
-      logger.warn("Failed to get total row count.\n" + listAttempt)
+      warn("Failed to get total row count.\n" + listAttempt)
     }
 
     total_count

--- a/core/src/main/scala/com/yahoo/maha/core/query/OffHeapRowList.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/OffHeapRowList.scala
@@ -1,0 +1,189 @@
+package com.yahoo.maha.core.query
+
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+import com.yahoo.maha.core.query.QueryRowList.ROW_COUNT_ALIAS
+import com.yahoo.maha.core.request.Parameter.RequestId
+import com.yahoo.maha.rocksdb.{RocksDBAccessor, RocksDBAccessorBuilder}
+import com.yahoo.maha.serde.LongSerDe
+import grizzled.slf4j.Logging
+import org.apache.commons.io.{FileUtils, FilenameUtils}
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
+
+/*
+    Created by pranavbhole on 2/3/20
+*/
+case class OffHeapRowListConfig(tempStoragePathOption:Option[String], inMemRowCountThreshold: Int = 10000)
+
+case class OffHeapRowList(query: Query, config: OffHeapRowListConfig) extends QueryRowList with AutoCloseable {
+
+  private[this] val tempStoragePath = OffHeapRowList.getAndValidateTempStorage(config.tempStoragePathOption)
+
+  private val logger = LoggerFactory.getLogger(classOf[OffHeapRowList])
+
+  private[this] var rocksDBAccessorOption: Option[RocksDBAccessor[Long, Row]] = None
+
+  private[this] val atomicLongRowCount = new AtomicLong(-1)
+
+  protected[this] val list: collection.mutable.ArrayBuffer[Row] = {
+    if(query.queryContext.requestModel.maxRows > 0) {
+      new ArrayBuffer[Row](query.queryContext.requestModel.maxRows + 10)
+    } else {
+      collection.mutable.ArrayBuffer.empty[Row]
+    }
+  }
+
+  def addRow(r: Row, er: Option[Row] = None) : Unit = {
+    postResultRowOperation(r, er)
+    if (atomicLongRowCount.get() >= config.inMemRowCountThreshold - 1) {
+      persist(r)
+    } else {
+      list+=r
+      atomicLongRowCount.incrementAndGet()
+    }
+  }
+
+  private[this] def persist(row:Row): Unit =  {
+    if(rocksDBAccessorOption.isEmpty) {
+      rocksDBAccessorOption = Some(OffHeapRowList.initRocksDB(tempStoragePath, query))
+    }
+    rocksDBAccessorOption.get.put(atomicLongRowCount.incrementAndGet(), row)
+  }
+
+  private[this] def rocksDBGet(index:Long): Row = {
+    require(index <= atomicLongRowCount.get(), s"Failed to get the index ${index} from rocksdb")
+    require(rocksDBAccessorOption.isDefined, "Invalid get call, RocksDB is yet not initialized")
+    val rowOption = rocksDBAccessorOption.get.get(index)
+    require(rowOption.isDefined, s"Failed to get row at index ${index} from rocksDB")
+    rowOption.get
+  }
+
+  def isEmpty : Boolean = {
+    if (atomicLongRowCount.get() < 0) {
+      true
+    } else false
+  }
+
+  override protected def kill(): Unit = {
+    if(rocksDBAccessorOption.isDefined) {
+      Try {
+        rocksDBAccessorOption.get.destroy()
+        rocksDBAccessorOption = None
+        atomicLongRowCount.set(-1)
+        list.clear()
+      }
+    }
+  }
+
+  def foreach(fn: Row => Unit) : Unit = {
+    list.foreach(fn)
+    Range.Long.inclusive(config.inMemRowCountThreshold, atomicLongRowCount.get, 1).foreach {
+      rc =>
+        fn(rocksDBGet(rc))
+    }
+  }
+
+  def forall(fn: Row => Boolean) : Boolean = {
+    list.forall(fn) && Range.Long.inclusive(config.inMemRowCountThreshold, atomicLongRowCount.get, 1).forall {
+      rc =>
+        fn(rocksDBGet(rc))
+    }
+  }
+
+  def map[T](fn: Row => T) : Iterable[T] = {
+    list.map(fn) ++ Range.Long.inclusive(config.inMemRowCountThreshold, atomicLongRowCount.get, 1).map {
+      rc =>
+        fn(rocksDBGet(rc))
+    }
+  }
+
+  def size: Int = {
+    if(atomicLongRowCount.get() < 0) {
+      0
+    } else atomicLongRowCount.intValue() + 1
+  }
+
+  //def javaForeach(fn: ParCallable)
+  override def getTotalRowCount: Int = {
+    var total_count = 0
+    val listAttempt = Try {
+      val firstRow = if (config.inMemRowCountThreshold > 0) {
+        list.head
+      } else {
+        rocksDBAccessorOption.get.get(0).get
+      }
+      require(firstRow.aliasMap.contains(ROW_COUNT_ALIAS), "TOTALROWS not defined in alias map")
+      val totalrow_col_num = firstRow.aliasMap(ROW_COUNT_ALIAS)
+      val current_totalrows = firstRow.cols(totalrow_col_num).toString.toInt
+      total_count = current_totalrows
+    }
+
+    if (!listAttempt.isSuccess) {
+      logger.warn("Failed to get total row count.\n" + listAttempt)
+    }
+
+    total_count
+  }
+
+  override def length : Int = {
+    atomicLongRowCount.intValue() + 1
+  }
+
+  override def close(): Unit = {
+    kill()
+  }
+
+  def isPersistentStoreInitialized(): Boolean = {
+    rocksDBAccessorOption.isDefined
+  }
+
+  def sizeOfInMemStore(): Int = {
+    list.size
+  }
+
+}
+
+object OffHeapRowList extends Logging {
+  final val MAHA_OFF_HEAP_STORAGE_PATH ="MAHA_OFF_HEAP_STORAGE_PATH"
+  final val DIRNAME = "off_heap_row_list"
+
+  def getAndValidateTempStorage(tempStoragePathOption:Option[String]): String = {
+    val tempStoragePath = if (tempStoragePathOption.isDefined) {
+      tempStoragePathOption.get
+    } else {
+      System.getenv(OffHeapRowList.MAHA_OFF_HEAP_STORAGE_PATH)
+    }
+
+    val file = FileUtils.getFile(tempStoragePath)
+
+    require(file.exists(), s"Failed to find the temp storage location $tempStoragePath")
+    require(file.isDirectory, s"Temp storage location should be directory")
+    val newFile = new File(tempStoragePath, DIRNAME)
+    if (!newFile.exists()) {
+      newFile.mkdirs()
+      info(s"Created tmp dir to store off heap row list ${newFile.getAbsolutePath}")
+    }
+    require(newFile.exists(), s"Failed to make temp directory to store off heap row list ${newFile.getAbsolutePath}")
+    newFile.getAbsolutePath
+  }
+
+  def initRocksDB(tempStoragePath:String, query: Query): RocksDBAccessor[Long, Row] = {
+    val params = query.queryContext.requestModel.additionalParameters
+    val uuid = if(params.contains(RequestId)) {
+      params.get(RequestId)
+    } else {
+      UUID.randomUUID().toString
+    }
+
+    new RocksDBAccessorBuilder(s"off-heap-rowlist-${uuid}", Some(tempStoragePath))
+      .addKeySerDe(LongSerDe)
+      .addValSerDe(RowSerDe)
+      .toRocksDBAccessor
+  }
+
+}

--- a/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
@@ -2,9 +2,11 @@
 // Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
 package com.yahoo.maha.core.query
 
+import com.twitter.chill.ScalaKryoInstantiator
 import com.yahoo.maha.core._
 import com.yahoo.maha.parrequest2.future.ParFunction
 import com.yahoo.maha.report.{RowCSVWriter, RowCSVWriterProvider}
+import com.yahoo.maha.serde.SerDe
 import org.json4s.JValue
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -74,6 +76,7 @@ sealed trait RowListLifeCycle {
   protected def start() : Unit
   def nextStage(): Unit = {}
   protected def end() : Unit
+  protected def kill(): Unit
 
   def withLifeCycle[T](fn: => T) : T = {
     start()
@@ -113,6 +116,10 @@ trait RowList extends RowListLifeCycle {
   protected def end() : Unit = {
     //do nothing
   }
+  protected def kill() : Unit = {
+    //do nothing
+  }
+
 }
 
 object QueryRowList {
@@ -219,7 +226,7 @@ trait InMemRowList extends QueryRowList {
       total_count = current_totalrows
     }
 
-    if(!listAttempt.isSuccess){
+    if (!listAttempt.isSuccess) {
       logger.warn("Failed to get total row count.\n" + listAttempt)
     }
 
@@ -834,6 +841,16 @@ case class PostResultRowData(r: Row, er: Option[Row] = None, columnAlias: String
     } else {
       None
     }
+  }
+}
+
+object RowSerDe extends SerDe[Row] {
+  override def serialize(t: Row): Array[Byte] = {
+    ScalaKryoInstantiator.defaultPool.toBytesWithClass(t)
+  }
+
+  override def deserialize(bytes: Array[Byte]): Row = {
+    ScalaKryoInstantiator.defaultPool.fromBytes(bytes).asInstanceOf[Row]
   }
 }
 

--- a/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
@@ -844,13 +844,4 @@ case class PostResultRowData(r: Row, er: Option[Row] = None, columnAlias: String
   }
 }
 
-object RowSerDe extends SerDe[Row] {
-  override def serialize(t: Row): Array[Byte] = {
-    ScalaKryoInstantiator.defaultPool.toBytesWithClass(t)
-  }
-
-  override def deserialize(bytes: Array[Byte]): Row = {
-    ScalaKryoInstantiator.defaultPool.fromBytes(bytes).asInstanceOf[Row]
-  }
-}
 

--- a/core/src/test/scala/com/yahoo/maha/core/DerivedExpressionTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/DerivedExpressionTest.scala
@@ -628,7 +628,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create Postgres NVL and parse parameters") {
     import PostgresExpression._
-    implicit val cc = new ColumnContext
     val nvlVal = NVL("{col_name}", "{default_str}")
     assert(!nvlVal.hasRollupExpression)
     assert(!nvlVal.hasNumericOperation)
@@ -637,7 +636,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create hive NVL and parse parameters") {
     import HiveExpression._
-    implicit val cc = new ColumnContext
     val nvlVal = NVL("{col_name}", "{default_str}")
     assert(!nvlVal.hasRollupExpression)
     assert(!nvlVal.hasNumericOperation)
@@ -646,7 +644,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create presto NVL and parse parameters") {
     import PrestoExpression._
-    implicit val cc = new ColumnContext
     val nvlVal = NVL("{col_name}", "{default_str}")
     assert(!nvlVal.hasRollupExpression)
     assert(!nvlVal.hasNumericOperation)
@@ -655,7 +652,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create oracle TRUNC and parse parameters") {
     import OracleExpression._
-    implicit val cc = new ColumnContext
     val truncVal = TRUNC("{col_name}")
     assert(!truncVal.hasRollupExpression)
     assert(!truncVal.hasNumericOperation)
@@ -664,7 +660,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create Postgres TRUNC and parse parameters") {
     import PostgresExpression._
-    implicit val cc = new ColumnContext
     val truncVal = TRUNC("{col_name}")
     assert(!truncVal.hasRollupExpression)
     assert(!truncVal.hasNumericOperation)
@@ -673,7 +668,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create oracle COALESCE and parse parameters") {
     import OracleExpression._
-    implicit val cc = new ColumnContext
     val coalesceVal = COALESCE("{col_name}", "''")
     assert(!coalesceVal.hasRollupExpression)
     assert(!coalesceVal.hasNumericOperation)
@@ -682,7 +676,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create Postgres COALESCE and parse parameters") {
     import PostgresExpression._
-    implicit val cc = new ColumnContext
     val coalesceVal = COALESCE("{col_name}", "''")
     assert(!coalesceVal.hasRollupExpression)
     assert(!coalesceVal.hasNumericOperation)
@@ -691,7 +684,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create hive COALESCE and parse parameters") {
     import HiveExpression._
-    implicit val cc = new ColumnContext
     val coalesceVal = COALESCE("{col_name}", "''")
     assert(!coalesceVal.hasRollupExpression)
     assert(!coalesceVal.hasNumericOperation)
@@ -700,7 +692,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create presto COALESCE and parse parameters") {
     import PrestoExpression._
-    implicit val cc = new ColumnContext
     val coalesceVal = COALESCE("{col_name}", "''")
     assert(!coalesceVal.hasRollupExpression)
     assert(!coalesceVal.hasNumericOperation)
@@ -709,7 +700,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create oracle TO_CHAR and parse parameters") {
     import OracleExpression._
-    implicit val cc = new ColumnContext
     val tocharVal = TO_CHAR("{col_name}", "''")
     assert(!tocharVal.hasRollupExpression)
     assert(!tocharVal.hasNumericOperation)
@@ -718,7 +708,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create Postgres TO_CHAR and parse parameters") {
     import PostgresExpression._
-    implicit val cc = new ColumnContext
     val tocharVal = TO_CHAR("{col_name}", "''")
     assert(!tocharVal.hasRollupExpression)
     assert(!tocharVal.hasNumericOperation)
@@ -727,7 +716,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create oracle ROUND and parse parameters") {
     import OracleExpression._
-    implicit val cc = new ColumnContext
     val roundVal = ROUND("{col_name}", 1)
     assert(!roundVal.hasRollupExpression)
     assert(!roundVal.hasNumericOperation)
@@ -736,7 +724,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create Postgres ROUND and parse parameters") {
     import PostgresExpression._
-    implicit val cc = new ColumnContext
     val roundVal = ROUND("{col_name}", 1)
     assert(!roundVal.hasRollupExpression)
     assert(!roundVal.hasNumericOperation)
@@ -745,7 +732,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create hive ROUND and parse parameters") {
     import HiveExpression._
-    implicit val cc = new ColumnContext
     val roundVal = ROUND("{col_name}", 1)
     assert(!roundVal.hasRollupExpression)
     assert(!roundVal.hasNumericOperation)
@@ -754,7 +740,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create presto ROUND and parse parameters") {
     import PrestoExpression._
-    implicit val cc = new ColumnContext
     val roundVal = ROUND("{col_name}", 1)
     assert(!roundVal.hasRollupExpression)
     assert(!roundVal.hasNumericOperation)
@@ -763,7 +748,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create presto TRIM and parse parameters") {
     import PrestoExpression._
-    implicit val cc = new ColumnContext
     val roundVal = TRIM("{col_name}")
     assert(!roundVal.hasRollupExpression)
     assert(!roundVal.hasNumericOperation)
@@ -772,7 +756,6 @@ class DerivedExpressionTest extends FunSuite with Matchers {
 
   test("Create presto MAX and parse parameters") {
     import PrestoExpression._
-    implicit val cc = new ColumnContext
     val roundVal = MAX("{col_name}")
     assert(roundVal.hasRollupExpression)
     assert(roundVal.hasNumericOperation)

--- a/core/src/test/scala/com/yahoo/maha/core/dimension/DimensionTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/dimension/DimensionTest.scala
@@ -614,7 +614,7 @@ class DimensionTest extends FunSuite with Matchers {
   test("construct public dim should fail if dim map is empty") {
     val thrown = intercept[IllegalArgumentException] {
       ColumnContext.withColumnContext { implicit cc =>
-        new PublicDim("pd","pd", null,
+        PublicDim("pd","pd", null,
           Set(
             PubCol("id", "PublicDim ID", InEquality)
           ), Map.empty, Set.empty, Set.empty)

--- a/core/src/test/scala/com/yahoo/maha/core/query/BaseRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/BaseRowListTest.scala
@@ -2,9 +2,13 @@
 // Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
 package com.yahoo.maha.core.query
 
+import com.yahoo.maha.core.RequestModel
+import com.yahoo.maha.core.query.oracle.BaseOracleQueryGeneratorTest
+import com.yahoo.maha.core.request.ReportingRequest
+
 /**
  * Created by hiral on 1/25/16.
  */
-trait BaseRowListTest extends BaseQueryGeneratorTest {
+trait BaseRowListTest extends BaseOracleQueryGeneratorTest {
 
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/OffHeapRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/OffHeapRowListTest.scala
@@ -159,6 +159,8 @@ class OffHeapRowListTest extends BaseRowListTest  {
     genericRowListFunctionalVerification(rowList)
     assert(rowList.isPersistentStoreInitialized() == false)
     assert(rowList.sizeOfInMemStore() == 100)
+    assert(rowList.sizeOfRocksDB() == 0 )
+
     rowList.close()
   }
 
@@ -168,6 +170,7 @@ class OffHeapRowListTest extends BaseRowListTest  {
     genericRowListFunctionalVerification(rowList)
     assert(rowList.isPersistentStoreInitialized() == true)
     assert(rowList.sizeOfInMemStore() == 10)
+    assert(rowList.sizeOfRocksDB() == 90)
     rowList.close()
   }
 
@@ -176,6 +179,7 @@ class OffHeapRowListTest extends BaseRowListTest  {
     genericRowListFunctionalVerification(rowList)
     assert(rowList.isPersistentStoreInitialized() == true)
     assert(rowList.sizeOfInMemStore() == 0)
+    assert(rowList.sizeOfRocksDB() == 100)
     rowList.close()
   }
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/OffHeapRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/OffHeapRowListTest.scala
@@ -1,0 +1,182 @@
+package com.yahoo.maha.core.query
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.yahoo.maha.core.RequestModel
+import com.yahoo.maha.core.request.ReportingRequest
+import com.yahoo.maha.parrequest2.future.ParFunction
+
+/*
+    Created by pranavbhole on 2/4/20
+*/
+class OffHeapRowListTest extends BaseRowListTest  {
+
+  def query : Query = {
+    val jsonString = s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                            {"field": "Campaign ID"},
+                            {"field": "Impressions"},
+                            {"field": "Campaign Name"},
+                            {"field": "Campaign Status"},
+                            {"field": "CTR"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "213"},
+                            {"field": "Campaign Name", "operator": "=", "value": "MegaCampaign"}
+                          ],
+                          "sortBy": [
+                            {"field": "Campaign Name", "order": "Asc"}
+                          ],
+                          "paginationStartIndex":-1,
+                          "rowsPerPage":100
+                        }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = RequestModel.from(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery]
+  }
+
+  def queryWithAlias : Query = {
+    val jsonString = s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                            {"field": "Campaign ID", "alias":"CampaignID"},
+                            {"field": "Impressions", "alias":"Impressions"},
+                            {"field": "Campaign Name", "alias":"CampaignName"},
+                            {"field": "Campaign Status", "alias":"CampaignStatus"},
+                            {"field": "CTR", "alias":"CTR"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "213"},
+                            {"field": "Campaign Name", "operator": "=", "value": "MegaCampaign"}
+                          ],
+                          "sortBy": [
+                            {"field": "Campaign Name", "order": "Asc"}
+                          ],
+                          "paginationStartIndex":-1,
+                          "rowsPerPage":100
+                        }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = RequestModel.from(request, registry)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery]
+  }
+
+
+  def createRows(rowList: OffHeapRowList): Unit = {
+    Range.apply(100, 200).foreach {
+      index =>
+        val row = rowList.newRow
+        row.addValue("Campaign ID", java.lang.Integer.valueOf(index))
+        row.addValue("Impressions", java.lang.Integer.valueOf(2))
+        row.addValue("Campaign Name", "\"name\"")
+        row.addValue("Campaign Status", "o,n\n")
+        row.addValue("CTR", java.lang.Double.valueOf(1.11D))
+        row.addValue("TOTALROWS", java.lang.Integer.valueOf(100))
+
+        rowList.addRow(row)
+    }
+  }
+
+  def verifyRowList(verifyFn: (AtomicInteger) => Unit): Unit = {
+    val rowCount = new AtomicInteger(0)
+    verifyFn(rowCount)
+    assert(rowCount.get() == 100)
+  }
+
+  def verifyRow(row:Row, rowCount: AtomicInteger): Boolean = {
+    val value = row.getValue("Campaign ID")
+    assert(value == rowCount.get()+100, "Order of the rows in the row list is not correct")
+    assert(row.getValue("Impressions") == 2, "Inconsistent value for Impressions in row")
+    rowCount.incrementAndGet()
+    row.getValue("TOTALROWS") == 100
+  }
+
+  def genericRowListFunctionalVerification(rowList: OffHeapRowList): Unit = {
+    rowList.withLifeCycle {
+      createRows(rowList)
+    }
+
+    assert(rowList.size == 100, "Inconsistent size in rowList")
+
+    assert(rowList.getTotalRowCount == 100, "Inconsistent total row count in rowList")
+
+    verifyRowList {
+      rowCount =>
+        rowList.foreach(row => verifyRow(row, rowCount))
+    }
+
+    verifyRowList {
+      rowCount=>
+        rowList.forall(row=> {
+          verifyRow(row, rowCount)
+        })
+    }
+
+    verifyRowList {
+      rowCount=>
+        rowList.map(row=> {
+          verifyRow(row, rowCount)
+        })
+    }
+
+    verifyRowList {
+      rowCount=>
+        rowList.javaForeach(ParFunction.from(row=> {
+          verifyRow(row, rowCount)
+        }))
+    }
+
+    verifyRowList {
+      rowCount=>
+        rowList.javaMap(ParFunction.from(row=> {
+          verifyRow(row, rowCount)
+        }))
+    }
+
+  }
+
+  test("Off Heap RowList test, cold start") {
+    val rowList = OffHeapRowList(query, OffHeapRowListConfig(Some("target/"), inMemRowCountThreshold = 200))
+    genericRowListFunctionalVerification(rowList)
+    assert(rowList.isPersistentStoreInitialized() == false)
+    assert(rowList.sizeOfInMemStore() == 100)
+    rowList.close()
+  }
+
+
+  test("Off Heap RowList test, warm start, init rocksdb") {
+    val rowList = OffHeapRowList(query, OffHeapRowListConfig(Some("target/"), inMemRowCountThreshold = 10))
+    genericRowListFunctionalVerification(rowList)
+    assert(rowList.isPersistentStoreInitialized() == true)
+    assert(rowList.sizeOfInMemStore() == 10)
+    rowList.close()
+  }
+
+  test("Off Heap RowList test, warm start, init rocksdb, store all in rocksdb") {
+    val rowList = OffHeapRowList(query, OffHeapRowListConfig(Some("target/"), inMemRowCountThreshold = 0))
+    genericRowListFunctionalVerification(rowList)
+    assert(rowList.isPersistentStoreInitialized() == true)
+    assert(rowList.sizeOfInMemStore() == 0)
+    rowList.close()
+  }
+
+}

--- a/core/src/test/scala/com/yahoo/maha/core/query/oracle/BaseOracleQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/oracle/BaseOracleQueryGeneratorTest.scala
@@ -12,13 +12,15 @@ import com.yahoo.maha.core.query.druid.{DruidQueryGenerator, SyncDruidQueryOptim
 import com.yahoo.maha.core.query.{BaseQueryGeneratorTest, SharedDimSchema}
 import com.yahoo.maha.core.registry.RegistryBuilder
 import com.yahoo.maha.core.request.AsyncRequest
-import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Created by hiral on 1/15/16.
  */
 trait BaseOracleQueryGeneratorTest
-  extends FunSuite with Matchers with BeforeAndAfterAll with BaseQueryGeneratorTest with SharedDimSchema {
+  extends AnyFunSuite with Matchers with BeforeAndAfterAll with BaseQueryGeneratorTest with SharedDimSchema {
 
   override protected def beforeAll(): Unit = {
     OracleQueryGenerator.register(queryGeneratorRegistry,DefaultPartitionColumnRenderer)

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/db/src/main/scala/com/yahoo/maha/rocksdb/RocksDBAccessor.scala
+++ b/db/src/main/scala/com/yahoo/maha/rocksdb/RocksDBAccessor.scala
@@ -15,6 +15,7 @@ import scala.collection.mutable
 import scala.util.Try
 
 object RocksDBAccessor extends Logging {
+  val _1MB: Int = 1024 * 1024
   val instanceId = new AtomicInteger(0)
   val prefix = "rocksdb_"
   def incrementAndGetId() : Int = instanceId.incrementAndGet()
@@ -162,8 +163,8 @@ thus leaving it public to invoke it as per the implementation
 }
 
 class RocksDBAccessorBuilder[K, V](val dbName: String, val baseDirOption: Option[String] = None, val timeToLive: Option[Int] = None) {
+  import RocksDBAccessor._1MB
 
-  private val _1MB: Int = 1024 * 1024
   var blockSize: Int = _1MB
   var cacheSize: Int = 500 * _1MB
   var maxOpenFiles: Int = 1000
@@ -172,6 +173,7 @@ class RocksDBAccessorBuilder[K, V](val dbName: String, val baseDirOption: Option
   var keySerDe: SerDe[K] = null
   var valSerDe: SerDe[V] = null
   val baseDir = baseDirOption.getOrElse("/home/y/tmp")
+  var compressionType:CompressionType = CompressionType.LZ4HC_COMPRESSION
 
   def addBlockSize(blockSize: Int) = {
     this.blockSize = blockSize
@@ -205,6 +207,11 @@ class RocksDBAccessorBuilder[K, V](val dbName: String, val baseDirOption: Option
 
   def setCreateIfMissing(createIfMissing: Boolean) = {
     this.createIfMissing = createIfMissing
+    this
+  }
+
+  def setCompressionType(compressionType: CompressionType) = {
+    this.compressionType  = compressionType
     this
   }
 

--- a/db/src/main/scala/com/yahoo/maha/rocksdb/RocksDBAccessor.scala
+++ b/db/src/main/scala/com/yahoo/maha/rocksdb/RocksDBAccessor.scala
@@ -52,7 +52,7 @@ class RocksDBAccessor[K, V](builder: RocksDBAccessorBuilder[K, V]) extends Loggi
     options.setMaxOpenFiles(builder.maxOpenFiles)
     options.setWriteBufferSize(builder.writeBufferSize)
     options.setCreateIfMissing(builder.createIfMissing)
-    options.setCompressionType(CompressionType.LZ4HC_COMPRESSION)
+    options.setCompressionType(builder.compressionType)
     options.setParanoidChecks(true)
     options.optimizeForPointLookup(builder.cacheSize)
     options.setMemTableConfig(new HashSkipListMemTableConfig)

--- a/db/src/main/scala/com/yahoo/maha/serde/SerDe.scala
+++ b/db/src/main/scala/com/yahoo/maha/serde/SerDe.scala
@@ -3,6 +3,7 @@
 package com.yahoo.maha.serde
 
 import java.nio.charset.StandardCharsets
+import com.google.common.primitives.Longs
 
 trait SerDe[T] {
   def serialize(t: T): Array[Byte]
@@ -33,3 +34,14 @@ object BytesSerDe extends SerDe[Array[Byte]] {
     bytes
   }
 }
+
+object LongSerDe extends SerDe[Long] {
+  override def serialize(t: Long): Array[Byte] = {
+    Longs.toByteArray(t)
+  }
+
+  override def deserialize(bytes: Array[Byte]): Long = {
+    Longs.fromByteArray(bytes)
+  }
+}
+

--- a/db/src/test/scala/com/yahoo/maha/rocksdb/RocksDBAccessorTest.scala
+++ b/db/src/test/scala/com/yahoo/maha/rocksdb/RocksDBAccessorTest.scala
@@ -4,7 +4,7 @@ package com.yahoo.maha.rocksdb
 
 import java.util.concurrent.TimeUnit
 
-import com.yahoo.maha.serde.StringSerDe
+import com.yahoo.maha.serde.{LongSerDe, StringSerDe}
 import org.junit.Assert._
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 
@@ -114,5 +114,10 @@ class RocksDBAccessorTest extends FunSuite with Matchers with BeforeAndAfterAll 
     list.foreach {
       f => assertFalse(f.getAbsolutePath, f.exists())
     }
+  }
+
+  test("Long Serde Test") {
+    val longBytes = LongSerDe.serialize(1234567890L)
+    assert(LongSerDe.deserialize(longBytes) == 1234567890L)
   }
 }

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.335-SNAPSHOT</version>
+    <version>5.336-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <curator.version>4.0.1</curator.version>
         <akka.version>2.5.27</akka.version>
         <mongo-java-driver.version>3.3.0</mongo-java-driver.version>
+        <twitter.chill.version>0.9.2</twitter.chill.version>
     </properties>
 
 
@@ -145,6 +146,11 @@
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
                 <version>${jodatime.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.twitter</groupId>
+                <artifactId>chill_${scala.major.version}</artifactId>
+                <version>${twitter.chill.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.beachape</groupId>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.335-SNAPSHOT</version>
+        <version>5.336-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Problem: Async Request Executors can generate large data and may trigger huge gc clean up. We are currently storing all rows in memory. 

Off heap row list : To overcome this, writing a OffHeapRowList which will store first N (inMemRowCountThreshold) rows in memory and after that it stores into rocksdb instance. User of the rowlist will be completely agonistic about where the data is stored, and all iterator functions on the rowlist works as expected. Added kill phase in the rowlist lifecycle which will take care of cleaning up rocksdb instance. 

To use this feature, you need to pass additional OffHeapRowListConfig in QueryPipelineContext while instantiating QueryPipelineFactory.

Please review and merge.  @patelh @pavanab4u @panditsurabhi 

Thank you 
 


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
