### PR TITLE
Optimize Druid JDBC lookup with secondary ts column

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/namespace/JDBCExtractionNamespace.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/namespace/JDBCExtractionNamespace.java
@@ -149,6 +149,9 @@ public class JDBCExtractionNamespace implements OnlineDatastoreExtractionNamespa
         return tsColumnConfig != null;
     }
 
+    public boolean hasSecondaryTsColumn() {
+        return this.hasTsColumnConfig() && this.getTsColumnConfig().hasSecondaryTsColumn();
+    }
 
     public boolean isFirstTimeCaching() {
         return firstTimeCaching;

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/namespace/TsColumnConfig.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/namespace/TsColumnConfig.java
@@ -21,6 +21,16 @@ public class TsColumnConfig {
     @JsonProperty
     private String secondaryTsColumnCondition;
 
+    public TsColumnConfig(){}
+
+    public TsColumnConfig(String name, String type, String format, String secondaryTsColumn, String secondaryTsColumnCondition) {
+        this.name = name;
+        this.type = type;
+        this.format = format;
+        this.secondaryTsColumn = secondaryTsColumn;
+        this.secondaryTsColumnCondition = secondaryTsColumnCondition;
+    }
+
     public String getName() {
         return name;
     }
@@ -30,11 +40,11 @@ public class TsColumnConfig {
     }
 
     public boolean isVarchar() {
-        return VARCHAR.equals(type);
+        return VARCHAR.equalsIgnoreCase(type);
     }
 
     public boolean isBigint() {
-        return BIGINT.equals(type);
+        return BIGINT.equalsIgnoreCase(type);
     }
 
     public String getFormat() {

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
@@ -57,7 +57,7 @@ public class JDBCExtractionNamespaceCacheFactory
         }
 
         final String[] maxTsCache = new String[1];
-        final String secondaryTsWhereClause = getSecondaryTsWhereClause(id, extractionNamespace, maxTsCache);
+        final String secondaryTsWhereCondition = getSecondaryTsWhereCondition(id, extractionNamespace, maxTsCache);
         final Timestamp lastDBUpdate = lastUpdates(id, extractionNamespace, false, maxTsCache);
 
         if (lastDBUpdate != null && lastDBUpdate.getTime() <= lastCheck) {
@@ -78,7 +78,7 @@ public class JDBCExtractionNamespaceCacheFactory
                                 extractionNamespace.getTable()
                         );
 
-                        populateRowListFromJDBC(extractionNamespace, query, lastDBUpdate, handle, new RowMapper(extractionNamespace, cache), secondaryTsWhereClause);
+                        populateRowListFromJDBC(extractionNamespace, query, lastDBUpdate, handle, new RowMapper(extractionNamespace, cache), secondaryTsWhereCondition);
                         return null;
                     }
             );
@@ -105,7 +105,7 @@ public class JDBCExtractionNamespaceCacheFactory
             Timestamp lastDBUpdate,
             Handle handle,
             RowMapper rm,
-            String secondaryTsWhereClause
+            String secondaryTsWhereCondition
     ) {
         Timestamp updateTS;
         if (extractionNamespace.isFirstTimeCaching()) {
@@ -113,7 +113,7 @@ public class JDBCExtractionNamespaceCacheFactory
             query = String.format("%s %s %s",
                     query,
                     getBaseWhereClause(FIRST_TIME_CACHING_WHERE_CLAUSE, extractionNamespace),
-                    secondaryTsWhereClause
+                    secondaryTsWhereCondition
             );
             updateTS = lastDBUpdate;
 
@@ -121,7 +121,7 @@ public class JDBCExtractionNamespaceCacheFactory
             query = String.format("%s %s %s",
                     query,
                     getBaseWhereClause(SUBSEQUENT_CACHING_WHERE_CLAUSE, extractionNamespace),
-                    secondaryTsWhereClause
+                    secondaryTsWhereCondition
             );
             updateTS = extractionNamespace.getPreviousLastUpdateTimestamp();
         }
@@ -135,7 +135,7 @@ public class JDBCExtractionNamespaceCacheFactory
         return null;
     }
 
