### PR TITLE
enable filtering on aggregated facts not included in output columns

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -1140,8 +1140,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     }
 
     val factCols = queryContext.factBestCandidate.factColMapping.toList.collect {
-      case (nonFkCol, alias) if queryContext.factBestCandidate.requestCols(nonFkCol) =>
-        (fact.columnsByNameMap(nonFkCol), alias)
+      case (nonFkCol, alias) => (fact.columnsByNameMap(nonFkCol), alias)
     }
 
     //render derived columns last


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adding the ability to filter aggregated facts that aren't included in the list of output columns. e.g. in the test case added -- excluding rows with impressions < 5, but not including the impressions count column in the output.

More details here: https://github.com/yahoo/maha/issues/634