### PR TITLE
Use postgres driver to escape literal

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/LiteralMapper.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/LiteralMapper.scala
@@ -13,11 +13,12 @@ import org.owasp.esapi.codecs.OracleCodec
 
 trait LiteralMapper {
   val ORACLE_CODEC = new OracleCodec
-  def getEscapedSqlString(s: String): String = {
+  protected def getEscapedSqlString(s: String): String = {
     ESAPI.encoder().encodeForSQL(ORACLE_CODEC, s)
   }
   def toLiteral(column: Column, value: String, grainOption: Option[Grain] = None) : String
 }
+
 class OracleLiteralMapper extends LiteralMapper {
   def getDateFormatFromGrain(grain: Grain): String = {
     grain match {

--- a/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
@@ -1263,9 +1263,10 @@ object PostgresQueryGenerator extends Logging {
   val ROW_COUNT_ALIAS: String = "TOTALROWS"
   val ANY_PARTITIONING_SCHEME = PostgresPartitioningScheme("") //no name needed since class name hashcode
 
-  def register(queryGeneratorRegistry: QueryGeneratorRegistry, partitionColumnRenderer:PartitionColumnRenderer) = {
+  def register(queryGeneratorRegistry: QueryGeneratorRegistry, partitionColumnRenderer:PartitionColumnRenderer
+               , postgresLiteralMapper: PostgresLiteralMapper = new PostgresLiteralMapper) = {
     if (!queryGeneratorRegistry.isEngineRegistered(PostgresEngine, Option(Version.DEFAULT))) {
-      val generator = new PostgresQueryGenerator(partitionColumnRenderer)
+      val generator = new PostgresQueryGenerator(partitionColumnRenderer, postgresLiteralMapper)
       queryGeneratorRegistry.register(PostgresEngine, generator)
     } else {
       queryGeneratorRegistry.getDefaultGenerator(PostgresEngine).foreach {

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -124,7 +124,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -360,7 +360,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MahaLookupExtractionFactoryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MahaLookupExtractionFactoryTest.java
@@ -70,7 +70,7 @@ public class MahaLookupExtractionFactoryTest extends TestMongoServer {
         injector = Initialization.makeInjectorWithModules(
                 injector,
                 ImmutableList.of(
-                        new Module() {
+                        new com.google.inject.Module() {
                             @Override
                             public void configure(Binder binder) {
                                 JsonConfigProvider.bindInstance(

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -170,7 +170,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <scoverage.aggregate>true</scoverage.aggregate>
         <scoverage.minimum.coverage>90</scoverage.minimum.coverage>
         <target_jdk_version>1.8</target_jdk_version>
-        <maven-surefire-plugin.version>2.20.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.major.version>2.12</scala.major.version>
@@ -43,7 +43,7 @@
         <logback.version>1.2.3</logback.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
-        <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <scoverage.plugin.version>1.4.1</scoverage.plugin.version>
         <enforcer.skip>true</enforcer.skip>
         <log4j2.version>2.3</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.364-SNAPSHOT</version>
+    <version>5.365-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/postgres/src/main/scala/com/yahoo/maha/executor/postgres/PostgresLiteralMapperUsingDriver.scala
+++ b/postgres/src/main/scala/com/yahoo/maha/executor/postgres/PostgresLiteralMapperUsingDriver.scala
@@ -1,0 +1,10 @@
+package com.yahoo.maha.executor.postgres
+
+import com.yahoo.maha.core.PostgresLiteralMapper
+
+class PostgresLiteralMapperUsingDriver extends PostgresLiteralMapper {
+  override protected def getEscapedSqlString(s: String): String = {
+    val sbuf = org.postgresql.core.Utils.escapeLiteral(null, s, true)
+    sbuf.toString
+  }
+}

--- a/postgres/src/test/scala/com/yahoo/maha/executor/postgres/PostgresQueryExecutorTest.scala
+++ b/postgres/src/test/scala/com/yahoo/maha/executor/postgres/PostgresQueryExecutorTest.scala
@@ -53,7 +53,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
     config.setUsername("postgres")
     config.setPassword("")
     config.setMaximumPoolSize(1)
-    PostgresQueryGenerator.register(queryGeneratorRegistry, DefaultPartitionColumnRenderer)
+    PostgresQueryGenerator.register(queryGeneratorRegistry, DefaultPartitionColumnRenderer, new PostgresLiteralMapperUsingDriver)
     DruidQueryGenerator.register(queryGeneratorRegistry)
     dataSource = Option(new HikariDataSource(config))
     jdbcConnection = dataSource.map(new JdbcConnection(_))

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/factory/LiteralMapperFactory.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/factory/LiteralMapperFactory.scala
@@ -6,6 +6,7 @@ import com.yahoo.maha.service.MahaServiceConfig.MahaConfigResult
 import com.yahoo.maha.core.{DruidLiteralMapper, OracleLiteralMapper, PostgresLiteralMapper}
 import org.json4s.JValue
 import _root_.scalaz._
+import com.yahoo.maha.executor.postgres.PostgresLiteralMapperUsingDriver
 import com.yahoo.maha.service.MahaServiceConfigContext
 import syntax.validation._
 
@@ -29,6 +30,13 @@ class DefaultDruidLiteralMapperFactory extends DruidLiteralMapperFactory {
 class DefaultPostgresLiteralMapperFactory extends PostgresLiteralMapperFactory {
   override def fromJson(config: JValue)(implicit context: MahaServiceConfigContext): MahaConfigResult[PostgresLiteralMapper] = {
     new PostgresLiteralMapper().successNel
+  }
+
+  override def supportedProperties: List[(String, Boolean)] = List.empty
+}
+class DefaultPostgresLiteralMapperUsingDriverFactory extends PostgresLiteralMapperFactory {
+  override def fromJson(config: JValue)(implicit context: MahaServiceConfigContext): MahaConfigResult[PostgresLiteralMapper] = {
+    new PostgresLiteralMapperUsingDriver().successNel
   }
 
   override def supportedProperties: List[(String, Boolean)] = List.empty

--- a/service/src/test/resources/mahaServiceExampleJson.json
+++ b/service/src/test/resources/mahaServiceExampleJson.json
@@ -143,6 +143,23 @@
         ]
       }
     },
+    "postgres2": {
+      "factoryClass": "com.yahoo.maha.service.factory.PostgresQueryGeneratorFactory",
+      "config": {
+        "partitionColumnRendererClass": "com.yahoo.maha.service.factory.DefaultPartitionColumnRendererFactory",
+        "partitionColumnRendererConfig": [
+          {
+            "key": "value"
+          }
+        ],
+        "literalMapperClass": "com.yahoo.maha.service.factory.DefaultPostgresLiteralMapperUsingDriverFactory",
+        "literalMapperConfig": [
+          {
+            "key": "value"
+          }
+        ]
+      }
+    },
     "oracle": {
       "factoryClass": "com.yahoo.maha.service.factory.OracleQueryGeneratorFactory",
       "config": {

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.364-SNAPSHOT</version>
+        <version>5.365-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Add a new literal mapper which uses postgres driver to escape literal.

Update a few plugins and qualify the use of Module in order to compile with JDK 11.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