-    protected String getSecondaryTsWhereClause(String id, JDBCExtractionNamespace extractionNamespace, String[] cache) {
+    protected String getSecondaryTsWhereCondition(String id, JDBCExtractionNamespace extractionNamespace, String[] cache) {
         String whereClauseExtension = "";
 
         if (extractionNamespace.hasSecondaryTsColumn()) {
@@ -162,7 +162,7 @@ public class JDBCExtractionNamespaceCacheFactory
             if (extractionNamespace.getTsColumnConfig().isVarchar()) {
                 tsValue = new SimpleDateFormat(extractionNamespace.getTsColumnConfig().getFormat()).format(updateTS);
             } else if (extractionNamespace.getTsColumnConfig().isBigint()) {
-                tsValue = updateTS.getTime();
+                tsValue = new Long(updateTS.getTime());
             }
         }
         return tsValue;

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
@@ -32,8 +32,9 @@ public class JDBCExtractionNamespaceCacheFactory
     private static final Logger LOG = new Logger(JDBCExtractionNamespaceCacheFactory.class);
     private static final String COMMA_SEPARATOR = ",";
     private static final String FIRST_TIME_CACHING_WHERE_CLAUSE = " WHERE %s <= %s";
-    private static final String WHERE_CLAUSE_EXTENSION = " AND %s %s %s";
+    private static final String AND_SECOND_TSWHERE_CLAUSE = " AND %s %s %s";
     private static final String SUBSEQUENT_CACHING_WHERE_CLAUSE = " WHERE %s > %s";
+    private static final String SECONDARY_TS_COL_ONLY_WHERE_CLAUSE = " WHERE %s %s %s";
     private static final String LAST_UPDATED_TIMESTAMP = ":lastUpdatedTimeStamp";
     private static final int FETCH_SIZE = 10000;
     private final ConcurrentMap<String, DBI> dbiCache = new ConcurrentHashMap<>();
@@ -50,17 +51,22 @@ public class JDBCExtractionNamespaceCacheFactory
             final Map<String, List<String>> cache
     ) {
         final long lastCheck = lastVersion == null ? Long.MIN_VALUE / 2 : Long.parseLong(lastVersion);
+
         if (!extractionNamespace.isCacheEnabled()) {
             return () -> String.valueOf(lastCheck);
         }
-        final Timestamp lastDBUpdate = lastUpdates(id, extractionNamespace, false);
+
+        final String[] maxTsCache = new String[1];
+        final String secondaryTsWhereClause = getSecondaryTsWhereClause(id, extractionNamespace, maxTsCache);
+        final Timestamp lastDBUpdate = lastUpdates(id, extractionNamespace, false, maxTsCache);
+
         if (lastDBUpdate != null && lastDBUpdate.getTime() <= lastCheck) {
             return () -> {
                 extractionNamespace.setPreviousLastUpdateTimestamp(lastDBUpdate);
                 return lastVersion;
             };
         }
-        final String whereClauseExtension = getWhereClauseExtension(id, extractionNamespace);
+
         return () -> {
             final DBI dbi = ensureDBI(id, extractionNamespace);
 
@@ -72,7 +78,7 @@ public class JDBCExtractionNamespaceCacheFactory
                                 extractionNamespace.getTable()
                         );
 
-                        populateRowListFromJDBC(extractionNamespace, query, lastDBUpdate, handle, new RowMapper(extractionNamespace, cache), whereClauseExtension);
+                        populateRowListFromJDBC(extractionNamespace, query, lastDBUpdate, handle, new RowMapper(extractionNamespace, cache), secondaryTsWhereClause);
                         return null;
                     }
             );
@@ -99,7 +105,7 @@ public class JDBCExtractionNamespaceCacheFactory
             Timestamp lastDBUpdate,
             Handle handle,
             RowMapper rm,
