### PR TITLE
Set dim only queries as dim driven by default

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -1080,6 +1080,13 @@ object RequestModel extends Logging {
             }
             DimensionRelations(relations)
           }
+          val isDimOnlyQuery = dimensionCandidates.nonEmpty && bestCandidatesOption.isEmpty
+
+          // All Dim only queries are by default dim driven
+          val forceDimensionDriven:Boolean = if(isDimOnlyQuery) {
+            true
+          } else request.forceDimensionDriven
+
 
           val allFactWithoutOr = allFactFilters.filterNot(filter => allOrFilters.contains(filter))
           new RequestModel(request.cube, bestCandidatesOption, allFactWithoutOr.to[SortedSet], dimensionCandidates,
@@ -1099,7 +1106,7 @@ object RequestModel extends Logging {
             hasDimFilters = hasDimFilters,
             hasNonFKDimFilters = hasNonFKDimFilters,
             hasDimSortBy = hasDimSortBy,
-            forceDimDriven = request.forceDimensionDriven,
+            forceDimDriven = forceDimensionDriven,
             forceFactDriven = request.forceFactDriven,
             hasNonDrivingDimSortOrFilter = hasNonDrivingDimSortOrFilter,
             hasDrivingDimNonFKNonPKSortBy = hasDrivingDimNonFKNonPKSortBy,

--- a/core/src/test/scala/com/yahoo/maha/core/RequestModelTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/RequestModelTest.scala
@@ -4161,9 +4161,9 @@ class RequestModelTest extends FunSuite with Matchers {
     assert(model.dimensionsCandidates.take(2).forall(!_.isDrivingDimension))
     assert(model.dimensionsCandidates.last.isDrivingDimension)
 
-    assert(model.publicDimToJoinTypeMap("advertiser") == LeftOuterJoin, "Should be LeftOuterJoin as request is dim sort")
-    assert(model.publicDimToJoinTypeMap("campaign") == LeftOuterJoin, "Should be LeftOuterJoin as request is dim sort")
-    assert(model.publicDimToJoinTypeMap("ad_group") == LeftOuterJoin, "Should be LeftOuterJoin as request is dim sort")
+    assert(model.publicDimToJoinTypeMap("advertiser") == InnerJoin, "Should be InnerJoin as request is dim sort")
+    assert(model.publicDimToJoinTypeMap("campaign") == InnerJoin, "Should be InnerJoin as request is dim sort")
+    assert(model.publicDimToJoinTypeMap("ad_group") == RightOuterJoin, "Should be RightOuterJoin as request is dim sort")
 
   }
 
@@ -4198,7 +4198,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     assert(model.publicDimToJoinTypeMap("advertiser") == InnerJoin, "Should be InnerJoin as request is fact driven and has dim filtering")
     assert(model.publicDimToJoinTypeMap("campaign") == InnerJoin, "Should be InnerJoin as request is fact driven and has dim filtering")
-    assert(model.publicDimToJoinTypeMap("ad_group") == InnerJoin, "Should be InnerJoin as request is fact driven and has dim filtering")
+    assert(model.publicDimToJoinTypeMap("ad_group") == RightOuterJoin, "Should be RightOuterJoin as request is fact driven and has dim filtering")
 
   }
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.351-SNAPSHOT</version>
+    <version>5.352-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.351-SNAPSHOT</version>
+        <version>5.352-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
As Dim only queries are getting serve from only one engine and all these queries are by default dimension driven. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
