### PR TITLE
Update rollup & subset with onwardsDate requirements

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/fact/Fact.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/fact/Fact.scala
@@ -3,6 +3,7 @@
 package com.yahoo.maha.core.fact
 
 import com.yahoo.maha.core._
+import com.yahoo.maha.core.NoopSchema.NoopSchema
 import com.yahoo.maha.core.ddl.{DDLAnnotation, HiveDDLAnnotation}
 import com.yahoo.maha.core.dimension.{BaseFunctionDimCol, ConstDimCol, DimensionColumn, PublicDimColumn}
 import com.yahoo.maha.core.fact.Fact.ViewTable
@@ -1241,6 +1242,7 @@ case class FactBuilder private[fact](private val baseFact: Fact, private var tab
     require(tableMap.contains(from), s"from table not valid $from")
     require(!tableMap.contains(name), s"table $name already exists")
     require(discarding.nonEmpty, "discarding set should never be empty")
+    require(availableOnwardsDate.isDefined || schemas == Set(NoopSchema), "Public rollups should have a defined availableOnwardsDate")
 
     val fromTable = tableMap(from)
 
@@ -1344,6 +1346,8 @@ case class FactBuilder private[fact](private val baseFact: Fact, private var tab
     require(tableMap.contains(from), s"from table not valid $from")
     require(!tableMap.contains(name), s"table $name already exists")
     require(discarding.nonEmpty, "discardings should never be empty in rollup")
+    require(availableOnwardsDate.isDefined || schemas == Set(NoopSchema), "Public rollups should have a defined availableOnwardsDate")
+
     val fromTable = tableMap(from)
     discarding foreach {
       d =>

--- a/core/src/test/scala/com/yahoo/maha/core/query/oracle/BaseOracleQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/oracle/BaseOracleQueryGeneratorTest.scala
@@ -99,7 +99,7 @@ trait BaseOracleQueryGeneratorTest
           , OracleFactConditionalHint(FactCondition(Option(true), Option(false), Option(false), Option(false)), "CONDITIONAL_HINT4")
           , OracleFactConditionalHint(FactCondition(None, minRowsEstimate = Option(900L))
             , "CONDITIONAL_HINT5")
-        )
+        ), availableOnwardsDate = Some("2010-01-01")
       ).toPublicFact("k_stats",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),
@@ -368,7 +368,7 @@ trait BaseOracleQueryGeneratorTest
         )
       )
     }
-      .newRollUp("k_stats_fact1", "k_stats_new_partitioning", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"))
+      .newRollUp("k_stats_fact1", "k_stats_new_partitioning", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"), availableOnwardsDate = Some("2010-01-01"))
       .toPublicFact("k_stats_new",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),
@@ -529,7 +529,7 @@ trait BaseOracleQueryGeneratorTest
         )
       )
     }
-      .newRollUp("k_stats_fact1", "k_stats_new_partitioning", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"))
+      .newRollUp("k_stats_fact1", "k_stats_new_partitioning", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"), availableOnwardsDate = Some("2010-01-01"))
       .toPublicFact("keyword_view_test",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),
@@ -757,7 +757,7 @@ trait BaseOracleQueryGeneratorTest
         )
       )
     }
-      .newRollUp("fact2", "fact1", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type", "source_name" -> "stats_source"))
+      .newRollUp("fact2", "fact1", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type", "source_name" -> "stats_source"), availableOnwardsDate = Some("2010-01-01"))
       .toPublicFact("k_stats_new_freq",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),

--- a/core/src/test/scala/com/yahoo/maha/core/query/postgres/BasePostgresQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/postgres/BasePostgresQueryGeneratorTest.scala
@@ -98,7 +98,7 @@ trait BasePostgresQueryGeneratorTest
           , PostgresFactConditionalHint(FactCondition(Option(true), Option(false), Option(false), Option(false)), "CONDITIONAL_HINT4")
           , PostgresFactConditionalHint(FactCondition(None, minRowsEstimate = Option(900L))
             , "CONDITIONAL_HINT5")
-        )
+        ), availableOnwardsDate = Some("2010-01-01")
       ).toPublicFact("k_stats",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),
@@ -367,7 +367,7 @@ trait BasePostgresQueryGeneratorTest
         )
       )
     }
-      .newRollUp("k_stats_fact1", "k_stats_new_partitioning", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"))
+      .newRollUp("k_stats_fact1", "k_stats_new_partitioning", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"), availableOnwardsDate = Some("2010-01-01"))
       .toPublicFact("k_stats_new",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),
@@ -528,7 +528,7 @@ trait BasePostgresQueryGeneratorTest
         )
       )
     }
-      .newRollUp("k_stats_fact1", "k_stats_new_partitioning", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"))
+      .newRollUp("k_stats_fact1", "k_stats_new_partitioning", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"), availableOnwardsDate = Some("2010-01-01"))
       .toPublicFact("keyword_view_test",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),
@@ -756,7 +756,7 @@ trait BasePostgresQueryGeneratorTest
         )
       )
     }
-      .newRollUp("fact2", "fact1", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type", "source_name" -> "stats_source"))
+      .newRollUp("fact2", "fact1", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type", "source_name" -> "stats_source"), availableOnwardsDate = Some("2010-01-01"))
       .toPublicFact("k_stats_new_freq",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),

--- a/core/src/test/scala/com/yahoo/maha/report/JsonRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/report/JsonRowListTest.scala
@@ -440,7 +440,7 @@ class JsonRowListTest extends FunSuite with BaseQueryGeneratorTest with SharedDi
         )
       )
     }
-      .newRollUp("fact_table_keywords", "fact0_table_keywords", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"))
+      .newRollUp("fact_table_keywords", "fact0_table_keywords", discarding = Set("ad_id"), columnAliasMap = Map("price_type" -> "pricing_type"), availableOnwardsDate = Some("2010-01-01"))
       .toPublicFact("k_stats",
         Set(
           PubCol("stats_date", "Day", InBetweenEquality),

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.350-SNAPSHOT</version>
+    <version>5.351-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.350-SNAPSHOT</version>
+        <version>5.351-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


This is a backwards incompatible change, as users will be expected to either make intermediate rollups non-queryable (NoopSchema) or define an earliest queryable date (availableOnwardsDate).  This is because new rollups are expected to not have all of the data that the parent table has, at least initially.