-            String whereClauseExtension
+            String secondaryTsWhereClause
     ) {
         Timestamp updateTS;
         if (extractionNamespace.isFirstTimeCaching()) {
@@ -107,7 +113,7 @@ public class JDBCExtractionNamespaceCacheFactory
             query = String.format("%s %s %s",
                     query,
                     getBaseWhereClause(FIRST_TIME_CACHING_WHERE_CLAUSE, extractionNamespace),
-                    whereClauseExtension
+                    secondaryTsWhereClause
             );
             updateTS = lastDBUpdate;
 
@@ -115,7 +121,7 @@ public class JDBCExtractionNamespaceCacheFactory
             query = String.format("%s %s %s",
                     query,
                     getBaseWhereClause(SUBSEQUENT_CACHING_WHERE_CLAUSE, extractionNamespace),
-                    whereClauseExtension
+                    secondaryTsWhereClause
             );
             updateTS = extractionNamespace.getPreviousLastUpdateTimestamp();
         }
@@ -129,17 +135,25 @@ public class JDBCExtractionNamespaceCacheFactory
         return null;
     }
 
-    protected String getWhereClauseExtension(String id, JDBCExtractionNamespace extractionNamespace) {
+    protected String getSecondaryTsWhereClause(String id, JDBCExtractionNamespace extractionNamespace, String[] cache) {
         String whereClauseExtension = "";
-        if (extractionNamespace.hasTsColumnConfig() && extractionNamespace.getTsColumnConfig().hasSecondaryTsColumn()) {
-            String maxVal = (String) getMaxValFromColumn(id, extractionNamespace, StringMapper.FIRST, extractionNamespace.getTsColumnConfig().getSecondaryTsColumn(), extractionNamespace.getTable());
-            whereClauseExtension = String.format(WHERE_CLAUSE_EXTENSION,
-                    extractionNamespace.getTsColumnConfig().getSecondaryTsColumn(),
-                    extractionNamespace.getTsColumnConfig().getSecondaryTsColumnCondition(),
-                    StringUtil.quoteStringLiteral(maxVal)
-            );
+
+        if (extractionNamespace.hasSecondaryTsColumn()) {
+            String maxSecondaryTsVal = (String) getMaxValFromColumn(id, extractionNamespace, StringMapper.FIRST, extractionNamespace.getTsColumnConfig().getSecondaryTsColumn(), extractionNamespace.getTable());
+            cache[0] = maxSecondaryTsVal;
+            whereClauseExtension = formatSecondTsWhereClause(extractionNamespace, maxSecondaryTsVal, AND_SECOND_TSWHERE_CLAUSE);
         }
+
         return whereClauseExtension;
+    }
+
+    protected String formatSecondTsWhereClause(JDBCExtractionNamespace extractionNamespace, String maxVal, String format) {
+        return String.format(
+                format,
+                extractionNamespace.getTsColumnConfig().getSecondaryTsColumn(),
+                extractionNamespace.getTsColumnConfig().getSecondaryTsColumnCondition(),
+                StringUtil.quoteStringLiteral(maxVal)
+        );
     }
 
     private Object getTsValue(JDBCExtractionNamespace extractionNamespace, Timestamp updateTS) {
@@ -158,7 +172,7 @@ public class JDBCExtractionNamespaceCacheFactory
         return String.format(
                 baseClause,
                 namespace.getTsColumn(),
-                namespace.hasTsColumnConfig()?
+                namespace.hasTsColumnConfig() ?
                         (namespace.getTsColumnConfig().isVarchar() ?
                                 StringUtil.quoteStringLiteral(LAST_UPDATED_TIMESTAMP)
                                 : LAST_UPDATED_TIMESTAMP)
@@ -198,6 +212,10 @@ public class JDBCExtractionNamespaceCacheFactory
     }
 
     protected Timestamp lastUpdates(String id, JDBCExtractionNamespace namespace, Boolean isFollower) {
+        return lastUpdates(id, namespace, isFollower, new String[]{"0"});
+    }
+
+    protected Timestamp lastUpdates(String id, JDBCExtractionNamespace namespace, Boolean isFollower, String[] maxTsCache) {
         final String table = namespace.getTable();
         final String tsColumn = namespace.getTsColumn();
 
@@ -209,24 +227,23 @@ public class JDBCExtractionNamespaceCacheFactory
             return namespace.getPreviousLastUpdateTimestamp();
 
         final Timestamp lastUpdatedTimeStamp =
-                (Timestamp) getMaxValFromColumn(id, namespace,
-                        namespace.hasTsColumnConfig() && namespace.getTsColumnConfig().getFormat() != null ? new CustomizedTimestampMapper(1, namespace.getTsColumnConfig().getFormat()) : CustomizedTimestampMapper.FIRST
-                        , tsColumn, table);
+                (Timestamp) getMaxValFromColumn(id, namespace, CustomizedTimestampMapper.getInstance(namespace), tsColumn, table,
+                        namespace.hasSecondaryTsColumn() ? formatSecondTsWhereClause(namespace, maxTsCache[0], SECONDARY_TS_COL_ONLY_WHERE_CLAUSE) : "");
         return lastUpdatedTimeStamp;
 
     }
 
     protected Object getMaxValFromColumn(String id, JDBCExtractionNamespace namespace, TypedMapper mapper, String col, String table) {
-        final DBI dbi = ensureDBI(id, namespace);
-        return getMaxValFromColumn(dbi, mapper, col, table);
+        return getMaxValFromColumn(id, namespace, mapper, col, table, "");
     }
 
-    protected Object getMaxValFromColumn(DBI dbi, TypedMapper mapper, String col, String table) {
+    protected Object getMaxValFromColumn(String id, JDBCExtractionNamespace namespace, TypedMapper mapper, String col, String table, String whereClause) {
+        final DBI dbi = ensureDBI(id, namespace);
         final Object maxVal = dbi.withHandle(
                 handle -> {
                     final String query = String.format(
-                            "SELECT MAX(%s) FROM %s",
-                            col, table
+                            "SELECT MAX(%s) FROM %s %s",
+                            col, table, whereClause
                     );
                     return handle
                             .createQuery(query)

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
@@ -32,7 +32,7 @@ public class JDBCExtractionNamespaceCacheFactory
     private static final Logger LOG = new Logger(JDBCExtractionNamespaceCacheFactory.class);
     private static final String COMMA_SEPARATOR = ",";
     private static final String FIRST_TIME_CACHING_WHERE_CLAUSE = " WHERE %s <= %s";
-    private static final String AND_SECOND_TSWHERE_CLAUSE = " AND %s %s %s";
+    private static final String AND_SECOND_TS_WHERE_CLAUSE = " AND %s %s %s";
     private static final String SUBSEQUENT_CACHING_WHERE_CLAUSE = " WHERE %s > %s";
     private static final String SECONDARY_TS_COL_ONLY_WHERE_CLAUSE = " WHERE %s %s %s";
     private static final String LAST_UPDATED_TIMESTAMP = ":lastUpdatedTimeStamp";
@@ -141,7 +141,7 @@ public class JDBCExtractionNamespaceCacheFactory
         if (extractionNamespace.hasSecondaryTsColumn()) {
             String maxSecondaryTsVal = (String) getMaxValFromColumn(id, extractionNamespace, StringMapper.FIRST, extractionNamespace.getTsColumnConfig().getSecondaryTsColumn(), extractionNamespace.getTable());
             cache[0] = maxSecondaryTsVal;
-            whereClauseExtension = formatSecondTsWhereClause(extractionNamespace, maxSecondaryTsVal, AND_SECOND_TSWHERE_CLAUSE);
+            whereClauseExtension = formatSecondTsWhereClause(extractionNamespace, maxSecondaryTsVal, AND_SECOND_TS_WHERE_CLAUSE);
         }
 
         return whereClauseExtension;

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/entity/CustomizedTimestampMapper.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/entity/CustomizedTimestampMapper.java
@@ -1,5 +1,6 @@
 package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.entity;
 
+import com.yahoo.maha.maha_druid_lookups.query.lookup.namespace.JDBCExtractionNamespace;
 import org.skife.jdbi.v2.util.TimestampMapper;
 
 import java.text.ParseException;
@@ -26,6 +27,13 @@ public class CustomizedTimestampMapper extends TimestampMapper {
     public CustomizedTimestampMapper(int index, String dateFormat) {
         super(index);
         this.dateFormat = new SimpleDateFormat(dateFormat);
+    }
+
+    public static TimestampMapper getInstance(JDBCExtractionNamespace namespace) {
+        if (namespace.hasTsColumnConfig() && namespace.getTsColumnConfig().getFormat() != null)
+            return new CustomizedTimestampMapper(1, namespace.getTsColumnConfig().getFormat());
+        else
+            return CustomizedTimestampMapper.FIRST;
     }
 
     @Override

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JdbcH2QueryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JdbcH2QueryTest.java
@@ -255,8 +255,7 @@ public class JdbcH2QueryTest {
         doCallRealMethod().when(myJdbcEncFactory).populateLastUpdatedTime(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getBaseWhereClause(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).populateRowListFromJDBC(any(), any(), any(), any(), any(), any());
-        doCallRealMethod().when(myJdbcEncFactory).getSecondaryTsWhereClause(any(), any());
-        doCallRealMethod().when(myJdbcEncFactory).getMaxValFromColumn(any(), any(), any(), any());
+        doCallRealMethod().when(myJdbcEncFactory).getSecondaryTsWhereClause(any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getMaxValFromColumn(any(), any(), any(), any(), any());
 
         Whitebox.setInternalState(myJdbcEncFactory, "dbiCache", new ConcurrentHashMap<>());

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JdbcH2QueryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JdbcH2QueryTest.java
@@ -256,7 +256,7 @@ public class JdbcH2QueryTest {
         doCallRealMethod().when(myJdbcEncFactory).populateLastUpdatedTime(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getBaseWhereClause(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).populateRowListFromJDBC(any(), any(), any(), any(), any(), any());
-        doCallRealMethod().when(myJdbcEncFactory).getSecondaryTsWhereClause(any(), any(), any());
+        doCallRealMethod().when(myJdbcEncFactory).getSecondaryTsWhereCondition(any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getMaxValFromColumn(any(), any(), any(), any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getMaxValFromColumn(any(), any(), any(), any(), any());
 

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JdbcH2QueryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JdbcH2QueryTest.java
@@ -255,7 +255,7 @@ public class JdbcH2QueryTest {
         doCallRealMethod().when(myJdbcEncFactory).populateLastUpdatedTime(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getBaseWhereClause(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).populateRowListFromJDBC(any(), any(), any(), any(), any(), any());
-        doCallRealMethod().when(myJdbcEncFactory).getWhereClauseExtension(any(), any());
+        doCallRealMethod().when(myJdbcEncFactory).getSecondaryTsWhereClause(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getMaxValFromColumn(any(), any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getMaxValFromColumn(any(), any(), any(), any(), any());
 

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JdbcH2QueryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JdbcH2QueryTest.java
@@ -249,6 +249,7 @@ public class JdbcH2QueryTest {
         doCallRealMethod().when(myJdbcEncFactory).doLeaderOperations(any(), any(), any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).populateRowListFromJDBC(any(), any(), any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).lastUpdates(any(), any(), any());
+        doCallRealMethod().when(myJdbcEncFactory).lastUpdates(any(), any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).ensureDBI(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).updateLocalCache(any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getCacheValue(any(), any(), any(), any(), any());
@@ -256,6 +257,7 @@ public class JdbcH2QueryTest {
         doCallRealMethod().when(myJdbcEncFactory).getBaseWhereClause(any(), any());
         doCallRealMethod().when(myJdbcEncFactory).populateRowListFromJDBC(any(), any(), any(), any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getSecondaryTsWhereClause(any(), any(), any());
+        doCallRealMethod().when(myJdbcEncFactory).getMaxValFromColumn(any(), any(), any(), any(), any(), any());
         doCallRealMethod().when(myJdbcEncFactory).getMaxValFromColumn(any(), any(), any(), any(), any());
 
         Whitebox.setInternalState(myJdbcEncFactory, "dbiCache", new ConcurrentHashMap<>());

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.343-SNAPSHOT</version>
+    <version>5.344-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.343-SNAPSHOT</version>
+        <version>5.344-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
**Summay**
--
In the existing implementation, `JDBCExtractionNamespaceCacheFactory` will run a `SELECT MAX(ts_column) FROM dim_table_name ` to fetch the max last updated time and store it into memory by `extractionNamespace.setPreviousLastUpdateTimestamp(lastDBUpdate);`. 

This logic works fine with tables that only contains one single snapshot in the DB, but it's not able to scale when table contains many snapshots. 

In this PR, I'm adding a where clause when running the select max(ts) query only against the latest snapshot, which essentially optimizes the query execution time for the above scenario.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
