### PR TITLE
implement support for Druid period granularity queries

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/DerivedFunction.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/DerivedFunction.scala
@@ -259,6 +259,26 @@ object DruidDerivedFunction {
     val sourceDimColName = "__time"
   }
 
+  case class DRUID_TIME_FORMAT_WITH_PERIOD_GRANULARITY(
+    format: String,
+    period: String,
+    zone: DateTimeZone = DateTimeZone.UTC
+  ) extends DruidDerivedFunction {
+    override def asJSON(): JObject =
+      makeObj(
+        List(
+          ("function_type" -> toJSON(this.getClass.getSimpleName))
+          , ("format" -> toJSON(format))
+          , ("period" -> toJSON(period))
+          , ("zone" -> toJSON(zone.toString))
+        )
+      )
+  }
+
+  object DRUID_TIME_FORMAT_WITH_PERIOD_GRANULARITY {
+    val sourceDimColName = "__time"
+  }
+
   /* Information like timezone is passed in the request context. */
   case class TIME_FORMAT_WITH_REQUEST_CONTEXT(format: String) extends DruidDerivedFunction {
     override def asJSON(): JObject =

--- a/core/src/test/scala/com/yahoo/maha/core/DerivedFunctionTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/DerivedFunctionTest.scala
@@ -52,10 +52,11 @@ class DerivedFunctionTest extends FunSuiteLike with Matchers {
     val ltf = LOOKUP_WITH_TIMEFORMATTER("namespace", "valCol", "yyyyMMdd", "yyyy", Map("do" -> "dont"), Some("override"))
     val ldr = LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE("namespace", "valCol", true, true, Map("rtn" -> "not"), "arg1", "decodeVal1", "arg2", "decodeVal2", "default")
     val dtz = DRUID_TIME_FORMAT("format", DateTimeZone.forID("Asia/Jakarta"))
+    val dpg = DRUID_TIME_FORMAT_WITH_PERIOD_GRANULARITY("format", "P1D", DateTimeZone.forID("Asia/Jakarta"))
     val rc = TIME_FORMAT_WITH_REQUEST_CONTEXT("yyyy")
     val lwt = LOOKUP_WITH_TIMESTAMP("namespace", "val", "fmt", Map.empty, Some("ovrVal"), asMillis = false)
 
-    val resultArray = List(gid, dow, dtf, dd, js, rgx, lu, lwd, lwe, lwo, ltf, ldr, dtz, rc, lwt)
+    val resultArray = List(gid, dow, dtf, dd, js, rgx, lu, lwd, lwe, lwo, ltf, ldr, dtz, dpg, rc, lwt)
 
     val expectedJSONs = List(
       """{"function_type":"GET_INTERVAL_DATE","fieldName":"fieldName","format":"yyyyMMdd"}""",
@@ -71,6 +72,7 @@ class DerivedFunctionTest extends FunSuiteLike with Matchers {
       """{"function_type":"LOOKUP_WITH_TIMEFORMATTER","lookupNamespace":"namespace","valueColumn":"valCol","inputFormat":"yyyyMMdd","resultFormat":"yyyy","dimensionOverrideMap":{"do":"dont"}}""",
       """{"function_type":"LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE","lookupNamespace":"namespace","valueColumn":"valCol","retainMissingValue":true,"injective":true,"dimensionOverrideMap":{"rtn":"not"},"args":"arg1,decodeVal1,arg2,decodeVal2,default"}""",
       """{"function_type":"DRUID_TIME_FORMAT","format":"format","zone":"Asia/Jakarta"}""",
+      """{"function_type":"DRUID_TIME_FORMAT_WITH_PERIOD_GRANULARITY","format":"format","period":"P1D","zone":"Asia/Jakarta"}""",
       """{"function_type":"TIME_FORMAT_WITH_REQUEST_CONTEXT","format":"yyyy"}""",
       """{"function_type":"LOOKUP_WITH_TIMESTAMP","lookupNamespace":"namespace","valueColumn":"val","resultFormat":"fmt","dimensionOverrideMap":{},"overrideValue":"ovrVal","asMillis":false}"""
     )

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
@@ -73,6 +73,7 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
           , DruidFuncDimCol("segments", StrType(), JAVASCRIPT("{segments}", "function(x) { return x > 0; }"))
           , DimCol("internal_bucket_id", StrType())
           , DruidFuncDimCol("click_exp_id", StrType(), REGEX("{internal_bucket_id}", "(cl-)(.*?)(,)", 2, replaceMissingValue = true, "-3"))
+          , DruidFuncDimCol("week_start", DateType(), DRUID_TIME_FORMAT_WITH_PERIOD_GRANULARITY("yyyy-MM-dd", "P1W"))
         ),
         Set(
           FactCol("impressions", IntType(3, 1))
@@ -324,7 +325,8 @@ class BaseDruidQueryGeneratorTest extends FunSuite with Matchers with BeforeAndA
           PubCol("woeids", "Woe ID", InEquality),
           PubCol("segments", "Segments", InEquality),
           PubCol("internal_bucket_id", "Internal Bucket ID", InEquality),
-          PubCol("click_exp_id", "Click Exp ID", InEquality)
+          PubCol("click_exp_id", "Click Exp ID", InEquality),
+          PubCol("week_start", "Week Start", InEquality)
           //PubCol("Ad Group Start Date Full", "Ad Group Start Date Full", InEquality)
         ),
         Set(


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Added Druid period granularity support (described in https://druid.apache.org/docs/latest/querying/granularities.html) so that we can query time dimensions at arbitrary granularities.

For example, using DRUID_TIME_FORMAT_WITH_PERIOD_GRANULARITY("YYYY-MM-dd", "P1W")) would generate the following as part of the dimensions spec:
```
{
    "outputName": "Week",
    "extractionFn": {
        "timeZone": "UTC",
        "asMillis": false,
        "granularity": "WEEK",
        "type": "timeFormat",
        "format": "YYYY-MM-dd"
    },
    "type": "extraction",
    "dimension": "__time",
    "outputType": "STRING"
}
```
