### PR TITLE
Add ability to get source primitives for all expressions

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/DerivedExpression.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/DerivedExpression.scala
@@ -862,13 +862,14 @@ trait DerivedExpression[T] {
   def getPrimitiveCols(colNames: Set[String]): Set[String] = {
     val cols: Set[Column] = colNames.map(name => columnContext.getColumnByName(name)).filter(col => col.isDefined).map(col => col.get)
     cols.flatMap(col => {
-      if(col.isDerivedColumn) {
-        col.asInstanceOf[DerivedColumn].derivedExpression.sourcePrimitiveColumns
-      } else if(col.isInstanceOf[FactCol] && col.asInstanceOf[FactCol].hasRollupWithEngineRequirement) {
-        val colNameSet = col.asInstanceOf[FactCol].rollupExpression.sourceColumns
-        getPrimitiveCols(colNameSet)
-      } else {
-        Set(col.alias.getOrElse(col.name))
+      col match {
+        case col1: DerivedColumn =>
+          col1.derivedExpression.sourcePrimitiveColumns
+        case col1: FactCol if col1.hasRollupWithEngineRequirement =>
+          val colNameSet = col1.rollupExpression.sourceColumns
+          getPrimitiveCols(colNameSet)
+        case _ =>
+          Set(col.alias.getOrElse(col.name))
       }
     })
   }

--- a/core/src/main/scala/com/yahoo/maha/core/DerivedExpression.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/DerivedExpression.scala
@@ -862,13 +862,13 @@ trait DerivedExpression[T] {
   def getPrimitiveCols(colNames: Set[String]): Set[String] = {
     val cols: Set[Column] = colNames.map(name => columnContext.getColumnByName(name)).filter(col => col.isDefined).map(col => col.get)
     cols.flatMap(col => {
-      if((!col.isDerivedColumn && !col.isInstanceOf[FactCol]) || (col.isInstanceOf[FactCol] && !col.asInstanceOf[FactCol].hasRollupWithEngineRequirement)) {
-        Set(col.alias.getOrElse(col.name))
-      } else if(col.isDerivedColumn) {
+      if(col.isDerivedColumn) {
         col.asInstanceOf[DerivedColumn].derivedExpression.sourcePrimitiveColumns
-      } else {
+      } else if(col.isInstanceOf[FactCol] && col.asInstanceOf[FactCol].hasRollupWithEngineRequirement) {
         val colNameSet = col.asInstanceOf[FactCol].rollupExpression.sourceColumns
         getPrimitiveCols(colNameSet)
+      } else {
+        Set(col.alias.getOrElse(col.name))
       }
     })
   }

--- a/core/src/main/scala/com/yahoo/maha/core/DerivedExpression.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/DerivedExpression.scala
@@ -849,6 +849,17 @@ trait DerivedExpression[T] {
     columnRegex.findAllIn(expression.asString).map(_.substring(1).replace("}","")).toSet
   }
 
+  lazy val sourceRealColumns: Set[String] = {
+    val cols = sourceColumns.map(colName => columnContext.getColumnByName(colName)).filter(entry => entry.isDefined).map(entry => entry.get)
+    cols.flatMap(col => {
+      if (col.isDerivedColumn) {
+        col.asInstanceOf[DerivedColumn].derivedExpression.sourceRealColumns
+      } else {
+        Set(col.alias.getOrElse(col.name))
+      }
+    })
+  }
+
   lazy val isDimensionDriven : Boolean = {
     sourceColumns.exists {
       sc =>

--- a/core/src/main/scala/com/yahoo/maha/core/fact/RollupExpression.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/fact/RollupExpression.scala
@@ -25,23 +25,23 @@ sealed trait CustomRollup extends RollupExpression
  */
 case class HiveCustomRollup(expression: HiveDerivedExpression) extends CustomRollup with WithHiveEngine {
   override val hasDerivedExpression: Boolean = true
-  override lazy val sourceColumns: Set[String] = expression.sourceRealColumns
+  override lazy val sourceColumns: Set[String] = expression.sourcePrimitiveColumns
 }
 case class PrestoCustomRollup(expression: PrestoDerivedExpression) extends CustomRollup with WithPrestoEngine {
   override val hasDerivedExpression: Boolean = true
-  override lazy val sourceColumns: Set[String] = expression.sourceRealColumns
+  override lazy val sourceColumns: Set[String] = expression.sourcePrimitiveColumns
 }
 case class OracleCustomRollup(expression: OracleDerivedExpression) extends CustomRollup with WithOracleEngine {
   override val hasDerivedExpression: Boolean = true
-  override lazy val sourceColumns: Set[String] = expression.sourceRealColumns
+  override lazy val sourceColumns: Set[String] = expression.sourcePrimitiveColumns
 }
 case class PostgresCustomRollup(expression: PostgresDerivedExpression) extends CustomRollup with WithPostgresEngine {
   override val hasDerivedExpression: Boolean = true
-  override lazy val sourceColumns: Set[String] = expression.sourceRealColumns
+  override lazy val sourceColumns: Set[String] = expression.sourcePrimitiveColumns
 }
 case class DruidCustomRollup(expression: DruidDerivedExpression) extends CustomRollup with WithDruidEngine {
   override val hasDerivedExpression: Boolean = true
-  override lazy val sourceColumns: Set[String] = expression.sourceRealColumns
+  override lazy val sourceColumns: Set[String] = expression.sourcePrimitiveColumns
 }
 case class DruidFilteredRollup(filter: Filter, factCol: DruidExpression.FieldAccess,
                                delegateAggregatorRollupExpression: RollupExpression) extends CustomRollup with WithDruidEngine {

--- a/core/src/test/scala/com/yahoo/maha/core/DerivedExpressionTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/DerivedExpressionTest.scala
@@ -134,8 +134,8 @@ class DerivedExpressionTest extends FunSuite with Matchers {
       assert(anotherCol.derivedExpression.sourceColumns.contains("clicks") && anotherCol.derivedExpression.sourceColumns.contains("BLAH"))
       assert(anotherCol.derivedExpression.sourceRealColumns.contains("clicks") && anotherCol.derivedExpression.sourceRealColumns.contains("impressions"))
 
-      val p = anotherCol2.rollupExpression.sourceColumns
-      val q: Set[String] = anotherCol2.rollupExpression.sourceColumns.map(colName => {
+      val sourceCols = anotherCol2.rollupExpression.sourceColumns
+      val realSources2: Set[String] = anotherCol2.rollupExpression.sourceColumns.map(colName => {
         val col = anotherCol2.columnContext.getColumnByName(colName)
         if (!col.isDefined) {
           Set.empty
@@ -146,7 +146,8 @@ class DerivedExpressionTest extends FunSuite with Matchers {
         }
       }).flatten
 
-      assert(true)
+      assert(sourceCols.contains("newCol") && sourceCols.contains("fakeDim"))
+      assert(realSources2.contains("clicks") && realSources2.contains("impressions") && realSources2.contains("account_id"))
 
     }
   }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


Currently, for a given column the process for finding all source column primitives is not built in, and often unsupported (rollups).  This handles that by giving derived expressions syntax for source primitives, and adding a method to find primitives in a rollup's ColumnContext (expressed in test).