### PR TITLE
Add date time between filter

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-example/src/main/resources/maha-service-config.json
+++ b/api-example/src/main/resources/maha-service-config.json
@@ -16,6 +16,7 @@
         "presto"
       ],
       "bucketingConfigName": "studentBucket",
+      "userTimeZoneProviderName": "studentUserTimeZone",
       "utcTimeProviderName": "studentUTC",
       "parallelServiceExecutorName": "studentParallelExec",
       "dimEstimatorFactoryClass": "com.yahoo.maha.service.factory.DefaultDimCostEstimatorFactory",
@@ -41,6 +42,7 @@
         "druid"
       ],
       "bucketingConfigName": "wikiBucket",
+      "userTimeZoneProviderName": "wikiUserTimeZone",
       "utcTimeProviderName": "wikiUTC",
       "parallelServiceExecutorName": "wikiParallelExec",
       "dimEstimatorFactoryClass": "com.yahoo.maha.service.factory.DefaultDimCostEstimatorFactory",
@@ -294,6 +296,20 @@
           }
         ],
         "queryGenerator": []
+      }
+    }
+  },
+  "userTimeZoneProviderMap": {
+    "studentUserTimeZone": {
+      "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+      "config": {
+        "k": "v"
+      }
+    },
+    "wikiUserTimeZone": {
+      "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+      "config": {
+        "k": "v"
       }
     }
   },

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/api-jersey/src/test/resources/maha-service-config.json
+++ b/api-jersey/src/test/resources/maha-service-config.json
@@ -14,6 +14,7 @@
         "druid"
       ],
       "bucketingConfigName": "academicBucket",
+      "userTimeZoneProviderName": "academicUserTimeZone",
       "utcTimeProviderName": "academicUTC",
       "parallelServiceExecutorName": "academicParallelExec",
       "dimEstimatorFactoryClass": "com.yahoo.maha.service.factory.DefaultDimCostEstimatorFactory",
@@ -203,6 +204,14 @@
           }
         ],
         "queryGenerator": []
+      }
+    }
+  },
+  "userTimeZoneProviderMap": {
+    "academicUserTimeZone": {
+      "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+      "config": {
+        "k": "v"
       }
     }
   },

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/BaseUTCTimeProvider.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/BaseUTCTimeProvider.scala
@@ -32,9 +32,11 @@ class BaseUTCTimeProvider extends UTCTimeProvider with Logging {
       if (timezone.contains(DateTimeZone.UTC.toString))
         return (utcDateTimeFilter, None, None)
 
-      val dateTimeZone = DateTimeZone.forID(timezone.get)
-      val requestDTF = localTimeDayFilter.asInstanceOf[DateTimeFilter]
-      utcDateTimeFilter = requestDTF.convertToUTCFromLocalZone(dateTimeZone)
+      if (timezone.isDefined) {
+        val dateTimeZone = DateTimeZone.forID(timezone.get)
+        val requestDTF = localTimeDayFilter.asInstanceOf[DateTimeFilter]
+        utcDateTimeFilter = requestDTF.convertToUTCFromLocalZone(dateTimeZone)
+      }
       (utcDateTimeFilter, None, None)
     } else {
       handleLegacyDayHourMinuteFilter(localTimeDayFilter, localTimeHourFilter, localTimeMinuteFilter, timezone, isDebugEnabled)

--- a/core/src/main/scala/com/yahoo/maha/core/DataType.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/DataType.scala
@@ -312,11 +312,11 @@ case object DateType extends Logging {
   private[this] val ORACLE_HOUR_FORMAT = "hh"
   private[this] val HIVE_HOUR = "YYYYMMDDHH"
   private[this] val UTC_TIME_HOUR = "yyyyMMddHH"
-  private[this] var formatterMap: LoadingCache[String, DateTimeFormatter] = {
+  private[this] val formatterMap: LoadingCache[String, DateTimeFormatter] = {
     val loader: CacheLoader[String, DateTimeFormatter] = new CacheLoader[String, DateTimeFormatter] {
       override def load(k: String): DateTimeFormatter = {
         try {
-          DateTimeFormat.forPattern(k) //timezone could be provided in the format string
+          DateTimeFormat.forPattern(k).withZoneUTC() //timezone could be provided in the format string
         } catch {
           case e: Exception =>
             error(s"Invalid date time format: $k", e)

--- a/core/src/main/scala/com/yahoo/maha/core/Grain.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/Grain.scala
@@ -13,6 +13,9 @@ sealed trait Grain {
   //value between 0 and 9
   def level: Int
   def formatString: String
+  def fullFormatString: String
+  def toFullFormattedString(dt: DateTime) : String
+  def fromFullFormattedString(date: String) : DateTime
   def toFormattedString(dt: DateTime) : String
   def fromFormattedString(date: String) : DateTime
   def incrementOne(dt: DateTime): DateTime
@@ -25,14 +28,17 @@ object Grain {
 }
 
 case object DailyGrain extends Grain with Logging {
-  
+
   val level = 0
-  
+
   val DAY_FILTER_FIELD: String = "Day"
 
   override val formatString = "yyyy-MM-dd"
   private[this] val datetimeFormat = DateTimeFormat.forPattern(formatString).withZoneUTC()
-  
+  override val fullFormatString = formatString
+
+  def toFullFormattedString(dt: DateTime) : String = toFormattedString(dt)
+  def fromFullFormattedString(date: String) : DateTime = fromFormattedString(date)
   def toFormattedString(dt: DateTime) : String = datetimeFormat.print(dt)
   def fromFormattedString(date: String) : DateTime = datetimeFormat.parseDateTime(date)
   def fromFormattedStringAndZone(date: String, timezone: String) : DateTime = DateTimeFormat.forPattern(formatString).withZone(DateTimeZone.forID(timezone)).parseDateTime(date)
@@ -96,12 +102,17 @@ case object DailyGrain extends Grain with Logging {
 case object HourlyGrain extends Grain {
 
   val level = 1
-  
-  val HOUR_FILTER_FIELD: String = "Hour"
-  
-  override val formatString = "HH"
-  private[this] val datetimeFormat = DateTimeFormat.forPattern(formatString)
 
+  val HOUR_FILTER_FIELD: String = "Hour"
+
+  override val formatString = "HH"
+  private[this] val datetimeFormat = DateTimeFormat.forPattern(formatString).withZoneUTC()
+
+  override val fullFormatString = s"${DailyGrain.fullFormatString}'T'$formatString"
+  private[this] val fullDatetimeFormat = DateTimeFormat.forPattern(fullFormatString).withZoneUTC()
+
+  def toFullFormattedString(dt: DateTime) : String = fullDatetimeFormat.print(dt)
+  def fromFullFormattedString(date: String) : DateTime = fullDatetimeFormat.parseDateTime(date)
   def toFormattedString(dt: DateTime) : String = datetimeFormat.print(dt)
   def fromFormattedString(date: String) : DateTime = datetimeFormat.parseDateTime(date)
   def incrementOne(dt: DateTime): DateTime = dt.plusHours(1)
@@ -136,8 +147,12 @@ case object MinuteGrain extends Grain {
   val MINUTE_FILTER_FIELD: String = "Minute"
 
   override val formatString = "mm"
-  private[this] val datetimeFormat = DateTimeFormat.forPattern(formatString)
+  private[this] val datetimeFormat = DateTimeFormat.forPattern(formatString).withZoneUTC()
+  override val fullFormatString = s"${HourlyGrain.fullFormatString}:$formatString"
+  private[this] val fullDatetimeFormat = DateTimeFormat.forPattern(fullFormatString).withZoneUTC()
 
+  def toFullFormattedString(dt: DateTime) : String = fullDatetimeFormat.print(dt)
+  def fromFullFormattedString(date: String) : DateTime = fullDatetimeFormat.parseDateTime(date)
   def toFormattedString(dt: DateTime) : String = datetimeFormat.print(dt)
   def fromFormattedString(date: String) : DateTime = datetimeFormat.parseDateTime(date)
   def incrementOne(dt: DateTime): DateTime = dt.plusMinutes(1)

--- a/core/src/main/scala/com/yahoo/maha/core/Grain.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/Grain.scala
@@ -30,7 +30,7 @@ case object DailyGrain extends Grain with Logging {
   
   val DAY_FILTER_FIELD: String = "Day"
 
-  override val formatString = "YYYY-MM-dd"
+  override val formatString = "yyyy-MM-dd"
   private[this] val datetimeFormat = DateTimeFormat.forPattern(formatString).withZoneUTC()
   
   def toFormattedString(dt: DateTime) : String = datetimeFormat.print(dt)
@@ -40,6 +40,8 @@ case object DailyGrain extends Grain with Logging {
 
   def validateFilterAndGetNumDays(filter: Filter): Int = {
     filter match {
+      case dtf: DateTimeBetweenFilter =>
+        dtf.daysBetween
       case BetweenFilter(field, from, to) =>
         validateFormat(field, from)
         validateFormat(field, to)

--- a/core/src/main/scala/com/yahoo/maha/core/JsonUtils.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/JsonUtils.scala
@@ -6,6 +6,7 @@ import org.json4s._
 import org.json4s.scalaz.JsonScalaz
 import org.json4s.scalaz.JsonScalaz._
 import _root_.scalaz.{Scalaz, syntax}
+import org.joda.time.DateTimeZone
 import org.json4s.JsonAST.{JArray, JValue}
 import syntax.validation._
 
@@ -46,6 +47,8 @@ object JsonUtils {
 
   def booleanFalse(json: JValue): Result[Boolean] = false.successNel
 
+  def optionNone[T](json: JValue): Result[Option[T]] = None.successNel
+  def noneDateTimeZone(json: JValue): Result[Option[DateTimeZone]] = None.successNel
   /**
    * Implicits used for JSON converters, IE Set, Map, Annotations, etc.
    */

--- a/core/src/main/scala/com/yahoo/maha/core/LiteralMapper.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/LiteralMapper.scala
@@ -18,8 +18,10 @@ trait LiteralMapper {
   }
   def toLiteral(column: Column, value: String, grainOption: Option[Grain] = None) : String
 }
-
-class OracleLiteralMapper extends LiteralMapper {
+trait SqlLiteralMapper extends LiteralMapper {
+  def getDateFormatFromGrain(grain: Grain): String
+}
+class OracleLiteralMapper extends SqlLiteralMapper {
   def getDateFormatFromGrain(grain: Grain): String = {
     grain match {
       case DailyGrain => "YYYY-MM-DD"
@@ -52,7 +54,7 @@ class OracleLiteralMapper extends LiteralMapper {
   }
 }
 
-class PostgresLiteralMapper extends LiteralMapper {
+class PostgresLiteralMapper extends SqlLiteralMapper {
   def getDateFormatFromGrain(grain: Grain): String = {
     grain match {
       case DailyGrain => "YYYY-MM-DD"
@@ -85,7 +87,7 @@ class PostgresLiteralMapper extends LiteralMapper {
   }
 }
 
-class HiveLiteralMapper extends LiteralMapper {
+class HiveLiteralMapper extends SqlLiteralMapper {
   def getDateFormatFromGrain(grain: Grain): String = {
     grain match {
       case DailyGrain => "YYYYMMdd"

--- a/core/src/main/scala/com/yahoo/maha/core/LiteralMapper.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/LiteralMapper.scala
@@ -158,12 +158,11 @@ class DruidLiteralMapper extends LiteralMapper {
           grain.toFormattedString(grain.fromFormattedString(value))
         }
       case TimestampType(fmt) =>
-        //TODO: validate format
         if(fmt.isDefined) {
           val dtf = DateTimeFormat.forPattern(fmt.get)
-          dtf.print(grain.fromFormattedString(value))
+          dtf.print(grain.fromFullFormattedString(value))
         } else {
-          grain.toFormattedString(grain.fromFormattedString(value))
+          grain.toFullFormattedString(grain.fromFullFormattedString(value))
         }
       case _ => value
     }

--- a/core/src/main/scala/com/yahoo/maha/core/UTCTimeProvider.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/UTCTimeProvider.scala
@@ -2,20 +2,11 @@
 // Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
 package com.yahoo.maha.core
 
-import com.yahoo.maha.core.request.{TimeZoneValue, Parameter, ReportingRequest}
-
-import scala.collection._
-
 /**
  * Created by hiral on 1/19/16.
  */
 trait UTCTimeProvider {
   def getUTCDayHourMinuteFilter(localTimeDayFilter: Filter, localTimeHourFilter: Option[Filter], localTimeMinuteFilter: Option[Filter], timezone: Option[String], isDebugEnabled: Boolean): (Filter, Option[Filter], Option[Filter])
-  def getTimezone(reportingRequest: ReportingRequest) : Option[String] = {
-    reportingRequest.additionalParameters.get(Parameter.TimeZone) collect {
-      case TimeZoneValue(value) => value
-    }
-  }
 }
 
 object PassThroughUTCTimeProvider extends UTCTimeProvider {

--- a/core/src/main/scala/com/yahoo/maha/core/UserTimeZoneProvider.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/UserTimeZoneProvider.scala
@@ -1,4 +1,4 @@
-package com.yahoo.maha.service
+package com.yahoo.maha.core
 
 import com.yahoo.maha.core.request.ReportingRequest
 
@@ -9,4 +9,3 @@ trait UserTimeZoneProvider {
 object NoopUserTimeZoneProvider extends UserTimeZoneProvider {
   def getTimeZone(request: ReportingRequest): Option[String] = None
 }
-

--- a/core/src/main/scala/com/yahoo/maha/core/fact/Fact.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/fact/Fact.scala
@@ -2057,6 +2057,9 @@ case class PublicFactTable private[fact](name: String
           case BetweenFilter(_,from,to) =>
             val fromDateMills = DailyGrain.fromFormattedString(from).getMillis
             availableFromDate.isBefore(fromDateMills) || availableFromDate.isEqual(fromDateMills)
+          case dtf: DateTimeBetweenFilter =>
+            val fromDateMills = dtf.fromDateTime.getMillis
+            availableFromDate.isBefore(fromDateMills) || availableFromDate.isEqual(fromDateMills)
           case InFilter(_,dates, _, _) =>
             val minDateMills = dates.map(DailyGrain.fromFormattedString(_).getMillis).min
             availableFromDate.isBefore(minDateMills) || availableFromDate.isEqual(minDateMills)

--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryGenerator.scala
@@ -294,14 +294,14 @@ object QueryGeneratorHelper {
     }
   }
 
-  def handleFilterRender(filter: Filter,
-                         publicFact: PublicFact,
-                         fact: Fact,
-                         aliasToNameMapFull: Map[String, String],
-                         queryContext: CombinedQueryContext,
-                         engine: Engine,
-                         literalMapper: LiteralMapper,
-                         colFn: Column => String): SqlResult = {
+  def handleFilterSqlRender(filter: Filter,
+                            publicFact: PublicFact,
+                            fact: Fact,
+                            aliasToNameMapFull: Map[String, String],
+                            queryContext: CombinedQueryContext,
+                            engine: Engine,
+                            literalMapper: SqlLiteralMapper,
+                            colFn: Column => String): SqlResult = {
     val fieldNames: mutable.ArrayBuffer[String] = new ArrayBuffer[String]()
     val isMultiField: Boolean = filter.isInstanceOf[MultiFieldForcedFilter]
 

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -425,7 +425,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
 
           val builder: TopNQueryBuilder = new TopNQueryBuilder()
             .dataSource(dataSource)
-            .intervals(getInterval(model))
+            .intervals(getInterval(model, fact))
             .granularity(getGranularity(queryContext))
             .metric(metric)
             .threshold(threshold)
@@ -457,7 +457,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
           && queryContext.requestModel.isTimeSeries) {
           val builder = Druids.newTimeseriesQueryBuilder()
             .dataSource(dataSource)
-            .intervals(getInterval(model))
+            .intervals(getInterval(model, fact))
             .granularity(getGranularity(queryContext))
             .context(context)
 
@@ -477,7 +477,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
         else {
           val builder = GroupByQuery.builder()
             .setDataSource(dataSource)
-            .setQuerySegmentSpec(getInterval(model))
+            .setQuerySegmentSpec(getInterval(model, fact))
             .setGranularity(getGranularity(queryContext))
             .setContext(context)
 
@@ -536,7 +536,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
 
         val builder = Druids.newScanQueryBuilder()
           .dataSource(dataSource)
-          .intervals(getInterval(model))
+          .intervals(getInterval(model, fact))
           .context(context)
 
         builder.limit(threshold)
@@ -673,7 +673,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
 
       val outerQueryBuilder = GroupByQuery.builder()
         .setDataSource(innerGroupByQueryBuilder.build())
-        .setQuerySegmentSpec(getInterval(queryContext.requestModel))
+        .setQuerySegmentSpec(getInterval(queryContext.requestModel, queryContext.factBestCandidate.fact))
         .setGranularity(getGranularity(queryContext))
         .setContext(context)
 
@@ -727,7 +727,12 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
       }
 
       if(hasExpensiveDateDimFilter) {
-        outerQueryDimFilterList ++= FilterDruid.renderDateDimFilters(queryContext.requestModel, queryContext.factBestCandidate.publicFact.aliasToNameColumnMap, queryContext.factBestCandidate.fact.columnsByNameMap, forOuterQuery = true)
+        outerQueryDimFilterList ++= FilterDruid.renderDateDimFilters(
+          queryContext.requestModel
+          , queryContext.factBestCandidate.publicFact.aliasToNameColumnMap
+          , queryContext.factBestCandidate.fact.columnsByNameMap
+          , queryContext.factBestCandidate.fact.grain
+          , forOuterQuery = true)
       }
 
       if (outerQueryDimFilterList.nonEmpty) {
@@ -765,7 +770,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
       //overwrite query
       val rowCountQueryBuilder = GroupByQuery.builder()
         .setDataSource(groupByQuery)
-        .setQuerySegmentSpec(getInterval(queryContext.requestModel))
+        .setQuerySegmentSpec(getInterval(queryContext.requestModel, queryContext.factBestCandidate.fact))
         .setGranularity(getGranularity(queryContext))
         .setContext(context)
       val countAggregatorFactory: AggregatorFactory = new CountAggregatorFactory(QueryRowList.ROW_COUNT_ALIAS)
@@ -828,24 +833,12 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     }
   }
 
-  private[this] def getInterval(model: RequestModel): QuerySegmentSpec = {
+  private[this] def getInterval(model: RequestModel, fact:Fact): QuerySegmentSpec = {
     model.utcTimeDayFilter match {
       case dtf: DateTimeBetweenFilter =>
         val f = dtf.fromDateTime
         //since to is exclusive, we add 1 unit
-        val t = {
-          val d = dtf.toDateTime
-          if(d.getMillisOfDay != 0)
-            d.plusMillis(1)
-          else if(d.getSecondOfMinute != 0)
-            d.plusSeconds(1)
-          else if(d.getMinuteOfHour != 0)
-            d.plusMinutes(1)
-          else if(d.getHourOfDay != 0)
-            d.plusHours(1)
-          else
-            d.plusDays(1)
-        }
+        val t = fact.grain.incrementOne(dtf.toDateTime)
         val interval = new Interval(f, t)
         new MultipleIntervalSegmentSpec(java.util.Arrays.asList(interval))
       case BetweenFilter(_, from, to) =>
@@ -1510,7 +1503,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
     val filters = queryContext.factBestCandidate.filters
     val whereFilters = new ArrayBuffer[DimFilter](filters.size)
     if (queryContext.factBestCandidate.publicFact.renderLocalTimeFilter) {
-      whereFilters ++= FilterDruid.renderDateDimFilters(queryContext.requestModel, queryContext.factBestCandidate.publicFact.aliasToNameColumnMap, fact.columnsByNameMap)
+      whereFilters ++= FilterDruid.renderDateDimFilters(queryContext.requestModel, queryContext.factBestCandidate.publicFact.aliasToNameColumnMap, fact.columnsByNameMap, fact.grain)
     }
     whereFilters
   }

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveOuterGroupByQueryGenerator.scala
@@ -211,7 +211,7 @@ abstract case class HiveOuterGroupByQueryGenerator(partitionColumnRenderer:Parti
             case any =>
               throw new UnsupportedOperationException(s"Found non fact column : $any")
           }
-        val result = QueryGeneratorHelper.handleFilterRender(filter, publicFact, fact, aliasToNameMapFull, null, HiveEngine, hiveLiteralMapper, colRenderFn)
+        val result = QueryGeneratorHelper.handleFilterSqlRender(filter, publicFact, fact, aliasToNameMapFull, null, HiveEngine, hiveLiteralMapper, colRenderFn)
 
         if (fact.dimColMap.contains(name)) {
           whereFilters += result.filter

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorCommon.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorCommon.scala
@@ -123,7 +123,7 @@ abstract class HiveQueryGeneratorCommon(partitionColumnRenderer:PartitionColumnR
             case any =>
               throw new UnsupportedOperationException(s"Found non fact column : $any")
           }
-        val result = QueryGeneratorHelper.handleFilterRender(filter, publicFact, fact, aliasToNameMapFull, queryContext, HiveEngine, hiveLiteralMapper, colRenderFn)
+        val result = QueryGeneratorHelper.handleFilterSqlRender(filter, publicFact, fact, aliasToNameMapFull, queryContext, HiveEngine, hiveLiteralMapper, colRenderFn)
 
         if (fact.dimColMap.contains(name)) {
           whereFilters += result.filter

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
@@ -1075,7 +1075,7 @@ b. Dim Driven
                 case any =>
                   throw new UnsupportedOperationException(s"Found non fact column : $any")
               }
-            val result = QueryGeneratorHelper.handleFilterRender(filter, publicFact, fact, publicFact.aliasToNameColumnMap, queryContext, OracleEngine, literalMapper, colRenderFn)
+            val result = QueryGeneratorHelper.handleFilterSqlRender(filter, publicFact, fact, publicFact.aliasToNameColumnMap, queryContext, OracleEngine, literalMapper, colRenderFn)
 
             if(fact.dimColMap.contains(name)) {
               whereFilters += result.filter

--- a/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
@@ -1075,7 +1075,7 @@ b. Dim Driven
                 case any =>
                   throw new UnsupportedOperationException(s"Found non fact column : $any")
               }
-            val result = QueryGeneratorHelper.handleFilterRender(filter, publicFact, fact, publicFact.aliasToNameColumnMap, queryContext, PostgresEngine, literalMapper, colRenderFn)
+            val result = QueryGeneratorHelper.handleFilterSqlRender(filter, publicFact, fact, publicFact.aliasToNameColumnMap, queryContext, PostgresEngine, literalMapper, colRenderFn)
 
             if(fact.dimColMap.contains(name)) {
               whereFilters += result.filter

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
@@ -156,7 +156,7 @@ abstract case class PrestoOuterGroupByQueryGenerator(partitionColumnRenderer:Par
               case any =>
                 throw new UnsupportedOperationException(s"Found non fact column : $any")
             }
-          val result = QueryGeneratorHelper.handleFilterRender(filter, publicFact, fact, aliasToNameMapFull, null, PrestoEngine, prestoLiteralMapper, colRenderFn)
+          val result = QueryGeneratorHelper.handleFilterSqlRender(filter, publicFact, fact, aliasToNameMapFull, null, PrestoEngine, prestoLiteralMapper, colRenderFn)
 
           if (fact.dimColMap.contains(name)) {
             whereFilters += result.filter

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
@@ -363,7 +363,7 @@ class PrestoQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, udfS
               case any =>
                 throw new UnsupportedOperationException(s"Found non fact column : $any")
             }
-          val result = QueryGeneratorHelper.handleFilterRender(filter, publicFact, fact, aliasToNameMapFull, queryContext, PrestoEngine, prestoLiteralMapper, colRenderFn)
+          val result = QueryGeneratorHelper.handleFilterSqlRender(filter, publicFact, fact, aliasToNameMapFull, queryContext, PrestoEngine, prestoLiteralMapper, colRenderFn)
 
           if (fact.dimColMap.contains(name)) {
             whereFilters += result.filter

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorV1.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorV1.scala
@@ -184,7 +184,7 @@ class PrestoQueryGeneratorV1(partitionColumnRenderer:PartitionColumnRenderer, ud
               case any =>
                 throw new UnsupportedOperationException(s"Found non fact column : $any")
             }
-          val result = QueryGeneratorHelper.handleFilterRender(filter, publicFact, fact, aliasToNameMapFull, queryContext, PrestoEngine, prestoLiteralMapper, colRenderFn)
+          val result = QueryGeneratorHelper.handleFilterSqlRender(filter, publicFact, fact, aliasToNameMapFull, queryContext, PrestoEngine, prestoLiteralMapper, colRenderFn)
 
           if (fact.dimColMap.contains(name)) {
             whereFilters += result.filter

--- a/core/src/main/scala/com/yahoo/maha/core/request/ReportingRequest.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/request/ReportingRequest.scala
@@ -91,6 +91,11 @@ case class ReportingRequest(cube: String
       additionalParameters(Parameter.Labels).asInstanceOf[LabelsValue].value
     } else List.empty
   }
+  def getTimezone : Option[String] = {
+    additionalParameters.get(Parameter.TimeZone) collect {
+      case TimeZoneValue(value) => value
+    }
+  }
 }
 
 trait BaseRequest {
@@ -316,6 +321,9 @@ trait BaseRequest {
         (date, date)
       case BetweenFilter(_,from,to) =>
         (DailyGrain.fromFormattedString(from), DailyGrain.fromFormattedString(to))
+      case dtf: DateTimeBetweenFilter =>
+        (DailyGrain.fromFormattedString(DailyGrain.toFormattedString(dtf.fromDateTime))
+          , DailyGrain.fromFormattedString(DailyGrain.toFormattedString(dtf.toDateTime)))
       case a =>
         throw new IllegalArgumentException(s"Cannot handle $dayFilter while sending scheduled email")
     }

--- a/core/src/test/scala/com/yahoo/maha/core/FilterTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/FilterTest.scala
@@ -9,7 +9,8 @@ import org.apache.druid.query.search.InsensitiveContainsSearchQuerySpec
 import org.apache.druid.segment.filter.BoundFilter
 import org.joda.time.DateTime
 import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.TreeSet
 
@@ -17,23 +18,26 @@ import scala.collection.immutable.TreeSet
  * Created by jians on 11/10/15.
  */
 
-class FilterTest extends FunSuite with Matchers {
+class FilterTest extends AnyFunSuite with Matchers {
+
+  System.setProperty("user.timezone", "GMT")
 
   val oracleLiteralMapper = new OracleLiteralMapper
+  val postgresLiteralMapper = new PostgresLiteralMapper
   val hiveLiteralMapper = new HiveLiteralMapper
-  val druidLiteralMapper = new DruidLiteralMapper
 
-  def render[T, O](renderer: FilterRenderer[T, O], filter: T, literalMapper: LiteralMapper, engine: Engine, column: Column, aliasToRenderedSqlMap: Map[String, (String, String)]) : O = {
+  def render[T, O](renderer: FilterRenderer[T, O], filter: T, literalMapper: SqlLiteralMapper, engine: Engine, column: Column, aliasToRenderedSqlMap: Map[String, (String, String)]) : O = {
     renderer.render(aliasToRenderedSqlMap, filter, literalMapper, column, engine, None)
   }
 
-  def renderWithGrain[T, O](renderer: FilterRenderer[T, O], filter: T, literalMapper: LiteralMapper, engine: Engine, column: Column, grain : Grain, aliasToRenderedSqlMap: Map[String, (String, String)]) : O = {
+  def renderWithGrain[T, O](renderer: FilterRenderer[T, O], filter: T, literalMapper: SqlLiteralMapper, engine: Engine, column: Column, grain : Grain, aliasToRenderedSqlMap: Map[String, (String, String)]) : O = {
     renderer.render(aliasToRenderedSqlMap, filter, literalMapper, column, engine, Some(grain))
   }
   
   implicit val columnContext: ColumnContext = new ColumnContext
   val col = DimCol("field1", StrType())
   val dateCol = DimCol("stats_date", DateType())
+  val timestampCol = DimCol("timestamp_date", TimestampType())
   val intDateCol = DimCol("date_sid", IntType(), annotations = Set(DayColumn("YYYYMMDD")))
   val strDateCol = DimCol("date_sid2", StrType(), annotations = Set(DayColumn("YYYYMMDD")))
   val insensitiveCol = DimCol("insensitive", StrType(), annotations = Set(CaseInsensitive))
@@ -62,6 +66,88 @@ class FilterTest extends FunSuite with Matchers {
     val strBetweenfilter = BetweenFilter("date_sid2", "2018-01-01", "2018-01-02")
     val strHourlyResult = renderWithGrain(SqlBetweenFilterRenderer, strBetweenfilter, oracleLiteralMapper, OracleEngine, strDateCol, HourlyGrain, Map("date_sid2" -> ("date_sid2", "date_sid2"))).filter
     strHourlyResult shouldBe "date_sid2 >= to_date('2018-01-01', 'HH24') AND date_sid2 <= to_date('2018-01-02', 'HH24')"
+  }
+
+  test("successfully render DateTimeBetweenFilter with daily and hourly grain and date type on oracle engine") {
+    val filter = DateTimeBetweenFilter(dateCol.name, "2018-01-01T01:10:50", "2018-01-06T10:20:30", "yyyy-MM-dd'T'HH:mm:ss")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, oracleLiteralMapper, OracleEngine, dateCol, DailyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    dailyResult shouldBe "stats_date >= to_date('2018-01-01', 'YYYY-MM-DD') AND stats_date <= to_date('2018-01-06', 'YYYY-MM-DD')"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, oracleLiteralMapper, OracleEngine, dateCol, HourlyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    hourlyResult shouldBe "stats_date >= to_date('2018-01-01', 'YYYY-MM-DD') AND stats_date <= to_date('2018-01-06', 'YYYY-MM-DD')"
+  }
+
+  test("successfully render DateTimeBetweenFilter with daily and hourly grain and timestamp type on oracle engine") {
+    val filter = DateTimeBetweenFilter(timestampCol.name, "2018-01-01T01:10:50", "2018-01-06T10:20:30", "yyyy-MM-dd'T'HH:mm:ss")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, oracleLiteralMapper, OracleEngine, timestampCol, DailyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    dailyResult shouldBe "timestamp_date >= TO_UTC_TIMESTAMP_TZ('2018-01-01T01:10:50.000Z') AND timestamp_date <= TO_UTC_TIMESTAMP_TZ('2018-01-06T10:20:30.000Z')"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, oracleLiteralMapper, OracleEngine, timestampCol, HourlyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    hourlyResult shouldBe "timestamp_date >= TO_UTC_TIMESTAMP_TZ('2018-01-01T01:10:50.000Z') AND timestamp_date <= TO_UTC_TIMESTAMP_TZ('2018-01-06T10:20:30.000Z')"
+  }
+
+  test("successfully render DateTimeBetweenFilter with daily and hourly grain and date type on postgres engine") {
+    val filter = DateTimeBetweenFilter(dateCol.name, "2018-01-01T01:10:50", "2018-01-06T10:20:30", "yyyy-MM-dd'T'HH:mm:ss")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, postgresLiteralMapper, PostgresEngine, dateCol, DailyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    dailyResult shouldBe "stats_date >= to_date('2018-01-01', 'YYYY-MM-DD') AND stats_date <= to_date('2018-01-06', 'YYYY-MM-DD')"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, postgresLiteralMapper, PostgresEngine, dateCol, HourlyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    hourlyResult shouldBe "stats_date >= to_date('2018-01-01', 'YYYY-MM-DD') AND stats_date <= to_date('2018-01-06', 'YYYY-MM-DD')"
+  }
+
+  test("successfully render DateTimeBetweenFilter with daily and hourly grain and timestamp type on postgres engine") {
+    val filter = DateTimeBetweenFilter(timestampCol.name, "2018-01-01T01:10:50", "2018-01-06T10:20:30", "yyyy-MM-dd'T'HH:mm:ss")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, postgresLiteralMapper, PostgresEngine, timestampCol, DailyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    dailyResult shouldBe "timestamp_date >= '2018-01-01T01:10:50.000Z'::timestamptz AND timestamp_date <= '2018-01-06T10:20:30.000Z'::timestamptz"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, postgresLiteralMapper, PostgresEngine, timestampCol, HourlyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    hourlyResult shouldBe "timestamp_date >= '2018-01-01T01:10:50.000Z'::timestamptz AND timestamp_date <= '2018-01-06T10:20:30.000Z'::timestamptz"
+  }
+
+  test("successfully render DateTimeBetweenFilter with daily and hourly grain and date type on hive engine") {
+    val filter = DateTimeBetweenFilter(dateCol.name, "2018-01-01T01:10:50", "2018-01-06T10:20:30", "yyyy-MM-dd'T'HH:mm:ss")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, hiveLiteralMapper, HiveEngine, dateCol, DailyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    dailyResult shouldBe "stats_date >= cast('2018-01-01' as date) AND stats_date <= cast('2018-01-06' as date)"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, hiveLiteralMapper, HiveEngine, dateCol, HourlyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    hourlyResult shouldBe "stats_date >= cast('2018-01-01' as date) AND stats_date <= cast('2018-01-06' as date)"
+  }
+
+  test("successfully render DateTimeBetweenFilter with daily and hourly grain and timestamp type on hive engine") {
+    val filter = DateTimeBetweenFilter(timestampCol.name, "2018-01-01T01:10:50", "2018-01-06T10:20:30", "yyyy-MM-dd'T'HH:mm:ss")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, hiveLiteralMapper, HiveEngine, timestampCol, DailyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    dailyResult shouldBe "timestamp_date >= cast('2018-01-01T01:10:50.000' as timestamp) AND timestamp_date <= cast('2018-01-06T10:20:30.000' as timestamp)"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, hiveLiteralMapper, HiveEngine, timestampCol, HourlyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    hourlyResult shouldBe "timestamp_date >= cast('2018-01-01T01:10:50.000' as timestamp) AND timestamp_date <= cast('2018-01-06T10:20:30.000' as timestamp)"
+  }
+
+  test("successfully render DateTimeBetweenFilter with daily and hourly grain and date type on presto engine") {
+    val filter = DateTimeBetweenFilter(dateCol.name, "2018-01-01T01:10:50", "2018-01-06T10:20:30", "yyyy-MM-dd'T'HH:mm:ss")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, hiveLiteralMapper, PrestoEngine, dateCol, DailyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    dailyResult shouldBe "stats_date >= date('2018-01-01') AND stats_date <= date('2018-01-06')"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, hiveLiteralMapper, PrestoEngine, dateCol, HourlyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    hourlyResult shouldBe "stats_date >= date('2018-01-01') AND stats_date <= date('2018-01-06')"
+  }
+
+  test("successfully render DateTimeBetweenFilter with daily and hourly grain and timestamp type on presto engine") {
+    val filter = DateTimeBetweenFilter(timestampCol.name, "2018-01-01T01:10:50", "2018-01-06T10:20:30", "yyyy-MM-dd'T'HH:mm:ss")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, hiveLiteralMapper, PrestoEngine, timestampCol, DailyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    dailyResult shouldBe "timestamp_date >= from_iso8601_timestamp('2018-01-01T01:10:50.000Z') AND timestamp_date <= from_iso8601_timestamp('2018-01-06T10:20:30.000Z')"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, hiveLiteralMapper, PrestoEngine, timestampCol, HourlyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    hourlyResult shouldBe "timestamp_date >= from_iso8601_timestamp('2018-01-01T01:10:50.000Z') AND timestamp_date <= from_iso8601_timestamp('2018-01-06T10:20:30.000Z')"
+  }
+
+  //we only need to test one engine here since only diff is the timezone input
+  test("successfully render DateTimeBetweenFilter with input zone offset, daily and hourly grain and date type on oracle engine") {
+    val filter = DateTimeBetweenFilter(dateCol.name, "2018-01-01T01:10:50+08:00", "2018-01-06T10:20:30+08:00", "yyyy-MM-dd'T'HH:mm:ssZZ")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, oracleLiteralMapper, OracleEngine, dateCol, DailyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    dailyResult shouldBe "stats_date >= to_date('2017-12-31', 'YYYY-MM-DD') AND stats_date <= to_date('2018-01-06', 'YYYY-MM-DD')"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, oracleLiteralMapper, OracleEngine, dateCol, HourlyGrain, Map("stats_date" -> ("stats_date", "stats_date"))).filter
+    hourlyResult shouldBe "stats_date >= to_date('2017-12-31', 'YYYY-MM-DD') AND stats_date <= to_date('2018-01-06', 'YYYY-MM-DD')"
+  }
+
+  //we only need to test one engine here since only diff is the timezone input
+  test("successfully render DateTimeBetweenFilter with input zone offset, daily and hourly grain and timestamp type on oracle engine") {
+    val filter = DateTimeBetweenFilter(timestampCol.name, "2018-01-01T01:10:50+08:00", "2018-01-06T10:20:30+08:00", "yyyy-MM-dd'T'HH:mm:ssZZ")
+    val dailyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, oracleLiteralMapper, OracleEngine, timestampCol, DailyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    dailyResult shouldBe "timestamp_date >= TO_UTC_TIMESTAMP_TZ('2017-12-31T17:10:50.000Z') AND timestamp_date <= TO_UTC_TIMESTAMP_TZ('2018-01-06T02:20:30.000Z')"
+    val hourlyResult = renderWithGrain(SqlDateTimeBetweenFilterRenderer, filter, oracleLiteralMapper, OracleEngine, timestampCol, HourlyGrain, Map("timestamp_date" -> ("timestamp_date", "timestamp_date"))).filter
+    hourlyResult shouldBe "timestamp_date >= TO_UTC_TIMESTAMP_TZ('2017-12-31T17:10:50.000Z') AND timestamp_date <= TO_UTC_TIMESTAMP_TZ('2018-01-06T02:20:30.000Z')"
   }
 
   test("Filter Types in Druid should return valid MaxDate") {
@@ -238,7 +324,7 @@ class FilterTest extends FunSuite with Matchers {
       , "field2" -> ("stats_date", "field2")
       , "field3" -> ("date_sid", "field3"))
     val engine : Engine = OracleEngine
-    val mapper : LiteralMapper = oracleLiteralMapper
+    val mapper : SqlLiteralMapper = oracleLiteralMapper
     val grainOption : Option[Grain] = Some(DailyGrain)
     val retVal = FilterSql.renderFilterWithAlias(orFilter, aliasToRenderedSqlMap, orCol, engine, mapper, grainOption)
     val expectedRenderedString : String = "(field1 IN ('abc','def','ghi')) OR (field2 >= trunc(to_date('def', 'YYYY-MM-DD')) AND field2 <= trunc(to_date('ghi', 'YYYY-MM-DD'))) OR (field3 = to_date('ghi', 'YYYY-MM-DD'))"
@@ -288,7 +374,7 @@ class FilterTest extends FunSuite with Matchers {
       , "field2" -> ("stats_date", "field2")
       , "field3" -> ("date_sid", "field3"))
     val engine : Engine = OracleEngine
-    val mapper : LiteralMapper = oracleLiteralMapper
+    val mapper : SqlLiteralMapper = oracleLiteralMapper
     val grainOption : Option[Grain] = Some(DailyGrain)
     val retVal = FilterSql.renderFilterWithAlias(andFilter, aliasToRenderedSqlMap, andCol, engine, mapper, grainOption)
     val expectedRenderedString : String = "(field1 IN ('abc','def','ghi')) AND (field2 >= trunc(to_date('def', 'YYYY-MM-DD')) AND field2 <= trunc(to_date('ghi', 'YYYY-MM-DD'))) AND (field3 = to_date('ghi', 'YYYY-MM-DD'))"
@@ -333,7 +419,7 @@ class FilterTest extends FunSuite with Matchers {
   test("BetweenFilter should fail for Druid engine") {
     val filter = BetweenFilter("filed1", "abc", "def")
     val thrown = intercept[IllegalArgumentException] {
-      render(SqlBetweenFilterRenderer, filter, druidLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
+      render(SqlBetweenFilterRenderer, filter, oracleLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
     }
     thrown.getMessage should startWith ("Unsupported engine for BetweenFilterRenderer Druid")
   }
@@ -346,7 +432,7 @@ class FilterTest extends FunSuite with Matchers {
   test("InFilter should fail for Druid engine") {
     val filter = InFilter("filed1", List("abc", "ads"))
     val thrown = intercept[IllegalArgumentException] {
-      render(SqlInFilterRenderer, filter, druidLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
+      render(SqlInFilterRenderer, filter, oracleLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
     }
     thrown.getMessage should startWith ("Unsupported engine for InFilterRenderer Druid")
   }
@@ -354,7 +440,7 @@ class FilterTest extends FunSuite with Matchers {
   test("NotInFilter should fail for Druid engine") {
     val filter = NotInFilter("filed1", List("abc", "ads"))
     val thrown = intercept[IllegalArgumentException] {
-      render(SqlNotInFilterRenderer, filter, druidLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
+      render(SqlNotInFilterRenderer, filter, oracleLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
     }
     thrown.getMessage should startWith ("Unsupported engine for NotInFilterRenderer Druid")
   }
@@ -362,7 +448,7 @@ class FilterTest extends FunSuite with Matchers {
   test("EqualityFilter should fail for Druid engine") {
     val filter = EqualityFilter("filed1", "abc")
     val thrown = intercept[IllegalArgumentException] {
-      render(SqlEqualityFilterRenderer, filter, druidLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
+      render(SqlEqualityFilterRenderer, filter, oracleLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
     }
     thrown.getMessage should startWith ("Unsupported engine for EqualityFilterRenderer Druid")
   }
@@ -370,27 +456,24 @@ class FilterTest extends FunSuite with Matchers {
   test("LikeFilter should fail for Druid engine") {
     val filter = LikeFilter("filed1", "ads")
     val thrown = intercept[IllegalArgumentException] {
-      render(SqlLikeFilterRenderer, filter, druidLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
+      render(SqlLikeFilterRenderer, filter, oracleLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
     }
     thrown.getMessage should startWith ("Unsupported engine for LikeFilterRenderer Druid")
   }
 
   test("SqlLikeFilterRenderer edit strings") {
     val filter = LikeFilter("%sfield__1", "ad%s")
-    val intFilter = LikeFilter("%sfield__2", "ads")
     val normalFilter = LikeFilter("field1", "ads")
-    val rendered = render(SqlLikeFilterRenderer, filter, druidLiteralMapper, OracleEngine, escapedCol,  Map("%sfield__1" -> ("%sfield__1", "%sfield__1")))
-    val renderedInt = render(SqlLikeFilterRenderer, intFilter, druidLiteralMapper, OracleEngine, escapedIntCol,  Map("%sfield__2" -> ("%sfield__2", "%sfield__2")))
-    val renderedNonEscaped = render(SqlLikeFilterRenderer, normalFilter, druidLiteralMapper, OracleEngine, col,  Map("field1" -> ("field1", "field1")))
+    val rendered = render(SqlLikeFilterRenderer, filter, oracleLiteralMapper, OracleEngine, escapedCol,  Map("%sfield__1" -> ("%sfield__1", "%sfield__1")))
+    val renderedNonEscaped = render(SqlLikeFilterRenderer, normalFilter, oracleLiteralMapper, OracleEngine, col,  Map("field1" -> ("field1", "field1")))
     assert(rendered.isInstanceOf[DefaultResult])
-    assert(renderedInt.isInstanceOf[DefaultResult])
     assert(renderedNonEscaped.isInstanceOf[DefaultResult])
   }
 
   test("NotEqualToFilter should fail for Druid engine") {
     val filter = NotEqualToFilter("filed1", "ads")
     val thrown = intercept[IllegalArgumentException] {
-      render(SqlNotEqualToFilterRenderer, filter, druidLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
+      render(SqlNotEqualToFilterRenderer, filter, oracleLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
     }
     thrown.getMessage should startWith ("Unsupported engine for NotEqualToFilterRenderer Druid")
   }
@@ -403,7 +486,7 @@ class FilterTest extends FunSuite with Matchers {
   test("IsNullFilter should fail for Druid engine") {
     val filter = IsNullFilter("filed1")
     val thrown = intercept[IllegalArgumentException] {
-      render(SqlIsNullFilterRenderer, filter, druidLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
+      render(SqlIsNullFilterRenderer, filter, oracleLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
     }
     thrown.getMessage should startWith ("Unsupported engine for IsNullFilterRenderer Druid")
   }
@@ -411,7 +494,7 @@ class FilterTest extends FunSuite with Matchers {
   test("IsNotNullFilter should fail for Druid engine") {
     val filter = IsNotNullFilter("filed1")
     val thrown = intercept[IllegalArgumentException] {
-      render(SqlIsNotNullFilterRenderer, filter, druidLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
+      render(SqlIsNotNullFilterRenderer, filter, oracleLiteralMapper, DruidEngine, col,  Map("filed1" -> ("filed1", "filed1")))
     }
     thrown.getMessage should startWith ("Unsupported engine for IsNotNullFilterRenderer Druid")
   }

--- a/core/src/test/scala/com/yahoo/maha/core/ReportingRequestTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/ReportingRequestTest.scala
@@ -89,7 +89,7 @@ class ReportingRequestTest extends FlatSpec {
                               {"field": "Product ID", "operator": "<>", "value": "-3"},
                               {"field": "Match Type", "operator": "isnull"},
                               {"field": "Pricing Type", "operator": "isnotnull"},
-                              {"field": "Day", "operator": "between", "from": "2014-04-01", "to": "2014-04-30"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "2014-04-01T00:00:00.000Z", "to": "2014-04-30T00:00:00.000Z", "format": "yyyy-MM-dd'T'HH:mm:ss.SSSZZ"},
                               {"field": "Turtles", "operator": "==", "compareTo": "Llamas"},
                               {"field": "Viewers", "operator": ">", "value": "10"},
                               {"field": "Viewees", "operator": "<", "value": "10"}
@@ -105,12 +105,15 @@ class ReportingRequestTest extends FlatSpec {
     val request: ReportingRequest = getReportingRequest(jsonString, AdvertiserSchema)
     assert(request.requestType === AsyncRequest)
     val ser = new String(ReportingRequest.serialize(request), StandardCharsets.UTF_8)
+    val deser = getReportingRequest(ser, AdvertiserSchema)
 
+    assert(request === deser)
     assert(request.numDays === 29)
-    assert(request.dayFilter.operator === BetweenFilterOperation)
-    assert(request.dayFilter.asInstanceOf[BetweenFilter].field === "Day")
-    assert(request.dayFilter.asInstanceOf[BetweenFilter].from === "2014-04-01")
-    assert(request.dayFilter.asInstanceOf[BetweenFilter].to === "2014-04-30")
+    assert(request.dayFilter.operator === DateTimeBetweenFilterOperation)
+    assert(request.dayFilter.asInstanceOf[DateTimeBetweenFilter].field === "Day")
+    assert(request.dayFilter.asInstanceOf[DateTimeBetweenFilter].from === "2014-04-01T00:00:00.000Z")
+    assert(request.dayFilter.asInstanceOf[DateTimeBetweenFilter].to === "2014-04-30T00:00:00.000Z")
+    assert(request.dayFilter.asInstanceOf[DateTimeBetweenFilter].format === "yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
   }
 
   "ReportingRequest" should "should be extracted from a json object as sync request" in {
@@ -135,7 +138,46 @@ class ReportingRequestTest extends FlatSpec {
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     assert(request.requestType === SyncRequest)
     val ser = new String(ReportingRequest.serialize(request), StandardCharsets.UTF_8)
+    val deser = getReportingRequestSync(ser)
 
+    assert(request === deser)
+    assert(request.dayFilter.operator === BetweenFilterOperation)
+    assert(request.dayFilter.asInstanceOf[BetweenFilter].field === "Day")
+    assert(request.dayFilter.asInstanceOf[BetweenFilter].from === "2014-04-01")
+    assert(request.dayFilter.asInstanceOf[BetweenFilter].to === "2014-04-30")
+  }
+
+  "ReportingRequest" should "fail when datetime between filter with Hour and Minute filters are provided" in {
+    val jsonString = s"""{
+                          "cube": "k_stats_minute_grain",
+                          "selectFields": [
+                            {"field": "Week"},
+                            {"field": "Keyword ID"},
+                            {"field": "Keyword Value"},
+                            {"field": "Source"},
+                            {"field": "Clicks"},
+                            {"field": "CTR"},
+                            {"field": "Reblogs"},
+                            {"field": "Reblog Rate"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "datetimebetween", "from": "2020-01-01T00:00:00.000Z", "to": "2020-01-07T00:00:00.000Z", "format": "yyyy-MM-dd'T'HH:mm:ss.SSSZZ"},
+                            {"field": "Hour", "operator": "between", "from": "02", "to": "05"},
+                            {"field": "Minute", "operator": "between", "from": "59", "to": "03"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "12345"}
+                          ],
+                          "sortBy": [
+                            {"field": "Impressions", "order": "Desc"}
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                        }"""
+    val request: ValidationNel[JsonScalaz.Error, ReportingRequest] = getReportingRequestValidation(jsonString, AdvertiserSchema)
+    request.leftMap { nel =>
+      require(nel.list.exists(e => e.toString.contains("UncategorizedError") && e.toString.contains("Day and Hour filters operator mismatch") === true),
+        s"invalid json format did not throw error: $request")
+    }
   }
 
   "ReportingRequest without filters (except Day)" should "should be extracted from a json object" in {

--- a/core/src/test/scala/com/yahoo/maha/core/RequestModelTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/RequestModelTest.scala
@@ -18,7 +18,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.json4s.JObject
 import org.scalatest.{FunSuite, Matchers}
 
-import scala.util.Random
+import scala.util.{Random, Try}
 
 /**
  * Created by jians on 10/23/15.
@@ -27,10 +27,15 @@ class RequestModelTest extends FunSuite with Matchers {
   
   CoreSchema.register()
 
+  private[this] val iso8601Format = DateTimeBetweenFilterHelper.iso8601FormatString
   private[this] val fromDate = DailyGrain.toFormattedString(DateTime.now(DateTimeZone.UTC).minusDays(7))
   private[this] val toDate = DailyGrain.toFormattedString(DateTime.now(DateTimeZone.UTC))
+  private[this] val fromDateTime = DateTimeBetweenFilterHelper.iso8601FormattedString(DateTime.now(DateTimeZone.UTC).minusDays(7))
+  private[this] val toDateTime = DateTimeBetweenFilterHelper.iso8601FormattedString(DateTime.now(DateTimeZone.UTC))
   private[this] val futureFromDate = DailyGrain.toFormattedString(DateTime.now(DateTimeZone.UTC).plusDays(1))
   private[this] val futureToDate = DailyGrain.toFormattedString(DateTime.now(DateTimeZone.UTC).plusDays(7))
+  private[this] val futureFromDateTime = DateTimeBetweenFilterHelper.iso8601FormattedString(DateTime.now(DateTimeZone.UTC).plusDays(1))
+  private[this] val futureToDateTime = DateTimeBetweenFilterHelper.iso8601FormattedString(DateTime.now(DateTimeZone.UTC).plusDays(7))
 
   protected[this] def getMaxDaysWindow: Map[(RequestType, Grain), Int] = {
     val interval = DailyGrain.getDaysBetween(fromDate, toDate)
@@ -481,6 +486,14 @@ class RequestModelTest extends FunSuite with Matchers {
     registryBuilder.build(factEstimator = new DefaultFactEstimator(Set("*-productAd","advertiser-ad","advertiser-adgroup","advertiser-campaign", "advertiser-campaign-adgroup", "advertiser-adgroup-ad", "advertiser-campaign-adgroup-ad")))
   }
 
+  def getRequestModel(request: ReportingRequest
+                      , registry: Registry
+                      , userTimeZoneProvider: UserTimeZoneProvider = NoopUserTimeZoneProvider
+                      , utcTimeProvider: UTCTimeProvider = PassThroughUTCTimeProvider
+                      , revision: Option[Int] = None): Try[RequestModel] = {
+    RequestModel.from(request, registry, userTimeZoneProvider, utcTimeProvider, revision)
+  }
+
   lazy val defaultRegistry: Registry = getDefaultRegistry()
 
   test("create model should fail when non existing cube requested") {
@@ -508,7 +521,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val registryBuilder = new RegistryBuilder
     val registry = registryBuilder.build()
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.failed.get.getMessage should startWith ("cube does not exist")
   }
 
@@ -534,7 +547,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
   }
 
@@ -560,7 +573,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
   }
 
@@ -584,7 +597,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
   }
 
@@ -608,7 +621,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
   }
 
@@ -632,7 +645,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith (s"requirement failed: ${UnknownFieldNameError("Field")}")
   }
@@ -658,7 +671,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith (s"requirement failed: ${UnknownFieldNameError("Filter")}")
   }
@@ -684,7 +697,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith ("requirement failed: Failed to determine dim or fact source for ordering by Blah")
   }
@@ -710,7 +723,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith ("requirement failed: Ordering fields must be in requested fields")
   }
@@ -739,7 +752,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith (s"requirement failed: ${UnknownFieldNameError("Site ID")}")
   }
@@ -766,7 +779,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith (s"requirement failed: ${NoRelationWithPrimaryKeyError(request.cube, "Site ID", Option("Site Status"))}")
   }
@@ -794,7 +807,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith (s"requirement failed: ${NoRelationWithPrimaryKeyError(request.cube, "Site ID")}")
   }
@@ -821,7 +834,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith (s"requirement failed: ${NoRelationWithPrimaryKeyError(request.cube, "Site ID", Option("Site Status"))}")
   }
@@ -847,7 +860,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith ("requirement failed: No candidates found for request!")
   }
@@ -873,7 +886,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(res.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(res.toOption.get.hasDimFilters)
@@ -907,7 +920,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(res.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(res.toOption.get.hasDimFilters)
@@ -945,7 +958,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(res.toOption.get.isFactDriven, "Request should be fact driven but isn't!")
     assert(res.toOption.get.hasDimFilters)
@@ -983,7 +996,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(!res.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(res.toOption.get.hasDimFilters)
@@ -1020,7 +1033,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(res.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(!res.toOption.get.hasDimFilters)
@@ -1058,7 +1071,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(!res.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res.toOption.get.hasDimFilters)
@@ -1095,7 +1108,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(!res.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res.toOption.get.hasDimFilters)
@@ -1129,7 +1142,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(!res.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res.toOption.get.hasDimFilters)
@@ -1164,7 +1177,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(!res.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res.toOption.get.hasDimFilters)
@@ -1201,7 +1214,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(!res.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(res.toOption.get.hasDimFilters)
@@ -1239,7 +1252,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(!res.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res.toOption.get.hasDimFilters)
@@ -1294,7 +1307,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request1: ReportingRequest = getReportingRequestSync(jsonString1)
     val registry = defaultRegistry
-    val res1 = RequestModel.from(request1, registry)
+    val res1 = getRequestModel(request1, registry)
     assert(res1.isSuccess, s"Create model failed : $res1")
     assert(!res1.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res1.toOption.get.hasDimFilters)
@@ -1306,7 +1319,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
 
     val request2: ReportingRequest = getReportingRequestSync(jsonString2)
-    val res2 = RequestModel.from(request2, registry)
+    val res2 = getRequestModel(request2, registry)
     assert(res2.isSuccess, s"Create model failed : $res2")
     assert(!res2.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res2.toOption.get.hasDimFilters)
@@ -1360,7 +1373,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request1: ReportingRequest = getReportingRequestAsync(jsonString1)
     val registry = defaultRegistry
-    val res1 = RequestModel.from(request1, registry)
+    val res1 = getRequestModel(request1, registry)
     assert(res1.isSuccess, s"Create model failed : $res1")
     assert(!res1.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res1.toOption.get.hasDimFilters)
@@ -1370,7 +1383,7 @@ class RequestModelTest extends FunSuite with Matchers {
     assert(!res1.toOption.get.hasFactSortBy)
 
     val request2: ReportingRequest = getReportingRequestAsync(jsonString2)
-    val res2 = RequestModel.from(request2, registry)
+    val res2 = getRequestModel(request2, registry)
     assert(res2.isSuccess, s"Create model failed : $res2")
     assert(!res2.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res2.toOption.get.hasDimFilters)
@@ -1424,7 +1437,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request1: ReportingRequest = getReportingRequestSync(jsonString1)
     val registry = defaultRegistry
-    val res1 = RequestModel.from(request1, registry)
+    val res1 = getRequestModel(request1, registry)
     assert(res1.isSuccess, s"Create model failed : $res1")
     assert(res1.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(res1.toOption.get.hasDimFilters)
@@ -1438,7 +1451,7 @@ class RequestModelTest extends FunSuite with Matchers {
     assert(res1.get.publicDimToJoinTypeMap("campaign") == InnerJoin, "Should inner join as request is filtering on dim")
 
     val request2: ReportingRequest = getReportingRequestSync(jsonString2)
-    val res2 = RequestModel.from(request2, registry)
+    val res2 = getRequestModel(request2, registry)
     assert(res2.isSuccess, s"Create model failed : $res2")
     assert(res2.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(res2.toOption.get.hasDimFilters)
@@ -1500,7 +1513,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request1: ReportingRequest = getReportingRequestAsync(jsonString1)
     val registry = defaultRegistry
-    val res1 = RequestModel.from(request1, registry)
+    val res1 = getRequestModel(request1, registry)
     assert(res1.isSuccess, s"Create model failed : $res1")
     assert(!res1.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(res1.toOption.get.hasDimFilters)
@@ -1512,7 +1525,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
 
     val request2: ReportingRequest = getReportingRequestAsync(jsonString2)
-    val res2 = RequestModel.from(request2, registry)
+    val res2 = getRequestModel(request2, registry)
     assert(res2.isSuccess, s"Create model failed : $res2")
     assert(!res2.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(res2.toOption.get.hasDimFilters)
@@ -1571,7 +1584,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request1: ReportingRequest = getReportingRequestSync(jsonString1)
     val registry = defaultRegistry
-    val res1 = RequestModel.from(request1, registry)
+    val res1 = getRequestModel(request1, registry)
     assert(res1.isSuccess, s"Create model failed : $res1")
     assert(!res1.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res1.toOption.get.hasDimFilters)
@@ -1585,7 +1598,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
 
     val request2: ReportingRequest = getReportingRequestSync(jsonString2)
-    val res2 = RequestModel.from(request2, registry)
+    val res2 = getRequestModel(request2, registry)
     assert(res2.isSuccess, s"Create model failed : $res2")
     assert(!res2.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res2.toOption.get.hasDimFilters)
@@ -1644,7 +1657,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request1: ReportingRequest = getReportingRequestAsync(jsonString1)
     val registry = defaultRegistry
-    val res1 = RequestModel.from(request1, registry)
+    val res1 = getRequestModel(request1, registry)
     assert(res1.isSuccess, s"Create model failed : $res1")
     assert(!res1.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res1.toOption.get.hasDimFilters)
@@ -1656,7 +1669,7 @@ class RequestModelTest extends FunSuite with Matchers {
     assert(res1.toOption.get.factFilters.map(_.field).contains("Advertiser ID"))
 
     val request2: ReportingRequest = getReportingRequestAsync(jsonString2)
-    val res2 = RequestModel.from(request2, registry)
+    val res2 = getRequestModel(request2, registry)
     assert(res2.isSuccess, s"Create model failed : $res2")
     assert(!res2.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res2.toOption.get.hasDimFilters)
@@ -1716,7 +1729,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request1: ReportingRequest = getReportingRequestSync(jsonString1)
     val registry = defaultRegistry
-    val res1 = RequestModel.from(request1, registry)
+    val res1 = getRequestModel(request1, registry)
     assert(res1.isSuccess, s"Create model failed : $res1")
     assert(res1.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(!res1.toOption.get.hasDimFilters)
@@ -1730,7 +1743,7 @@ class RequestModelTest extends FunSuite with Matchers {
     assert(res1.get.publicDimToJoinTypeMap("campaign") == LeftOuterJoin, "Should left outer join as request is not filtering on dim")
 
     val request2: ReportingRequest = getReportingRequestSync(jsonString2)
-    val res2 = RequestModel.from(request2, registry)
+    val res2 = getRequestModel(request2, registry)
     assert(res2.isSuccess, s"Create model failed : $res2")
     assert(res2.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(!res2.toOption.get.hasDimFilters)
@@ -1792,7 +1805,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request1: ReportingRequest = getReportingRequestAsync(jsonString1)
     val registry = defaultRegistry
-    val res1 = RequestModel.from(request1, registry)
+    val res1 = getRequestModel(request1, registry)
     assert(res1.isSuccess, s"Create model failed : $res1")
     assert(!res1.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res1.toOption.get.hasDimFilters)
@@ -1804,7 +1817,7 @@ class RequestModelTest extends FunSuite with Matchers {
     assert(res1.toOption.get.factFilters.map(_.field).contains("Advertiser ID"))
 
     val request2: ReportingRequest = getReportingRequestAsync(jsonString2)
-    val res2 = RequestModel.from(request2, registry)
+    val res2 = getRequestModel(request2, registry)
     assert(res2.isSuccess, s"Create model failed : $res2")
     assert(!res2.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(!res2.toOption.get.hasDimFilters)
@@ -1840,7 +1853,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(res.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(res.toOption.get.hasDimFilters)
@@ -1881,8 +1894,36 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, res.errorMessage("Create model failed "))
+  }
+
+  test("create model should fail when from date is in future with datetime between filter") {
+
+    val jsonString = s"""{
+                          "cube": "publicFact",
+                          "selectFields": [
+                              {"field": "Advertiser ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Report Type", "value" : "MyType"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$futureFromDateTime", "to": "$futureToDateTime", "format": "$iso8601Format"},
+                              {"field": "Campaign Status", "operator": "=", "value": "active"}
+                          ],
+                          "sortBy": [
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val res = getRequestModel(request, registry)
+    assert(res.isFailure && res.failed.toOption.get.getMessage.contains("ERROR_CODE:10006")
+      , res.errorMessage("Should be like requirement failed: ERROR_CODE:10006 Querying for future date 2020-07-23 is not supported"))
   }
 
   test("create model should fail when all dates are in future") {
@@ -1907,7 +1948,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
      val request: ReportingRequest = getReportingRequestSync(jsonString)
      val registry = defaultRegistry
-     val res = RequestModel.from(request, registry)
+     val res = getRequestModel(request, registry)
      assert(res.isFailure, res.errorMessage("Create model failed "))
    }
 
@@ -1933,7 +1974,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
   }
 
@@ -1960,7 +2001,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(res.toOption.get.isDimDriven, "Request should be dim driven but isn't!")
     assert(res.toOption.get.hasDimFilters)
@@ -2000,7 +2041,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(res.toOption.get.isFactDriven, "Request should be fact driven but isn't!")
     assert(res.toOption.get.hasDimFilters)
@@ -2040,7 +2081,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
     assert(!res.toOption.get.isDimDriven, "Request should not be dim driven but is!")
     assert(res.toOption.get.hasDimFilters)
@@ -2077,7 +2118,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith ("requirement failed: required filter for cube=publicFact, schema=advertiser, fact=fact1 not found = Set(Advertiser ID)")
   }
@@ -2107,7 +2148,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -2159,7 +2200,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -2213,7 +2254,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -2261,7 +2302,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, s"$res")
     val model = res.toOption.get
     assert(model.requestCols.size === 2)
@@ -2309,7 +2350,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 2)
@@ -2357,7 +2398,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 2)
@@ -2400,7 +2441,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, s"$res")
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -2447,7 +2488,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, s"$res")
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -2498,7 +2539,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -2539,7 +2580,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 5)
@@ -2598,7 +2639,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
 
@@ -2671,7 +2712,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -2731,7 +2772,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -2793,7 +2834,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -2854,7 +2895,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -2909,7 +2950,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -2965,7 +3006,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -3018,7 +3059,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -3069,7 +3110,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -3127,7 +3168,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -3184,7 +3225,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -3239,7 +3280,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -3294,7 +3335,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -3354,7 +3395,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -3415,7 +3456,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -3484,7 +3525,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -3553,7 +3594,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -3637,7 +3678,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 4)
@@ -3720,7 +3761,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.factFilters.size === 2)
@@ -3755,7 +3796,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.factFilters.size === 2)
@@ -3789,7 +3830,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "request model should fail")
     res.failed.get.getMessage should startWith ("requirement failed: Unsupported filter operation : cube=publicFact, col=Clicks, operation=Between")
   }
@@ -3817,7 +3858,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "request model should fail")
     res.failed.get.getMessage should startWith ("requirement failed: Unsupported filter operation : cube=publicFact, col=Source, operation=Between")
   }
@@ -3844,7 +3885,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "request model should fail")
     res.failed.get.getMessage should startWith ("requirement failed: Unsupported filter operation : dimension=campaign, col=Campaign Status, operation=Between")
   }
@@ -3871,7 +3912,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "request model should fail")
     res.failed.get.getMessage should startWith ("requirement failed: Missing required field: cube=publicFact2, field=Keyword ID")
   }
@@ -3899,7 +3940,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("request model should succeed"))
   }
 
@@ -3922,8 +3963,56 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, res.errorMessage("Should be : Max days window exceeded expected=8, actual=20 for cube/fact=publicFact2"))
+  }
+
+  test("""create model should fail when request dates out of window with datetime between filter""") {
+    val jsonString = s"""{
+                          "cube": "publicFact2",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Keyword Status"},
+                              {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "2016-09-01T00:00:00.000Z", "to": "2016-09-21T00:00:00.000Z", "format": "$iso8601Format"}
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = defaultRegistry
+    val res = getRequestModel(request, registry)
+    assert(res.isFailure && res.failed.toOption.get.getMessage.contains("ERROR_CODE:10001")
+      , res.errorMessage("Should be : Max days window exceeded expected=8, actual=20 for cube/fact=publicFact2"))
+  }
+
+  test("""create model should fail when request dates out of lookback window with datetime between filter""") {
+    val jsonString = s"""{
+                          "cube": "publicFact2",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Keyword Status"},
+                              {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "2016-09-01T00:00:00.000Z", "to": "2016-09-07T00:00:00.000Z", "format": "$iso8601Format"}
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = defaultRegistry
+    val res = getRequestModel(request, registry)
+    assert(res.isFailure && res.failed.toOption.get.getMessage.contains("ERROR_CODE:10002")
+      , res.errorMessage("Should be like requirement failed: ERROR_CODE:10002 Max look back window exceeded expected=17, actual=1420 for cube/fact=publicFact2"))
   }
 
   test("""create model should fail when missing required filter""") {
@@ -3949,7 +4038,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "request model should fail")
     res.failed.get.getMessage should startWith ("requirement failed: Missing required filter: cube=publicFact3, field=Ad Group ID")
   }
@@ -3978,7 +4067,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("request model should succeed"))
   }
 
@@ -4006,7 +4095,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "request model should fail")
     res.failed.get.getMessage should startWith ("requirement failed: Missing dependent column : cube=publicFact2, field=Destination URL, depensOnColumn=Ad ID")
   }
@@ -4036,7 +4125,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("request model should succeed"))
   }
 
@@ -4065,7 +4154,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry(Set(EqualityFilter("Source", "2", isForceFilter = true)))
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("request model should succeed"))
     val model = res.toOption.get
     assert(!model.bestCandidates.get.requestCols("stats_source"))
@@ -4095,7 +4184,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 3)
@@ -4154,7 +4243,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.hasNonDrivingDimSortOrFilter,"Failed to recognize the case of sorting on non driving dimension")
@@ -4189,7 +4278,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.hasNonDrivingDimSortOrFilter,"Failed to recognize the case of sorting and filtering on non driving dimension")
@@ -4223,7 +4312,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.requestCols.size === 2)
@@ -4275,7 +4364,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.isFactDriven)
@@ -4299,7 +4388,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.bestCandidates.get.requestJoinCols("ad_group_id"))
@@ -4331,7 +4420,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry(Set(EqualityFilter("Source", "2", isForceFilter = true)))
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("request model should succeed"))
     val model = res.toOption.get
     assert(!model.bestCandidates.get.requestCols("stats_source"))
@@ -4669,7 +4758,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.dimFilters.exists(_.operator == LikeFilterOperation))
@@ -4697,7 +4786,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should startWith ("requirement failed: ERROR_CODE:10008 Incompatible columns found in request, Device Type is not compatible with Set(Device ID)")
   }
@@ -4722,7 +4811,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
   }
 
@@ -4747,7 +4836,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, res.errorMessage("Create model succeeded even with duplidate fields "))
   }
 
@@ -4775,7 +4864,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, res.errorMessage("Create model succeeded even with duplidate fields "))
   }
 
@@ -4801,7 +4890,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, res.errorMessage("Create model succeeded even with forbidden schema "))
     res.failed.get.getMessage should startWith ("requirement failed: ERROR_CODE:10007 (Ad Format Name) can't be used with advertiser schema in publicFact cube")
   }
@@ -4827,7 +4916,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed with non forbidden schema"))
   }
 
@@ -4858,7 +4947,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Create model failed "))
   }
 
@@ -4889,7 +4978,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, res.errorMessage("OuterFilter Ad Group ID is not in selected column list"))
     res.failed.get.getMessage should startWith ("requirement failed: OuterFilter Ad Group ID is not in selected column list")
   }
@@ -4949,7 +5038,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure)
     res.failed.get.getMessage should startWith ("requirement failed: Or filter cannot have combination of fact and dim filters, factFilters=Some(List(EqualityFilter(Impressions,1,false,false))) dimFilters=Some(List(EqualityFilter(Campaign ID,1,false,false)))")
   }*/
@@ -4981,7 +5070,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     val orOp = OrFilterOperation
     assert(res.isSuccess)
     assert(!res.get.orFilterMeta.isEmpty)
@@ -5024,7 +5113,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(!res.get.orFilterMeta.isEmpty)
     assert(res.get.orFilterMeta.size == 2)
@@ -5065,7 +5154,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.factFilters.size === 3)
@@ -5101,7 +5190,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.factFilters.size === 2)
@@ -5136,7 +5225,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(res.get.factCost.head._2.isScanOptimized, "Fact should be scan optimized!")
   }
@@ -5163,7 +5252,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.toString)
     assert(!res.get.factCost.head._2.isScanOptimized, "Fact should not be scan optimized!")
   }
@@ -5191,7 +5280,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(res.get.factCost.head._2.isGrainOptimized, "Fact should be grain optimized!")
   }
@@ -5218,7 +5307,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(!res.get.factCost.head._2.isGrainOptimized, "Fact should not be grain optimized!")
   }
@@ -5245,7 +5334,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(res.get.factCost.head._2.isIndexOptimized, "Fact should be index optimized!")
   }
@@ -5271,7 +5360,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString, PublisherSchema)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(!res.get.factCost.head._2.isIndexOptimized, "Fact should not be index optimized!")
   }
@@ -5299,7 +5388,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(!res.get.dimensionsCandidates.headOption.get.hasLowCardinalityFilter, "Dim should have low cardinality filter")
   }
@@ -5327,7 +5416,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(!res.get.dimensionsCandidates.headOption.get.hasLowCardinalityFilter, "Dim should have low cardinality filter")
   }
@@ -5355,7 +5444,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     assert(res.get.dimensionsCandidates.headOption.get.hasLowCardinalityFilter, "Dim should have low cardinality filter")
   }
@@ -5379,7 +5468,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     res.isFailure shouldBe true
     res.failed.get.getMessage should equal("requirement failed: Unsupported filter operation : cube=publicFact4, col=Advertiser ID, operation=Like")
   }
@@ -5403,7 +5492,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     val model = res.toOption.get
     assert(model.factFilters.exists(_.field === "Advertiser ID") === true)
@@ -5430,7 +5519,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess)
     val model = res.toOption.get
     assert(model.factFilters.exists(_.field === "Device ID") === true)
@@ -5491,7 +5580,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess,res)
     val model = res.toOption.get
     assert(model.factFilters.exists(_.field === "Impressions") === true)
@@ -5520,7 +5609,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess,res)
     val model = res.toOption.get
     assert(model.factFilters.exists(_.field === "Impressions") === true)
@@ -5549,7 +5638,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess,res)
     val model = res.toOption.get
     assert(model.factFilters.exists(_.field === "Pricing Type") === true)
@@ -5578,7 +5667,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure,res)
     assert(res.failed.get.getMessage.contains("Unknown filter value for field=Pricing Type, value=1"))
   }
@@ -5606,7 +5695,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     val model = res.toOption.get
     assert(model.factFilters.size === 2)
@@ -5641,11 +5730,11 @@ class RequestModelTest extends FunSuite with Matchers {
     val registry = defaultRegistry
 
     val validRequest: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
-    val validResp = RequestModel.from(validRequest, registry)
+    val validResp = getRequestModel(validRequest, registry)
     assert(validResp.isSuccess, validResp)
 
     val invalidRequest: ReportingRequest = getReportingRequestSync(jsonString, PublisherSchema)
-    val failureResp = RequestModel.from(invalidRequest, registry)
+    val failureResp = getRequestModel(invalidRequest, registry)
     failureResp.isFailure shouldBe true
     failureResp.failed.get.getMessage should  startWith (s"requirement failed: ERROR_CODE:10007 (Advertiser Email) can't be used with publisher schema ")
 
@@ -5754,7 +5843,7 @@ class RequestModelTest extends FunSuite with Matchers {
     val registry = defaultRegistry
 
     val validRequest: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
-    val validResp = RequestModel.from(validRequest, registry, revision = Some(1))
+    val validResp = getRequestModel(validRequest, registry, revision = Some(1))
     assert(validResp.isSuccess, validResp)
 
   }
@@ -5781,7 +5870,7 @@ class RequestModelTest extends FunSuite with Matchers {
     val registry = defaultRegistry
 
     val validRequest: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
-    val validResp = RequestModel.from(validRequest, registry)
+    val validResp = getRequestModel(validRequest, registry)
     assert(validResp.isSuccess, validResp)
 
 
@@ -5813,7 +5902,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "Request from Restricted Schema should fail on filter, even without filter requested.")
 
     println(res.failed.get.getMessage)
@@ -5837,7 +5926,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, AdvertiserSchema)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "should fail on not having filter on Advertiser iD")
     res.failed.get.getMessage should startWith (s"requirement failed: Missing Dim Only query Schema(advertiser) required filter on 'Advertiser ID'")
   }
@@ -5860,7 +5949,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, AdvertiserSchema)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, "should fail on not having filter on Advertiser iD")
     res.failed.get.getMessage should startWith (s"requirement failed: Invalid Schema Required Filter Advertiser ID operation, expected at least one of set(In,=), found Not In")
   }
@@ -5883,7 +5972,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, AdvertiserSchema)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, "should fail not fail on having filter on Advertiser iD")
   }
 
@@ -5904,7 +5993,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, AdvertiserSchema)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, s"should fail on not having filter on Advertiser iD ${}")
     assert(res.failed.get.getMessage.contains("requirement failed: Missing Dim Only query Schema(advertiser) required filter on 'Advertiser ID'"))
   }
@@ -5927,7 +6016,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, AdvertiserSchema)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, s"should not fail on having filter on Advertiser ID")
   }
 
@@ -5950,7 +6039,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isFailure, s"should fail on having filter on Ad Group ID")
     assert(res.failed.get.getMessage.contains("Query must use at least one required filter: [internal -> Set(Advertiser ID, Campaign ID)]"))
   }
@@ -5974,7 +6063,7 @@ class RequestModelTest extends FunSuite with Matchers {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, s"should not fail on having filter on Campaign ID")
   }
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/BaseQueryChainTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/BaseQueryChainTest.scala
@@ -121,7 +121,7 @@ trait BaseQueryChainTest {
   def getRequestModel(jsonString: String): RequestModel = {
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val res = RequestModel.from(request, registry)
+    val res = getRequestModel(request, registry)
     assert(res.isSuccess, res.errorMessage("Failed to build request model"))
     res.toOption.get
   }

--- a/core/src/test/scala/com/yahoo/maha/core/query/CSVRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/CSVRowListTest.scala
@@ -7,7 +7,7 @@ import java.nio.file.{Files, StandardOpenOption}
 
 import com.yahoo.maha.core.query.oracle.BaseOracleQueryGeneratorTest
 import com.yahoo.maha.core.request.ReportingRequest
-import com.yahoo.maha.core.{IntType, RequestModel, StrType}
+import com.yahoo.maha.core.{IntType, StrType}
 import com.yahoo.maha.report.{FileRowCSVWriterProvider, JsonRowList}
 
 import scala.collection.mutable.ArrayBuffer
@@ -41,7 +41,7 @@ class CSVRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -75,7 +75,7 @@ class CSVRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/CompleteRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/CompleteRowListTest.scala
@@ -12,7 +12,7 @@ import com.yahoo.maha.core.query.druid.{AsyncDruidQueryOptimizer, DruidQuery, Dr
 import com.yahoo.maha.core.query.oracle.BaseOracleQueryGeneratorTest
 import com.yahoo.maha.core.registry.RegistryBuilder
 import com.yahoo.maha.core.request.ReportingRequest
-import com.yahoo.maha.core.{ColumnContext, DailyGrain, DateType, DecType, DruidEngine, DruidExpression, EqualityFilter, EscapingRequired, Filter, ForeignKey, IntType, RequestModel, StrType}
+import com.yahoo.maha.core.{ColumnContext, DailyGrain, DateType, DecType, DruidEngine, DruidExpression, EqualityFilter, EscapingRequired, Filter, ForeignKey, IntType, StrType}
 
 /**
  * Created by hiral on 1/25/16.
@@ -43,7 +43,7 @@ class CompleteRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListT
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -161,7 +161,7 @@ class CompleteRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListT
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -192,7 +192,7 @@ class CompleteRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListT
     registryBuilder.register(druid_pubfact(Set.empty))
     registerDims(registryBuilder)
     val registry = registryBuilder.build()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/DefaultQueryPipelineFactoryTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/DefaultQueryPipelineFactoryTest.scala
@@ -512,7 +512,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("force injectFilterSet to fk primary key") {
     val request: ReportingRequest = getReportingRequestSync(requestWithFkInjected)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -554,7 +554,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
 
     val request: ReportingRequest = ReportingRequest.forceOracle(getReportingRequestSync(requestWithMetricSort))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -610,7 +610,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
 
     val request: ReportingRequest = getReportingRequestSync(requestWithMetricSort)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -687,7 +687,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
 
     val request: ReportingRequest = getReportingRequestSync(requestWithMetricSort)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -778,7 +778,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
 
     val request: ReportingRequest = getReportingRequestSync(requestWithMetricSort)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -813,7 +813,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync multi engine query for oracle + druid") {
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(requestWithIdSort))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -853,7 +853,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync multi engine query for oracle + druid with no PK in request") {
     val request: ReportingRequest = getReportingRequestSync(requestWithDimSortNoPK)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -891,7 +891,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync multi engine query for druid + oracle") {
     val request: ReportingRequest = getReportingRequestSync(requestWithMetricSort)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -929,7 +929,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync multi engine query for druid + oracle with no PK in request") {
     val request: ReportingRequest = getReportingRequestSync(requestWithMetricSortNoPK)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -965,7 +965,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync query for oracle and not druid + oracle when fact driven with low cardinality filter") {
     val request: ReportingRequest = getReportingRequestSync(factRequestWithMetricSortDimFilter)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -998,7 +998,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync query for oracle and not druid + oracle when fact driven with no dimension ids") {
     val request: ReportingRequest = getReportingRequestSync(factRequestWithMetricSortNoDimensionIds)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1030,7 +1030,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync multi engine query for druid + oracle with fact query with no sort") {
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(factRequestWithNoSort))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1071,7 +1071,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate fact driven sync multi engine query for druid + oracle with noop when no data from druid") {
     val request: ReportingRequest = getReportingRequestSync(factRequestWithMetricSort)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1093,7 +1093,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync multi engine query for druid + oracle with rerun on oracle when no data from druid") {
     val request: ReportingRequest = getReportingRequestSync(requestWithMetricSort)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1134,7 +1134,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync multi engine query for druid + oracle with rerun on oracle when partial page data from druid on page 2") {
     val request: ReportingRequest = getReportingRequestSync(requestWithMetricSortPage2)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1196,7 +1196,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate sync multi engine query for druid + oracle with rerun on oracle when no data from oracle") {
     val request: ReportingRequest = getReportingRequestSync(requestWithMetricSort)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1252,7 +1252,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions.+:(BetweenFilter("Impressions", "10", "1000")))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1268,7 +1268,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions.+:(EqualityFilter("Ad Group Status", "ON")))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1284,7 +1284,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions ++ IndexedSeq(EqualityFilter("Ad Group Status", "ON"), BetweenFilter("Impressions", "10", "1000")))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1300,7 +1300,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions.+:(BetweenFilter("Impressions", "10", "1000")))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1316,7 +1316,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions.+:(EqualityFilter("Ad Group Status", "ON")))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1332,7 +1332,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions ++ IndexedSeq(EqualityFilter("Ad Group Status", "ON"), BetweenFilter("Impressions", "10", "1000")))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1345,7 +1345,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate async single engine query") {
     val request: ReportingRequest = getReportingRequestAsync(requestWithMetricSortAndDay)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1379,7 +1379,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully run async dim only query") {
     val request: ReportingRequest = getReportingRequestAsync(requestWithDimOnly)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1409,11 +1409,11 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
 
     val request1: ReportingRequest = ReportingRequest.forceOracle(getReportingRequestSync(requestWithMetricSort))
     val registry = defaultRegistry
-    val requestModel1 = RequestModel.from(request1, registry)
+    val requestModel1 = getRequestModel(request1, registry)
     assert(requestModel1.isSuccess, requestModel1.errorMessage("Building request model failed"))
 
     val request2: ReportingRequest = getReportingRequestSync(requestWithIdSort)
-    val requestModel2 = RequestModel.from(request2, registry)
+    val requestModel2 = getRequestModel(request2, registry)
     assert(requestModel2.isSuccess, requestModel2.errorMessage("Building request model failed"))
 
     val queryPipelineTries = queryPipelineFactory.from((requestModel1.get, Some(requestModel2.get)), QueryAttributes.empty)
@@ -1425,7 +1425,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
     val request = getReportingRequestSync(requestWithDruidFactAndDim)
 
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1439,7 +1439,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
     val request = getReportingRequestSync(requestWithOutOfRangeDruidDim)
 
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1454,7 +1454,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
     val request = getReportingRequestAsync(requestWithOutOfRangeDruidDim)
 
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1470,7 +1470,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions ++ IndexedSeq(EqualityFilter("Ad Group Status", "ON"), InFilter("Ad Group ID", List("1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31","32","33","34","35","36","37","38","39","40","41","42","43","44","45","46","47","48","49","50","51","52","53","54","55","56","57","58","59","60","61","62","63","64","65","66","67","68","69","70","71","72","73","74","75","76","77","78","79","80","81","82","83","84","85","86","87","88","89","90","91","92","93","94","95","96","97","98","99","100","101","102","103","104","105","106","107","108","109","110","111","112","113","114","115","116","117","118","119","120","121","122","123","124","125","126","127","128","129","130","131","132","133","134","135","136","137","138","139","140","141","142","143","144","145","146","147","148","149","150","151","152","153","154","155","156","157","158","159","160","161","162","163","164","165","166","167","168","169","170","171","172","173","174","175","176","177","178","179","180","181","182","183","184","185","186","187","188","189","190","191","192","193","194","195","196","197","198","199","200","201","202","203","204","205","206","207","208","209","210","211","212","213","214","215","216","217","218","219","220","221","222","223","224","225","226","227","228","229","230","231","232","233","234","235","236","237","238","239","240","241","242","243","244","245","246","247","248","249","250","251","252","253","254","255","256","257","258","259","260","261","262","263","264","265","266","267","268","269","270","271","272","273","274","275","276","277","278","279","280","281","282","283","284","285","286","287","288","289","290","291","292","293","294","295","296","297","298","299","300","301","302","303","304","305","306","307","308","309","310","311","312","313","314","315","316","317","318","319","320","321","322","323","324","325","326","327","328","329","330","331","332","333","334","335","336","337","338","339","340","341","342","343","344","345","346","347","348","349","350","351","352","353","354","355","356","357","358","359","360","361","362","363","364","365","366","367","368","369","370","371","372","373","374","375","376","377","378","379","380","381","382","383","384","385","386","387","388","389","390","391","392","393","394","395","396","397","398","399","400","401","402","403","404","405","406","407","408","409","410","411","412","413","414","415","416","417","418","419","420","421","422","423","424","425","426","427","428","429","430","431","432","433","434","435","436","437","438","439","440","441","442","443","444","445","446","447","448","449","450","451","452","453","454","455","456","457","458","459","460","461","462","463","464","465","466","467","468","469","470","471","472","473","474","475","476","477","478","479","480","481","482","483","484","485","486","487","488","489","490","491","492","493","494","495","496","497","498","499","500","501","502","503","504","505","506","507","508","509","510","511","512","513","514","515","516","517","518","519","520","521","522","523","524","525","526","527","528","529","530","531","532","533","534","535","536","537","538","539","540","541","542","543","544","545","546","547","548","549","550","551","552","553","554","555","556","557","558","559","560","561","562","563","564","565","566","567","568","569","570","571","572","573","574","575","576","577","578","579","580","581","582","583","584","585","586","587","588","589","590","591","592","593","594","595","596","597","598","599","600","601","602","603","604","605","606","607","608","609","610","611","612","613","614","615","616","617","618","619","620","621","622","623","624","625","626","627","628","629","630","631","632","633","634","635","636","637","638","639","640","641","642","643","644","645","646","647","648","649","650","651","652","653","654","655","656","657","658","659","660","661","662","663","664","665","666","667","668","669","670","671","672","673","674","675","676","677","678","679","680","681","682","683","684","685","686","687","688","689","690","691","692","693","694","695","696","697","698","699","700","701","702","703","704","705","706","707","708","709","710","711","712","713","714","715","716","717","718","719","720","721","722","723","724","725","726","727","728","729","730","731","732","733","734","735","736","737","738","739","740","741","742","743","744","745","746","747","748","749","750","751","752","753","754","755","756","757","758","759","760","761","762","763","764","765","766","767","768","769","770","771","772","773","774","775","776","777","778","779","780","781","782","783","784","785","786","787","788","789","790","791","792","793","794","795","796","797","798","799","800","801","802","803","804","805","806","807","808","809","810","811","812","813","814","815","816","817","818","819","820","821","822","823","824","825","826","827","828","829","830","831","832","833","834","835","836","837","838","839","840","841","842","843","844","845","846","847","848","849","850","851","852","853","854","855","856","857","858","859","860","861","862","863","864","865","866","867","868","869","870","871","872","873","874","875","876","877","878","879","880","881","882","883","884","885","886","887","888","889","890","891","892","893","894","895","896","897","898","899","900","901","902","903","904","905","906","907","908","909","910","911","912","913","914","915","916","917","918","919","920","921","922","923","924","925","926","927","928","929","930","931","932","933","934","935","936","937","938","939","940","941","942","943","944","945","946","947","948","949","950","951","952","953","954","955","956","957","958","959","960","961","962","963","964","965","966","967","968","969","970","971","972","973","974","975","976","977","978","979","980","981","982","983","984","985","986","987","988","989","990","991","992","993","994","995","996","997","998","999","1000"))))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1484,7 +1484,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions ++ IndexedSeq(EqualityFilter("Ad Group Status", "ON"), InFilter("Impressions", List("1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31","32","33","34","35","36","37","38","39","40","41","42","43","44","45","46","47","48","49","50","51","52","53","54","55","56","57","58","59","60","61","62","63","64","65","66","67","68","69","70","71","72","73","74","75","76","77","78","79","80","81","82","83","84","85","86","87","88","89","90","91","92","93","94","95","96","97","98","99","100","101","102","103","104","105","106","107","108","109","110","111","112","113","114","115","116","117","118","119","120","121","122","123","124","125","126","127","128","129","130","131","132","133","134","135","136","137","138","139","140","141","142","143","144","145","146","147","148","149","150","151","152","153","154","155","156","157","158","159","160","161","162","163","164","165","166","167","168","169","170","171","172","173","174","175","176","177","178","179","180","181","182","183","184","185","186","187","188","189","190","191","192","193","194","195","196","197","198","199","200","201","202","203","204","205","206","207","208","209","210","211","212","213","214","215","216","217","218","219","220","221","222","223","224","225","226","227","228","229","230","231","232","233","234","235","236","237","238","239","240","241","242","243","244","245","246","247","248","249","250","251","252","253","254","255","256","257","258","259","260","261","262","263","264","265","266","267","268","269","270","271","272","273","274","275","276","277","278","279","280","281","282","283","284","285","286","287","288","289","290","291","292","293","294","295","296","297","298","299","300","301","302","303","304","305","306","307","308","309","310","311","312","313","314","315","316","317","318","319","320","321","322","323","324","325","326","327","328","329","330","331","332","333","334","335","336","337","338","339","340","341","342","343","344","345","346","347","348","349","350","351","352","353","354","355","356","357","358","359","360","361","362","363","364","365","366","367","368","369","370","371","372","373","374","375","376","377","378","379","380","381","382","383","384","385","386","387","388","389","390","391","392","393","394","395","396","397","398","399","400","401","402","403","404","405","406","407","408","409","410","411","412","413","414","415","416","417","418","419","420","421","422","423","424","425","426","427","428","429","430","431","432","433","434","435","436","437","438","439","440","441","442","443","444","445","446","447","448","449","450","451","452","453","454","455","456","457","458","459","460","461","462","463","464","465","466","467","468","469","470","471","472","473","474","475","476","477","478","479","480","481","482","483","484","485","486","487","488","489","490","491","492","493","494","495","496","497","498","499","500","501","502","503","504","505","506","507","508","509","510","511","512","513","514","515","516","517","518","519","520","521","522","523","524","525","526","527","528","529","530","531","532","533","534","535","536","537","538","539","540","541","542","543","544","545","546","547","548","549","550","551","552","553","554","555","556","557","558","559","560","561","562","563","564","565","566","567","568","569","570","571","572","573","574","575","576","577","578","579","580","581","582","583","584","585","586","587","588","589","590","591","592","593","594","595","596","597","598","599","600","601","602","603","604","605","606","607","608","609","610","611","612","613","614","615","616","617","618","619","620","621","622","623","624","625","626","627","628","629","630","631","632","633","634","635","636","637","638","639","640","641","642","643","644","645","646","647","648","649","650","651","652","653","654","655","656","657","658","659","660","661","662","663","664","665","666","667","668","669","670","671","672","673","674","675","676","677","678","679","680","681","682","683","684","685","686","687","688","689","690","691","692","693","694","695","696","697","698","699","700","701","702","703","704","705","706","707","708","709","710","711","712","713","714","715","716","717","718","719","720","721","722","723","724","725","726","727","728","729","730","731","732","733","734","735","736","737","738","739","740","741","742","743","744","745","746","747","748","749","750","751","752","753","754","755","756","757","758","759","760","761","762","763","764","765","766","767","768","769","770","771","772","773","774","775","776","777","778","779","780","781","782","783","784","785","786","787","788","789","790","791","792","793","794","795","796","797","798","799","800","801","802","803","804","805","806","807","808","809","810","811","812","813","814","815","816","817","818","819","820","821","822","823","824","825","826","827","828","829","830","831","832","833","834","835","836","837","838","839","840","841","842","843","844","845","846","847","848","849","850","851","852","853","854","855","856","857","858","859","860","861","862","863","864","865","866","867","868","869","870","871","872","873","874","875","876","877","878","879","880","881","882","883","884","885","886","887","888","889","890","891","892","893","894","895","896","897","898","899","900","901","902","903","904","905","906","907","908","909","910","911","912","913","914","915","916","917","918","919","920","921","922","923","924","925","926","927","928","929","930","931","932","933","934","935","936","937","938","939","940","941","942","943","944","945","946","947","948","949","950","951","952","953","954","955","956","957","958","959","960","961","962","963","964","965","966","967","968","969","970","971","972","973","974","975","976","977","978","979","980","981","982","983","984","985","986","987","988","989","990","991","992","993","994","995","996","997","998","999","1000"))))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1497,7 +1497,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions ++ IndexedSeq(InFilter("Impressions", List("1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31","32","33","34","35","36","37","38","39","40","41","42","43","44","45","46","47","48","49","50","51","52","53","54","55","56","57","58","59","60","61","62","63","64","65","66","67","68","69","70","71","72","73","74","75","76","77","78","79","80","81","82","83","84","85","86","87","88","89","90","91","92","93","94","95","96","97","98","99","100","101","102","103","104","105","106","107","108","109","110","111","112","113","114","115","116","117","118","119","120","121","122","123","124","125","126","127","128","129","130","131","132","133","134","135","136","137","138","139","140","141","142","143","144","145","146","147","148","149","150","151","152","153","154","155","156","157","158","159","160","161","162","163","164","165","166","167","168","169","170","171","172","173","174","175","176","177","178","179","180","181","182","183","184","185","186","187","188","189","190","191","192","193","194","195","196","197","198","199","200","201","202","203","204","205","206","207","208","209","210","211","212","213","214","215","216","217","218","219","220","221","222","223","224","225","226","227","228","229","230","231","232","233","234","235","236","237","238","239","240","241","242","243","244","245","246","247","248","249","250","251","252","253","254","255","256","257","258","259","260","261","262","263","264","265","266","267","268","269","270","271","272","273","274","275","276","277","278","279","280","281","282","283","284","285","286","287","288","289","290","291","292","293","294","295","296","297","298","299","300","301","302","303","304","305","306","307","308","309","310","311","312","313","314","315","316","317","318","319","320","321","322","323","324","325","326","327","328","329","330","331","332","333","334","335","336","337","338","339","340","341","342","343","344","345","346","347","348","349","350","351","352","353","354","355","356","357","358","359","360","361","362","363","364","365","366","367","368","369","370","371","372","373","374","375","376","377","378","379","380","381","382","383","384","385","386","387","388","389","390","391","392","393","394","395","396","397","398","399","400","401","402","403","404","405","406","407","408","409","410","411","412","413","414","415","416","417","418","419","420","421","422","423","424","425","426","427","428","429","430","431","432","433","434","435","436","437","438","439","440","441","442","443","444","445","446","447","448","449","450","451","452","453","454","455","456","457","458","459","460","461","462","463","464","465","466","467","468","469","470","471","472","473","474","475","476","477","478","479","480","481","482","483","484","485","486","487","488","489","490","491","492","493","494","495","496","497","498","499","500","501","502","503","504","505","506","507","508","509","510","511","512","513","514","515","516","517","518","519","520","521","522","523","524","525","526","527","528","529","530","531","532","533","534","535","536","537","538","539","540","541","542","543","544","545","546","547","548","549","550","551","552","553","554","555","556","557","558","559","560","561","562","563","564","565","566","567","568","569","570","571","572","573","574","575","576","577","578","579","580","581","582","583","584","585","586","587","588","589","590","591","592","593","594","595","596","597","598","599","600","601","602","603","604","605","606","607","608","609","610","611","612","613","614","615","616","617","618","619","620","621","622","623","624","625","626","627","628","629","630","631","632","633","634","635","636","637","638","639","640","641","642","643","644","645","646","647","648","649","650","651","652","653","654","655","656","657","658","659","660","661","662","663","664","665","666","667","668","669","670","671","672","673","674","675","676","677","678","679","680","681","682","683","684","685","686","687","688","689","690","691","692","693","694","695","696","697","698","699","700","701","702","703","704","705","706","707","708","709","710","711","712","713","714","715","716","717","718","719","720","721","722","723","724","725","726","727","728","729","730","731","732","733","734","735","736","737","738","739","740","741","742","743","744","745","746","747","748","749","750","751","752","753","754","755","756","757","758","759","760","761","762","763","764","765","766","767","768","769","770","771","772","773","774","775","776","777","778","779","780","781","782","783","784","785","786","787","788","789","790","791","792","793","794","795","796","797","798","799","800","801","802","803","804","805","806","807","808","809","810","811","812","813","814","815","816","817","818","819","820","821","822","823","824","825","826","827","828","829","830","831","832","833","834","835","836","837","838","839","840","841","842","843","844","845","846","847","848","849","850","851","852","853","854","855","856","857","858","859","860","861","862","863","864","865","866","867","868","869","870","871","872","873","874","875","876","877","878","879","880","881","882","883","884","885","886","887","888","889","890","891","892","893","894","895","896","897","898","899","900","901","902","903","904","905","906","907","908","909","910","911","912","913","914","915","916","917","918","919","920","921","922","923","924","925","926","927","928","929","930","931","932","933","934","935","936","937","938","939","940","941","942","943","944","945","946","947","948","949","950","951","952","953","954","955","956","957","958","959","960","961","962","963","964","965","966","967","968","969","970","971","972","973","974","975","976","977","978","979","980","981","982","983","984","985","986","987","988","989","990","991","992","993","994","995","996","997","998","999","1000"))))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1509,7 +1509,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions ++ IndexedSeq(EqualityFilter("Ad Group ID", "1"), InFilter("Ad Group Status", List("1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31","32","33","34","35","36","37","38","39","40","41","42","43","44","45","46","47","48","49","50","51","52","53","54","55","56","57","58","59","60","61","62","63","64","65","66","67","68","69","70","71","72","73","74","75","76","77","78","79","80","81","82","83","84","85","86","87","88","89","90","91","92","93","94","95","96","97","98","99","100","101","102","103","104","105","106","107","108","109","110","111","112","113","114","115","116","117","118","119","120","121","122","123","124","125","126","127","128","129","130","131","132","133","134","135","136","137","138","139","140","141","142","143","144","145","146","147","148","149","150","151","152","153","154","155","156","157","158","159","160","161","162","163","164","165","166","167","168","169","170","171","172","173","174","175","176","177","178","179","180","181","182","183","184","185","186","187","188","189","190","191","192","193","194","195","196","197","198","199","200","201","202","203","204","205","206","207","208","209","210","211","212","213","214","215","216","217","218","219","220","221","222","223","224","225","226","227","228","229","230","231","232","233","234","235","236","237","238","239","240","241","242","243","244","245","246","247","248","249","250","251","252","253","254","255","256","257","258","259","260","261","262","263","264","265","266","267","268","269","270","271","272","273","274","275","276","277","278","279","280","281","282","283","284","285","286","287","288","289","290","291","292","293","294","295","296","297","298","299","300","301","302","303","304","305","306","307","308","309","310","311","312","313","314","315","316","317","318","319","320","321","322","323","324","325","326","327","328","329","330","331","332","333","334","335","336","337","338","339","340","341","342","343","344","345","346","347","348","349","350","351","352","353","354","355","356","357","358","359","360","361","362","363","364","365","366","367","368","369","370","371","372","373","374","375","376","377","378","379","380","381","382","383","384","385","386","387","388","389","390","391","392","393","394","395","396","397","398","399","400","401","402","403","404","405","406","407","408","409","410","411","412","413","414","415","416","417","418","419","420","421","422","423","424","425","426","427","428","429","430","431","432","433","434","435","436","437","438","439","440","441","442","443","444","445","446","447","448","449","450","451","452","453","454","455","456","457","458","459","460","461","462","463","464","465","466","467","468","469","470","471","472","473","474","475","476","477","478","479","480","481","482","483","484","485","486","487","488","489","490","491","492","493","494","495","496","497","498","499","500","501","502","503","504","505","506","507","508","509","510","511","512","513","514","515","516","517","518","519","520","521","522","523","524","525","526","527","528","529","530","531","532","533","534","535","536","537","538","539","540","541","542","543","544","545","546","547","548","549","550","551","552","553","554","555","556","557","558","559","560","561","562","563","564","565","566","567","568","569","570","571","572","573","574","575","576","577","578","579","580","581","582","583","584","585","586","587","588","589","590","591","592","593","594","595","596","597","598","599","600","601","602","603","604","605","606","607","608","609","610","611","612","613","614","615","616","617","618","619","620","621","622","623","624","625","626","627","628","629","630","631","632","633","634","635","636","637","638","639","640","641","642","643","644","645","646","647","648","649","650","651","652","653","654","655","656","657","658","659","660","661","662","663","664","665","666","667","668","669","670","671","672","673","674","675","676","677","678","679","680","681","682","683","684","685","686","687","688","689","690","691","692","693","694","695","696","697","698","699","700","701","702","703","704","705","706","707","708","709","710","711","712","713","714","715","716","717","718","719","720","721","722","723","724","725","726","727","728","729","730","731","732","733","734","735","736","737","738","739","740","741","742","743","744","745","746","747","748","749","750","751","752","753","754","755","756","757","758","759","760","761","762","763","764","765","766","767","768","769","770","771","772","773","774","775","776","777","778","779","780","781","782","783","784","785","786","787","788","789","790","791","792","793","794","795","796","797","798","799","800","801","802","803","804","805","806","807","808","809","810","811","812","813","814","815","816","817","818","819","820","821","822","823","824","825","826","827","828","829","830","831","832","833","834","835","836","837","838","839","840","841","842","843","844","845","846","847","848","849","850","851","852","853","854","855","856","857","858","859","860","861","862","863","864","865","866","867","868","869","870","871","872","873","874","875","876","877","878","879","880","881","882","883","884","885","886","887","888","889","890","891","892","893","894","895","896","897","898","899","900","901","902","903","904","905","906","907","908","909","910","911","912","913","914","915","916","917","918","919","920","921","922","923","924","925","926","927","928","929","930","931","932","933","934","935","936","937","938","939","940","941","942","943","944","945","946","947","948","949","950","951","952","953","954","955","956","957","958","959","960","961","962","963","964","965","966","967","968","969","970","971","972","973","974","975","976","977","978","979","980","981","982","983","984","985","986","987","988","989","990","991","992","993","994","995","996","997","998","999","1000"))))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1521,7 +1521,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions ++ IndexedSeq(OrFilter(List(InFilter("Impressions", List("1"))))))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1534,7 +1534,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
       request.copy(filterExpressions = request.filterExpressions ++ IndexedSeq(OrFilter(List(InFilter("Impressions", List("1"))))))
     }
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1568,7 +1568,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
                         }"""
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1604,7 +1604,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("fail to generate sync query for presto") {
     val request: ReportingRequest = ReportingRequest.forcePresto(getReportingRequestSync(requestWithIdSort))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1615,7 +1615,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate fallback query on sync request and execute it") {
     val request: ReportingRequest = getReportingRequestSync(factRequestWithOracleAndDruidDim)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1649,7 +1649,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate fallback query on sync request with force engine and execute it") {
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(factRequestWithOracleAndDruidDim))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1683,7 +1683,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate fallback query on sync request and fail to execute it due to missing executor") {
     val request: ReportingRequest = getReportingRequestSync(factRequestWithOracleAndDruidDim)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1707,7 +1707,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate fallback query on async request and execute it") {
     val request: ReportingRequest = getReportingRequestAsync(factRequestWithOracleAndDruidDim)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1741,7 +1741,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate fallback query on async request with force engine and execute it") {
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestAsync(factRequestWithOracleAndDruidDim))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1775,7 +1775,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully execute pipeline while failing to create fallback query") {
     val request: ReportingRequest = getReportingRequestAsync(factRequestWithDruidFactAndDim)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1800,7 +1800,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate fallback query on async request with force engine and execute it when no joins required") {
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestAsync(factRequestWithNoDims))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1833,7 +1833,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate query with queryGeneratorBucket defined") {
     val request: ReportingRequest = ReportingRequest.forceHive(getReportingRequestAsync(requestWithMetricSortAndDay))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     object TestBucketingConfig extends BucketingConfig {
@@ -1862,7 +1862,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate query with force queryGen version") {
     val request: ReportingRequest = ReportingRequest.forceHive(getReportingRequestAsync(requestWithMetricSortAndDay))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     object TestBucketingConfig extends BucketingConfig {
@@ -1893,7 +1893,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("successfully generate query with queryGeneratorBucket defined and no dryRun requestModel") {
     val request: ReportingRequest = ReportingRequest.forceHive(getReportingRequestAsync(requestWithMetricSortAndDay))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     object TestBucketingConfig extends BucketingConfig {
@@ -1921,7 +1921,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("test fact and dim revisioning logic") {
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(factRequestWithNoSort))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Some(10))
+    val requestModel = getRequestModel(request, registry, revision = Some(10))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1935,7 +1935,7 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
   test("Drop into V0 if selected revision is fake.") {
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(factRequestWithNoSortAndKeywordIdForInvalidQuery))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Some(10))
+    val requestModel = getRequestModel(request, registry, revision = Some(10))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.dimensionsCandidates.head.dim.name == "ad_group")
   }

--- a/core/src/test/scala/com/yahoo/maha/core/query/DerivedRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/DerivedRowListTest.scala
@@ -128,7 +128,7 @@ class DerivedRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListTe
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -159,7 +159,7 @@ class DerivedRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListTe
     registryBuilder.register(druid_pubfact(Set.empty))
     registerDims(registryBuilder)
     val registry = registryBuilder.build()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/DimDrivenFactOrderedPartialRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/DimDrivenFactOrderedPartialRowListTest.scala
@@ -35,7 +35,7 @@ class DimDrivenFactOrderedPartialRowListTest extends BaseOracleQueryGeneratorTes
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -70,7 +70,7 @@ class DimDrivenFactOrderedPartialRowListTest extends BaseOracleQueryGeneratorTes
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/FactDrivenPartialRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/FactDrivenPartialRowListTest.scala
@@ -30,7 +30,7 @@ class FactDrivenPartialRowListTest extends BaseOracleQueryGeneratorTest with Bas
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/NoopRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/NoopRowListTest.scala
@@ -35,7 +35,7 @@ class NoopRowListTest extends FunSuite with Matchers with BaseOracleQueryGenerat
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/OffHeapRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/OffHeapRowListTest.scala
@@ -35,7 +35,7 @@ class OffHeapRowListTest extends BaseRowListTest  {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -69,7 +69,7 @@ class OffHeapRowListTest extends BaseRowListTest  {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/PartialRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/PartialRowListTest.scala
@@ -35,7 +35,7 @@ class PartialRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListTe
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -118,7 +118,7 @@ class PartialRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListTe
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/QueryContextTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/QueryContextTest.scala
@@ -46,7 +46,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     //test with oracle
@@ -117,7 +117,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     intercept[IllegalArgumentException] {
@@ -131,7 +131,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     //test with oracle
@@ -204,7 +204,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     intercept[IllegalArgumentException] {
       val builder = new QueryContextBuilder(FactOnlyQuery, requestModel.get)
@@ -240,7 +240,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     intercept[IllegalArgumentException] {
       val builder = new QueryContextBuilder(FactOnlyQuery, requestModel.get)
@@ -254,7 +254,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     //test with oracle only
@@ -325,7 +325,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     //test with oracle only
@@ -410,7 +410,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     intercept[IllegalArgumentException] {
       val builder = new QueryContextBuilder(DimFactQuery, requestModel.get)
@@ -439,7 +439,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val builder = new QueryContextBuilder(DimOnlyQuery, requestModel.get)
     val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
@@ -473,7 +473,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val builder = new QueryContextBuilder(DimOnlyQuery, requestModel.get)
 
@@ -507,7 +507,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val builder = new QueryContextBuilder(FactOnlyQuery, requestModel.get)
     val bestFact = DefaultQueryPipelineFactory.findBestFactCandidate(requestModel.get, Set.empty, Set(OracleEngine, DruidEngine), queryGeneratorRegistry = queryGeneratorRegistry )
@@ -547,7 +547,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val builder = new QueryContextBuilder(DimFactOuterGroupByQuery, requestModel.get)
 
@@ -587,7 +587,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val builder = new QueryContextBuilder(FactOnlyQuery, requestModel.get)
     val bestFact = DefaultQueryPipelineFactory.findBestFactCandidate(requestModel.get, Set(OracleEngine), Set(OracleEngine, DruidEngine), queryGeneratorRegistry = queryGeneratorRegistry )
@@ -618,7 +618,7 @@ class QueryContextTest extends FunSuite with Matchers with BeforeAndAfterAll wit
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val builder = new QueryContextBuilder(FactOnlyQuery, requestModel.get)
     intercept[IllegalArgumentException] {

--- a/core/src/test/scala/com/yahoo/maha/core/query/QueryExecutorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/QueryExecutorTest.scala
@@ -56,7 +56,7 @@ class QueryExecutorTest extends FunSuite with Matchers with BaseOracleQueryGener
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -116,7 +116,7 @@ class QueryExecutorTest extends FunSuite with Matchers with BaseOracleQueryGener
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/QueryPipelineWithFallbackTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/QueryPipelineWithFallbackTest.scala
@@ -98,7 +98,7 @@ class QueryPipelineWithFallbackTest extends FunSuite with Matchers with BeforeAn
 
     val request: ReportingRequest = getReportingRequestAsync(jsonRequest)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -193,7 +193,7 @@ class QueryPipelineWithFallbackTest extends FunSuite with Matchers with BeforeAn
 
     val request: ReportingRequest = getReportingRequestAsync(jsonRequest)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry

--- a/core/src/test/scala/com/yahoo/maha/core/query/QueryTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/QueryTest.scala
@@ -36,7 +36,7 @@ class QueryTest extends FunSuite with Matchers with BaseOracleQueryGeneratorTest
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/UnionViewRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/UnionViewRowListTest.scala
@@ -56,7 +56,7 @@ class UnionViewRowListTest extends BaseOracleQueryGeneratorTest with BaseRowList
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     DruidQueryGenerator.register(queryGeneratorRegistry, useCustomRoundingSumAggregator = true)

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
@@ -10,6 +10,7 @@ import com.yahoo.maha.core.query._
 import com.yahoo.maha.core.request.{ReportingRequest, RequestContext, RowCountQuery}
 import org.apache.commons.lang.StringUtils
 import org.apache.druid.common.config.NullHandling
+import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 
 /**
  * Created by hiral on 1/14/16.
@@ -21,7 +22,10 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   test("registering Druid query generation multiple times should fail") {
     intercept[IllegalArgumentException] {
       val dummyQueryGenerator = new QueryGenerator[WithDruidEngine] {
-        override def generate(queryContext: QueryContext): Query = { null }
+        override def generate(queryContext: QueryContext): Query = {
+          null
+        }
+
         override def engine: Engine = DruidEngine
       }
       queryGeneratorRegistry.register(DruidEngine, dummyQueryGenerator)
@@ -29,7 +33,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("dim query context should fail with UnsupportedOperationException") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -48,7 +53,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val dimMapping = DefaultQueryPipelineFactory.findDimCandidatesMapping(requestModel.get)
     val dims = DefaultQueryPipelineFactory.findBestDimCandidates(DruidEngine, requestModel.get, dimMapping, DefaultQueryPipelineFactory.druidMultiQueryEngineList)
     val queryContext = new QueryContextBuilder(DimOnlyQuery, requestModel.get).addDimTable(dims).build()
@@ -59,7 +64,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("limit should be set to defaultMaxRows when maxRows is less than 1") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -85,18 +91,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """limit":1020"""
 
     assert(result.contains(json), result)
   }
 
   test("Druid query should be generated with greater than filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -116,18 +123,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"type":"greaterThan","aggregation":"Impressions","value":1000}]}"""
 
     assert(result.contains(json), result)
   }
 
   test("Druid query should be generated with less than filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -147,18 +155,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"type":"lessThan","aggregation":"Impressions","value":1000}]}"""
 
     assert(result.contains(json), result)
   }
 
   test("Druid query should be generated with IsNull filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -179,11 +188,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     print(s"result: $result")
     val json = """{"type":"lessThan","aggregation":"Impressions","value":1000}]}"""
     assert(result.contains(json), result)
@@ -192,7 +201,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Druid query should be generated with IsNotNull filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -213,11 +223,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     print(result)
     val json = """{"type":"lessThan","aggregation":"Impressions","value":1000}]}"""
     assert(result.contains(json), result)
@@ -226,7 +236,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Druid query should be generated with Between filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -247,11 +258,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"type":"lessThan","aggregation":"Impressions","value":1000}]}"""
     assert(result.contains(json), result)
     val boundFilterJson = """{"type":"bound","dimension":"landing_page_url","lower":"A","upper":"ZZ","lowerStrict":false,"upperStrict":false,"ordering":{"type":"lexicographic"}}"""
@@ -286,7 +297,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
@@ -298,7 +309,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("DruidQueryGenerator: getAggregatorFactory should fail on DruidFilteredListRollup with only 1 list element") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -324,13 +336,14 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(!queryPipelineTry.isSuccess && queryPipelineTry.errorMessage("").contains("ToUse FilteredListAggregator filterList must have 2 or more filters"), "Query pipeline should have failed, but didn't" + queryPipelineTry.errorMessage(""))
   }
 
   test("limit should be set to defaultMaxRowsAsync when request is Async and rowsPerPage is <= 0") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "user_stats",
                           "selectFields": [
                             {"field": "Impressions"},
@@ -347,18 +360,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """limit":100000"""
 
     assert(result.contains(json), result)
   }
 
   test("group by strategy should be set to v2 and no chunk period") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "user_stats",
                           "selectFields": [
                             {"field": "Impressions"},
@@ -375,7 +389,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
-    val requestModelTry = RequestModel.from(request, defaultRegistry)
+    val requestModelTry = getRequestModel(request, defaultRegistry)
     assert(requestModelTry.isSuccess, requestModelTry.errorMessage("Building request model failed"))
 
     val requestModel = requestModelTry.toOption.get.copy(
@@ -385,7 +399,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = generatePipeline(requestModel)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"groupByStrategy":"v2""""
 
     assert(result.contains(json), result)
@@ -393,7 +407,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("metric should be set to inverted when order is Desc and queryType is topN") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -412,18 +427,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"metric":{"type":"numeric","metric":"Impressions"}"""
 
     assert(result.contains(json), result)
   }
 
   test("for topN queryType aggregations, postAggregations, dimension and filter should be set") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -443,11 +459,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
 
     val json = """\{"queryType":"topN","dataSource":\{"type":"table","name":"fact1"\},"virtualColumns":\[\],"dimension":\{"type":"default","dimension":"id","outputName":"Keyword ID","outputType":"STRING"\},"metric":\{"type":"numeric","metric":"Impressions"\},"threshold":120,"intervals":\{"type":"intervals","intervals":\[".*"\]\},"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\}\],"context":\{"applyLimitPushDown":"false","userId":"someUser","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
@@ -456,7 +472,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Successfully generate a query with Javascript extractionFn") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -477,11 +494,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"statsDate","value":"[0-9]+"\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"extraction","dimension":"segments","outputName":"Segments","outputType":"STRING","extractionFn":\{"type":"javascript","function":"function\(x\) \{ return x > 0; \}","injective":false\}\},\{"type":"default","dimension":"id","outputName":"Keyword ID","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":120\},"context":\{"applyLimitPushDown":"false","userId":"someUser","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
 
@@ -489,7 +506,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Successfully generate a query with Javascript Filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -507,12 +525,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
 
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"columnComparison","dimensions":\[\{"type":"default","dimension":"ad_id","outputName":"ad_id","outputType":"STRING"\},\{"type":"default","dimension":"ad_group_id","outputName":"ad_group_id","outputType":"STRING"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"id","outputName":"Keyword ID","outputType":"STRING"\}\],"aggregations":\[\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"filtered","aggregator":\{"type":"thetaSketch","name":"Conversion User Count","fieldName":"uniqueUserCount","size":16384,"shouldFinalize":true,"isInputThetaSketch":false\},"filter":\{"type":"javascript","dimension":"segments","function":"function\(x\) \{ return x \> 0; \}"\},"name":"Conversion User Count"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"\/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"applyLimitPushDown":"false","userId":"someUser","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
@@ -521,7 +538,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Successfully generate a query with RegEx extractionFn") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -542,19 +560,20 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
-//
+    //
 
     assert(result.contains("{\"type\":\"extraction\",\"dimension\":\"internal_bucket_id\",\"outputName\":\"Click Exp ID\",\"outputType\":\"STRING\",\"extractionFn\":{\"type\":\"regex\",\"expr\":\"(cl-)(.*?)(,)\",\"index\":2,\"replaceMissingValue\":true,\"replaceMissingValueWith\":\"-3\"}}"), result)
   }
 
   test("Successfully generate a query with RegEx Filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -573,19 +592,20 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
-//
+    //
 
     assert(result.contains("{\"type\":\"selector\",\"dimension\":\"internal_bucket_id\",\"value\":\"abcd\",\"extractionFn\":{\"type\":\"regex\",\"expr\":\"(cl-)(.*?)(,)\",\"index\":2,\"replaceMissingValue\":true,\"replaceMissingValueWith\":\"-3\"}}]},\"granularity\":{\"type\":\"all\"},\"dimensions\":[{\"type\":\"extraction\",\"dimension\":\"internal_bucket_id\",\"outputName\":\"Click Exp ID\",\"outputType\":\"STRING\",\"extractionFn\":{\"type\":\"regex\",\"expr\":\"(cl-)(.*?)(,)\",\"index\":2,\"replaceMissingValue\":true,\"replaceMissingValueWith\":\"-3\"}}"), result)
   }
 
   test("Should fail to generate a metric query with Field Comparison Filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -603,13 +623,14 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isFailure && queryPipelineTry.failed.get.getMessage.contains("Column Comparison is not supported on Druid fact fields"), "Column comparison should fail for metrics.")
   }
 
   test("DruidQueryGenerator: arbitrary static mapping should succeed") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -629,11 +650,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"extraction","dimension":"landing_page_url","outputName":"Landing URL Translation",\"outputType\":\"STRING\","extractionFn":\{"type":"lookup","lookup":\{"type":"map","map":\{"Valid":"Something"\},"isOneToOne":false\},"retainMissingValue":false,"replaceMissingValueWith":"Empty","injective":false,"optimize":true\}\},\{"type":"default","dimension":"id","outputName":"Keyword ID"\,\"outputType\":\"STRING\"}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":120\},"context":\{"applyLimitPushDown":"false","userId":"someUser","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
 
@@ -641,7 +662,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("for timeseries queryType aggregations, postAggregations and filter should be set but not dimension") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats_no_local_time",
                           "selectFields": [
                             {"field": "Day"},
@@ -658,7 +680,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -668,14 +690,15 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"timeseries","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"descending":false,"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":"DAY","aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\}\],"limit":2147483647,"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\}\}"""
 
     result should fullyMatch regex json
   }
 
   test("direction in limitSpec should be set to DESCENDING when order is Desc and queryType is groupBy") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -700,18 +723,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"extraction","dimension":"price_type","outputName":"Pricing Type",\"outputType\":\"STRING\","extractionFn":\{"type":"lookup","lookup":\{"type":"map","map":\{"-10":"CPE","-20":"CPF","6":"CPV","1":"CPC","2":"CPA","7":"CPCV","3":"CPM"\},"isOneToOne":false\},"retainMissingValue":false,"replaceMissingValueWith":"NONE","injective":false,"optimize":true\}\},\{"type":"default","dimension":"id","outputName":"Keyword ID"\,\"outputType\":\"STRING\"}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"doubleMax","name":"Max Bid","fieldName":"max_bid"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"longSum","name":"Clicks","fieldName":"clicks"\},\{"type":"doubleMin","name":"Min Bid","fieldName":"min_bid"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\},\{"type":"arithmetic","name":"CTR","fn":"/","fields":\[\{"type":"fieldAccess","name":"clicks","fieldName":"Clicks"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":120\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
 
     result should fullyMatch regex json
   }
 
   test("dimension based aggregate via filtered aggregate for fact col") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -735,11 +759,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"stats_source","outputName":"Source"\,\"outputType\":\"STRING\"},\{"type":"default","dimension":"id","outputName":"Keyword ID"\,\"outputType\":\"STRING\"}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"filtered","aggregator":\{"type":"longSum","name":"Reblogs","fieldName":"engagement_count"\},"filter":\{"type":"selector","dimension":"engagement_type","value":"1"\},"name":"Reblogs"\},\{"type":"longSum","name":"Clicks","fieldName":"clicks"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Reblog Rate","fn":"\*","fields":\[\{"type":"arithmetic","name":"_placeHolder_2","fn":"/","fields":\[\{"type":"fieldAccess","name":"Reblogs","fieldName":"Reblogs"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\},\{"type":"constant","name":"_constant_.*","value":100\}\]\},\{"type":"arithmetic","name":"CTR","fn":"/","fields":\[\{"type":"fieldAccess","name":"clicks","fieldName":"Clicks"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":120\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
 
 
@@ -747,7 +771,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("dimension extraction function for start of the week dimension") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -773,11 +798,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"dimension":"statsDate","outputName":"Week","outputType":"STRING","extractionFn":{"type":"time","timeFormat":"yyyyMMdd","resultFormat":"YYYY-w","joda":false}}"""
     val filterjson = """{"type":"selector","dimension":"statsDate","value":"2017-24","extractionFn":{"type":"time","timeFormat":"yyyyMMdd","resultFormat":"YYYY-w","joda":false}},{"type":"selector","dimension":"statsDate","value":"2017-26","extractionFn":{"type":"time","timeFormat":"yyyyMMdd","resultFormat":"YYYY-w","joda":false}}"""
 
@@ -786,7 +811,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("dimension extraction function for start of the month dimension") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -812,11 +838,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"dimension":"statsDate","outputName":"Month","outputType":"STRING","extractionFn":{"type":"time","timeFormat":"yyyyMMdd","resultFormat":"yyyy-MM-01","joda":false}}"""
     val filterjson = """{"type":"selector","dimension":"statsDate","value":"2017-06-01","extractionFn":{"type":"time","timeFormat":"yyyyMMdd","resultFormat":"yyyy-MM-01","joda":false}},{"type":"selector","dimension":"statsDate","value":"2017-07-01","extractionFn":{"type":"time","timeFormat":"yyyyMMdd","resultFormat":"yyyy-MM-01","joda":false}}"""
 
@@ -825,7 +851,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("dimension time extraction function for druid time") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -850,17 +877,18 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"type":"extraction","dimension":"__time","outputName":"My Date","outputType":"STRING","extractionFn":{"type":"timeFormat","format":"YYYY-MM-dd","timeZone":"UTC","granularity":{"type":"none"},"asMillis":false}}"""
     assert(result.contains(json), result)
   }
 
   test("successfully render filter on column using dimension time extraction function for druid time") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "user_stats_v2",
                           "selectFields": [
                             {"field": "Campaign ID"},
@@ -884,18 +912,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = s""""filter":{"type":"and","fields":[{"type":"or","fields":[{"type":"selector","dimension":"__time","value":"$fromDate","extractionFn":{"type":"timeFormat","format":"YYYY-MM-dd","timeZone":"UTC","granularity":{"type":"none"},"asMillis":false}},{"type":"selector","dimension":"__time","value":"$toDate","extractionFn":{"type":"timeFormat","format":"YYYY-MM-dd","timeZone":"UTC","granularity":{"type":"none"},"asMillis":false}}]}"""
 
     assert(result.contains(json), result)
   }
 
   test("no dimension cols and no sorts should produce timeseries query") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats_no_local_time",
                           "selectFields": [
                             {"field": "Day"},
@@ -910,24 +939,25 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
-    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator)//do not include local time filter
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator) //do not include local time filter
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory(druidMultiQueryEngineList = List(defaultFactEngine))(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"queryType":"timeseries","""
 
     assert(result.contains(json), result)
   }
 
   test("no dimension cols and no sorts on a cube with renderLocalTimeFilter=true should not produce timeseries but groupBy query") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -942,24 +972,25 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
-    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator)//do not include local time filter
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator) //do not include local time filter
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory(druidMultiQueryEngineList = List(defaultFactEngine))(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"queryType":"groupBy","""
 
     assert(result.contains(json), result)
   }
 
   test("fact sort with single dim col should produce topN query") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -978,21 +1009,22 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"queryType":"topN","""
 
     assert(result.contains(json), result)
   }
 
   test("fact sort with no dim col on a cube with renderLocalTimeFilter=true should produce groupBy query not topN") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Impressions"}
@@ -1009,21 +1041,22 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"queryType":"groupBy","""
 
     assert(result.contains(json), result)
   }
 
   test("fact sort with multiple dim col should produce group by query") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1047,14 +1080,14 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"queryType":"groupBy","""
 
     assert(result.contains(json), result)
@@ -1065,21 +1098,22 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
       .getLines.mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"""
 
     assert(result.contains(json), result)
   }
 
   test("startIndex greater than maximumMaxRows should throw error") {
-      val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1102,14 +1136,15 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                           "rowsPerPage":100
                         }"""
 
-      val request: ReportingRequest = getReportingRequestSync(jsonString)
-      val requestModel = RequestModel.from(request, defaultRegistry)
-      val queryPipelineTry = generatePipeline(requestModel.toOption.get)
-      assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val requestModel = getRequestModel(request, defaultRegistry)
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
   }
 
   test("limit should be set to 2*maxRows if there is a NonFKDimfilter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1136,18 +1171,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """limit":220"""
 
     assert(result.contains(json), result)
   }
 
   test("queryPipeline should fail when request has NonFKDimfilter and (startIndex + 2*maxRows) > 5000") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1174,7 +1210,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
     assert(queryPipelineTry.checkFailureMessage("requirement failed: Failed to find best candidate, forceEngine=None, engine disqualifyingSet=Set(Druid, Hive, Presto), candidates=Set((fact1,Druid))"))
@@ -1182,7 +1218,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("successfully set group by single threaded to true when cardinality is below max allowed value") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1206,7 +1243,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModelTry = RequestModel.from(request, registry)
+    val requestModelTry = getRequestModel(request, registry)
     assert(requestModelTry.isSuccess, requestModelTry.errorMessage("Building request model failed"))
 
 
@@ -1214,13 +1251,14 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = generatePipeline(requestModel)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"groupByIsSingleThreaded":true"""
 
     assert(result.contains(json), result)
   }
   test("successfully set group by single threaded to false when cardinality is above max allowed value") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1244,7 +1282,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModelTry = RequestModel.from(request, registry)
+    val requestModelTry = getRequestModel(request, registry)
     assert(requestModelTry.isSuccess, requestModelTry.errorMessage("Building request model failed"))
 
 
@@ -1252,13 +1290,14 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = generatePipeline(requestModel)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"groupByIsSingleThreaded":false"""
 
     assert(result.contains(json), result)
   }
   test("successfully set chunk period when dim cardinality is defined and above max cost") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1282,24 +1321,25 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModelTry = RequestModel.from(request, registry)
+    val requestModelTry = getRequestModel(request, registry)
     assert(requestModelTry.isSuccess, requestModelTry.errorMessage("Building request model failed"))
 
 
     val requestModel = requestModelTry.toOption.get.copy(
       dimCardinalityEstimate = Some(DruidQueryGenerator.defaultMaxSingleThreadedDimCardinality + 1)
-    , factCost = requestModelTry.toOption.get.factCost.mapValues(rc => rc.copy(costEstimate = DruidQueryGenerator.defaultMaxNoChunkCost + 1))
+      , factCost = requestModelTry.toOption.get.factCost.mapValues(rc => rc.copy(costEstimate = DruidQueryGenerator.defaultMaxNoChunkCost + 1))
     )
     val queryPipelineTry = generatePipeline(requestModel)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"chunkPeriod":"P3D""""
 
     assert(result.contains(json), result)
   }
   test("successfully ignore chunk period when dim cardinality is defined and below max cost") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1323,7 +1363,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModelTry = RequestModel.from(request, registry)
+    val requestModelTry = getRequestModel(request, registry)
     assert(requestModelTry.isSuccess, requestModelTry.errorMessage("Building request model failed"))
 
 
@@ -1334,12 +1374,13 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = generatePipeline(requestModel)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     assert(!result.contains("chunkPeriod"))
   }
   test("successfully ignore chunk period when dim cardinality is not defined") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1363,7 +1404,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModelTry = RequestModel.from(request, registry)
+    val requestModelTry = getRequestModel(request, registry)
     assert(requestModelTry.isSuccess, requestModelTry.errorMessage("Building request model failed"))
 
 
@@ -1374,12 +1415,13 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = generatePipeline(requestModel)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     assert(!result.contains("chunkPeriod"))
   }
   test("successfully set minTopNThreshold when dim cardinality is defined") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1399,18 +1441,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModelTry = RequestModel.from(request, defaultRegistry)
+    val requestModelTry = getRequestModel(request, defaultRegistry)
     val requestModel = requestModelTry.toOption.get.copy(dimCardinalityEstimate = Option(12345))
     val queryPipelineTry = generatePipeline(requestModel)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """"minTopNThreshold":12345"""
 
     assert(result.contains(json), result)
   }
   test("successfully set minTopNThreshold when dim cardinality is not defined") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1430,18 +1473,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModelTry = RequestModel.from(request, defaultRegistry)
+    val requestModelTry = getRequestModel(request, defaultRegistry)
     val requestModel = requestModelTry.toOption.get.copy(dimCardinalityEstimate = None)
     val queryPipelineTry = generatePipeline(requestModel)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     assert(!result.contains("minTopNThreshold"), result)
   }
 
   test("namespace lookup extraction functionality") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1459,7 +1503,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1469,14 +1513,15 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"type":"extraction","dimension":"advertiser_id","outputName":"Advertiser Name","outputType":"STRING","extractionFn":{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"name","dimensionOverrideMap":{},"useQueryLevelCache":false}}"""
 
     assert(result.contains(json), result)
   }
 
   test("Fail filtering on PassthroughType") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1495,7 +1540,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1508,7 +1553,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("namespace lookup extraction functionality for dim") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1531,7 +1577,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1541,12 +1587,12 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val expect_empty_lookup = """{"type":"extraction","dimension":"campaign_id_alias","outputName":"Campaign Name","outputType":"STRING","extractionFn":{"type":"mahaRegisteredLookup","lookup":"campaign_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"name","dimensionOverrideMap":{},"useQueryLevelCache":false}}"""
     val expect_replace_with_other = """{"type":"extraction","dimension":"campaign_id_alias","outputName":"Campaign Total","outputType":"STRING","extractionFn":{"type":"mahaRegisteredLookup","lookup":"campaign_lookup","retainMissingValue":false,"replaceMissingValueWith":"Other","injective":false,"optimize":true,"valueColumn":"total","dimensionOverrideMap":{},"useQueryLevelCache":false}}"""
     val expect_time_extract_func = """{"type":"extraction","dimension":"Campaign Start Date","outputName":"Campaign Start Date","outputType":"STRING","extractionFn":{"type":"time","timeFormat":"yyyy-MM-dd HH:mm:ss","resultFormat":"yyyy-MM-dd","joda":false}}"""
     val expect_replace_with_null = """{"type":"extraction","dimension":"campaign_id_alias","outputName":"Campaign End Date","outputType":"STRING","extractionFn":{"type":"mahaRegisteredLookup","lookup":"campaign_lookup","retainMissingValue":false,"replaceMissingValueWith":"null","injective":false,"optimize":true,"valueColumn":"end_time","dimensionOverrideMap":{},"useQueryLevelCache":false}}"""
-    
+
     assert(result.contains(expect_empty_lookup))
     assert(result.contains(expect_replace_with_other))
     assert(result.contains(expect_time_extract_func))
@@ -1554,7 +1600,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("should generate nested groupby query if dim filter is present") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1577,7 +1624,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1587,13 +1634,14 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"query","query":\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\},\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\},\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\},\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\},\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\},\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\},\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\},\{"type":"selector","dimension":"statsDate","value":"[0-9]{8}"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"statsDate","outputName":"Day","outputType":"STRING"\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Advertiser Status","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"OFF","injective":false,"optimize":true,"valueColumn":"status","dimensionOverrideMap":\{\},"useQueryLevelCache":false\}\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Reseller ID","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"managed_by","dimensionOverrideMap":\{\},"useQueryLevelCache":false\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"filtered","aggregator":\{"type":"roundingDoubleSum","name":"Click Rate Success Case","fieldName":"clicks","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"engagement_type","value":"1"\},\{"type":"selector","dimension":"campaign_id_alias","value":"1"\}\]\},"name":"Click Rate Success Case"\},\{"type":"filtered","aggregator":\{"type":"longSum","name":"Reblogs","fieldName":"engagement_count"\},"filter":\{"type":"selector","dimension":"engagement_type","value":"1"\},"name":"Reblogs"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"doubleMax","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\},\{"type":"arithmetic","name":"Average Position","fn":"/","fields":\[\{"type":"fieldAccess","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"NoopLimitSpec"},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"Advertiser Status","value":"ON"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"Day","outputName":"Day","outputType":"STRING"\},\{"type":"extraction","dimension":"Advertiser Status","outputName":"Advertiser Status","outputType":"STRING","extractionFn":\{"type":"lookup","lookup":\{"type":"map","map":\{"ON":"ON"\},"isOneToOne":false\},"retainMissingValue":false,"replaceMissingValueWith":"OFF","injective":false,"optimize":true\}\},\{"type":"default","dimension":"Reseller ID","outputName":"Reseller ID","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"Impressions"\},\{"type":"roundingDoubleSum","name":"Click Rate Success Case","fieldName":"Click Rate Success Case","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"longSum","name":"Reblogs","fieldName":"Reblogs"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"_sum_avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"doubleMax","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\},\{"type":"arithmetic","name":"Average Position","fn":"/","fields":\[\{"type":"fieldAccess","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\],"limit":220\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
     result should fullyMatch regex json
   }
 
   test("should generate nested groupby query if lookup with decode column is present") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1613,7 +1661,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1623,7 +1671,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"query","query":\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"statsDate","outputName":"Day","outputType":"STRING"\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Advertiser Status","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"OFF","injective":false,"optimize":true,"valueColumn":"status","dimensionOverrideMap":\{\},"useQueryLevelCache":false\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"filtered","aggregator":\{"type":"longSum","name":"Reblogs","fieldName":"engagement_count"\},"filter":\{"type":"selector","dimension":"engagement_type","value":"1"\},"name":"Reblogs"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"doubleMax","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\},\{"type":"arithmetic","name":"Average Position","fn":"/","fields":\[\{"type":"fieldAccess","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"NoopLimitSpec"\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"Day","outputName":"Day","outputType":"STRING"\},\{"type":"extraction","dimension":"Advertiser Status","outputName":"Advertiser Status","outputType":"STRING","extractionFn":\{"type":"lookup","lookup":\{"type":"map","map":\{"ON":"ON"\},"isOneToOne":false\},"retainMissingValue":false,"replaceMissingValueWith":"OFF","injective":false,"optimize":true\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"Impressions"\},\{"type":"longSum","name":"Reblogs","fieldName":"Reblogs"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"_sum_avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"doubleMax","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\},\{"type":"arithmetic","name":"Average Position","fn":"/","fields":\[\{"type":"fieldAccess","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
 
 
@@ -1631,7 +1679,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("should not generate nested groupby query if dim filter column present is not of type druid lookup") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1651,7 +1700,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1661,7 +1710,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"statsDate","outputName":"Day","outputType":"STRING"\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Reseller ID","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"managed_by","dimensionOverrideMap":\{\},"useQueryLevelCache":false\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"filtered","aggregator":\{"type":"longSum","name":"Reblogs","fieldName":"engagement_count"\},"filter":\{"type":"selector","dimension":"engagement_type","value":"1"\},"name":"Reblogs"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"doubleMax","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\},\{"type":"arithmetic","name":"Average Position","fn":"/","fields":\[\{"type":"fieldAccess","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
 
 
@@ -1669,7 +1718,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("should include dim column related to dim filter in nested groupby query if dim filter is present even though dim column is not present in the request") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1689,7 +1739,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1699,7 +1749,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"query","query":\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"statsDate","outputName":"Day","outputType":"STRING"\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Advertiser Status","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"OFF","injective":false,"optimize":true,"valueColumn":"status","dimensionOverrideMap":\{\},"useQueryLevelCache":false\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"filtered","aggregator":\{"type":"longSum","name":"Reblogs","fieldName":"engagement_count"\},"filter":\{"type":"selector","dimension":"engagement_type","value":"1"\},"name":"Reblogs"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"doubleMax","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\},\{"type":"arithmetic","name":"Average Position","fn":"/","fields":\[\{"type":"fieldAccess","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"NoopLimitSpec"\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"Advertiser Status","value":"ON"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"Day","outputName":"Day","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"Impressions"\},\{"type":"longSum","name":"Reblogs","fieldName":"Reblogs"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"_sum_avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\},\{"type":"doubleMax","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\},\{"type":"arithmetic","name":"Average Position","fn":"/","fields":\[\{"type":"fieldAccess","name":"avg_pos_times_impressions","fieldName":"avg_pos_times_impressions"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\],"limit":220\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
 
 
@@ -1707,7 +1757,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("namespace lookup extraction functionality for a public fact with new dimRevision") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1730,7 +1781,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1739,14 +1790,15 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"query","query":\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"statsDate","outputName":"Day","outputType":"STRING"\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Advertiser Status","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"status","dimensionOverrideMap":\{\},"useQueryLevelCache":true\}\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Currency","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"currency","dimensionOverrideMap":\{"-3":"Unknown","":"Unknown"\},"useQueryLevelCache":true\}\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Timezone","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"timezone","decode":\{"columnToCheck":"timezone","valueToCheck":"US","columnIfValueMatched":"timezone","columnIfValueNotMatched":"currency"\},"dimensionOverrideMap":\{\},"useQueryLevelCache":true\}\},\{"type":"extraction","dimension":"external_id","outputName":"External Site Name","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"site_lookup","retainMissingValue":false,"replaceMissingValueWith":"Others","injective":false,"optimize":true,"valueColumn":"external_site_name","dimensionOverrideMap":\{\},"useQueryLevelCache":false\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\}\],"limitSpec":\{"type":"NoopLimitSpec"\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"Advertiser Status","value":"ON"\},\{"type":"selector","dimension":"Currency","value":"USD"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"Day","outputName":"Day","outputType":"STRING"\},\{"type":"default","dimension":"Advertiser Status","outputName":"Advertiser Status","outputType":"STRING"\},\{"type":"default","dimension":"Currency","outputName":"Currency","outputType":"STRING"\},\{"type":"default","dimension":"Timezone","outputName":"Timezone","outputType":"STRING"\},\{"type":"extraction","dimension":"External Site Name","outputName":"External Site Name","outputType":"STRING","extractionFn":\{"type":"lookup","lookup":\{"type":"map","map":\{"null":"Others","":"Others"\},"isOneToOne":false\},"retainMissingValue":true,"injective":true,"optimize":true\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"Impressions"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"_sum_avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\],"limit":220\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
 
     result should fullyMatch regex json
   }
 
   test("should include dimension columns from DruidPostResultDerivedFactCol in DimensionSpec") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -1765,7 +1817,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1774,7 +1826,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json =
       """\{"queryType":"groupBy","dataSource":\{"type":"query","query":\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"statsDate","outputName":"Day","outputType":"STRING"\},\{"type":"default","dimension":"show_sov_flag","outputName":"show_sov_flag","outputType":"STRING"\},\{"type":"extraction","dimension":"advertiser_id","outputName":"Advertiser Status","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"status","dimensionOverrideMap":\{\},"useQueryLevelCache":false\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"longSum","name":"sov_impressions","fieldName":"sov_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Impression Share","fn":"/","fields":\[\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\},\{"type":"fieldAccess","name":"sov_impressions","fieldName":"sov_impressions"\}\]\}\],"limitSpec":\{"type":"NoopLimitSpec"\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"Advertiser Status","value":"ON"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"Day","outputName":"Day","outputType":"STRING"\},\{"type":"default","dimension":"show_sov_flag","outputName":"show_sov_flag","outputType":"STRING"\},\{"type":"default","dimension":"Advertiser Status","outputName":"Advertiser Status","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"Impressions"\},\{"type":"longSum","name":"sov_impressions","fieldName":"sov_impressions"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Impression Share","fn":"/","fields":\[\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\},\{"type":"fieldAccess","name":"sov_impressions","fieldName":"sov_impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\],"limit":220\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}""".stripMargin
 
@@ -1782,7 +1834,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("dimension extraction function for day of the week dimension") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1807,18 +1860,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """{"type":"extraction","dimension":"statsDate","outputName":"Day of Week","outputType":"STRING","extractionFn":{"type":"time","timeFormat":"yyyyMMdd","resultFormat":"EEEE","joda":false}}"""
 
     assert(result.contains(json), result)
   }
 
   test("dimension extraction function for datetime formatter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1844,11 +1898,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json_date = s"""{"type":"extraction","dimension":"start_time","outputName":"Start Date","outputType":"STRING","extractionFn":{"type":"substring","index":0,"length":8}}"""
     val json_hour = s"""{"type":"extraction","dimension":"start_time","outputName":"Start Hour","outputType":"STRING","extractionFn":{"type":"substring","index":8,"length":2}}"""
 
@@ -1858,7 +1912,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("dimension filter extraction function for datetime formatter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats_start_time",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -1883,12 +1938,12 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Failed to get request model"))
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json_date_filter =
       s"""{"type":"and","fields":[{"type":"or","fields":[{"type":"selector","dimension":"start_time","value":"$toDateMinusOneHive","extractionFn":{"type":"substring","index":0,"length":8}},{"type":"selector","dimension":"start_time","value":"$toDateHive","extractionFn":{"type":"substring","index":0,"length":8}}]}""".stripMargin
     val json_date_filter_case_1 = s"""{"type":"and","fields":[{"type":"or","fields":[{"type":"selector","dimension":"start_time","value":"$toDateHive","extractionFn":{"type":"substring","index":0,"length":8}},{"type":"selector","dimension":"start_time","value":"$toDateMinusOneHive","extractionFn":{"type":"substring","index":0,"length":8}}]}"""
@@ -1903,7 +1958,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
   }
 
-  test("dimension filter extraction function for decode dim"){
+  test("dimension filter extraction function for decode dim") {
     val jsonString =
       s"""{
                           "cube": "k_stats_decode_dim",
@@ -1920,7 +1975,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1937,7 +1992,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     result should fullyMatch regex json
   }
 
-  test("dimension filter extraction function for decode dim with mapped null string"){
+  test("dimension filter extraction function for decode dim with mapped null string") {
     val jsonString =
       s"""{
                           "cube": "k_stats_decode_dim",
@@ -1954,7 +2009,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1971,7 +2026,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     result should fullyMatch regex json
   }
 
-  test("dimension filter extraction function for decode dim that has staticMapping for source col"){
+  test("dimension filter extraction function for decode dim that has staticMapping for source col") {
     val jsonString =
       s"""{
                           "cube": "k_stats_decode_dim",
@@ -1988,7 +2043,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2023,7 +2078,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2036,12 +2091,13 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
 
     val json =
-    """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"or","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"price_type","value":"7"\},\{"type":"selector","dimension":"price_type","value":"6"\},\{"type":"selector","dimension":"price_type","value":"8"\}\]\}\]\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\}\],"aggregations":\[\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}""".stripMargin
+      """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"or","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"price_type","value":"7"\},\{"type":"selector","dimension":"price_type","value":"6"\},\{"type":"selector","dimension":"price_type","value":"8"\}\]\}\]\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\}\],"aggregations":\[\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}""".stripMargin
     result should fullyMatch regex json
   }
 
   test("where clause: ensure duplicate filter mappings are not propagated into the where clause") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -2063,11 +2119,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json = """\{"queryType":"topN","dataSource":\{"type":"table","name":"fact1"\},"virtualColumns":\[\],"dimension":\{"type":"default","dimension":"id","outputName":"Keyword ID"\,\"outputType\":\"STRING\"},"metric":\{"type":"numeric","metric":"Impressions"\},"threshold":120,"intervals":\{"type":"intervals","intervals":\[".*"\]\},"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\},\{"type":"or","fields":\[\{"type":"selector","dimension":"stats_source","value":"1"\},\{"type":"selector","dimension":"stats_source","value":"2"\}\]\}\]\},"granularity":\{"type":"all"\},"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"_sum_avg_bid","fieldName":"avg_bid","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"count","name":"_count_avg_bid"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Average Bid","fn":"/","fields":\[\{"type":"fieldAccess","name":"_sum_avg_bid","fieldName":"_sum_avg_bid"\},\{"type":"fieldAccess","name":"_count_avg_bid","fieldName":"_count_avg_bid"\}\]\}\],"context":\{"applyLimitPushDown":"false","userId":"someUser","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
 
@@ -2075,7 +2131,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Or filter expression with dimension AND fact filters should render properly") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -2103,11 +2160,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val filterjson = s""""fields":[{"type":"or","fields":[{"type":"search","dimension":"Advertiser Name","query":{"type":"insensitive_contains","value":"2","caseSensitive":false}},{"type":"selector","dimension":"Campaign Total","value":"Nike"},{"type":"selector","dimension":"Campaign Name","value":"Nike"},{"type":"selector","dimension":"Source","value":"1"},{"type":"selector","dimension":"Ad ID","value":"12345"}]}]"""
     val filterFactJson = s"""{"type":"or","fields":[{"type":"selector","dimension":"ad_id","value":"12345"},{"type":"selector","dimension":"stats_source","value":"1"}]}"""
@@ -2116,7 +2173,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Or filter expression with fact filters") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -2140,13 +2198,13 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-    
-    val filterjson = s""""filter":{"type":"and","fields":[{"type":"selector","dimension":"statsDate","value":"${fromDate.replace("-","")}"},{"type":"selector","dimension":"advertiser_id","value":"12345"}]}"""
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+
+    val filterjson = s""""filter":{"type":"and","fields":[{"type":"selector","dimension":"statsDate","value":"${fromDate.replace("-", "")}"},{"type":"selector","dimension":"advertiser_id","value":"12345"}]}"""
     val havingJson = s""""having":{"type":"and","havingSpecs":[{"type":"or","havingSpecs":[{"type":"or","havingSpecs":[{"type":"equalTo","aggregation":"Clicks","value":1},{"type":"equalTo","aggregation":"Clicks","value":2}]},{"type":"equalTo","aggregation":"Impressions","value":2}]}]}"""
 
     assert(result.contains(filterjson), result)
@@ -2157,7 +2215,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val fromMinute = "00"
     val toMinute = "60"
 
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats_minute_grain",
                           "selectFields": [
                             {"field": "Week"},
@@ -2183,23 +2242,161 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                           "rowsPerPage":100
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Failed to get request model"))
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val expectectDimensionsJson = """"dimensions":[{"type":"extraction","dimension":"statsDate","outputName":"Week","outputType":"STRING","extractionFn":{"type":"time","timeFormat":"yyyyMMdd","resultFormat":"w","joda":false}},{"type":"default","dimension":"stats_source","outputName":"Source","outputType":"STRING"},{"type":"default","dimension":"id","outputName":"Keyword ID","outputType":"STRING"}"""
 
     assert(result.contains(expectectDimensionsJson), s"$expectectDimensionsJson \n\n not found in \n\n $result")
   }
 
+  test("Generate a valid query at minute grain with datetime between filter with timestamp type for Day") {
+    val cubes = List("k_stats_minute_grain_ts_dtf"
+      , "k_stats_minute_grain_ts_period", "k_stats_minute_grain_ts_context", "k_stats_minute_grain_ts_fmt"
+      , "k_stats_minute_grain_ts_dtf_no_local")
+    val validationMap: Map[String, String] = Map(
+      "k_stats_minute_grain_ts_dtf" -> MinuteGrain.toFullFormattedString(baseDate)
+      , "k_stats_minute_grain_ts_period" -> DailyGrain.toFullFormattedString(baseDate)
+      , "k_stats_minute_grain_ts_context" -> {
+        val fmt: DateTimeFormatter = DateTimeFormat.forPattern("YYY-MM-dd HH").withZoneUTC()
+        fmt.print(baseDate)
+      }
+      , "k_stats_minute_grain_ts_fmt" -> {
+        val fmt: DateTimeFormatter = DateTimeFormat.forPattern("yyyyMMddHHmm").withZoneUTC()
+        fmt.print(baseDate)
+      }
+    )
+    cubes.foreach {
+      cube =>
+        val jsonString =
+          s"""{
+                          "cube": "$cube",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Week"},
+                            {"field": "Keyword ID"},
+                            {"field": "Keyword Value"},
+                            {"field": "Source"},
+                            {"field": "Clicks"},
+                            {"field": "CTR"},
+                            {"field": "Reblogs"},
+                            {"field": "Reblog Rate"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "datetimebetween", "from": "${toDateTimeMinusTenMinutes}", "to": "$toDateTime", "format": "$iso8601Format"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "12345"}
+                          ],
+                          "sortBy": [
+                            {"field": "Impressions", "order": "Desc"}
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                        }"""
+        val request: ReportingRequest = getReportingRequestSync(jsonString)
+        val requestModel = getRequestModel(request, defaultRegistry)
+        assert(requestModel.isSuccess, requestModel.errorMessage("Failed to get request model"))
+        val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+        assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+        val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+        assert(result.contains("Day") && result.contains("selector"), result)
+        validationMap.get(cube).foreach {
+          dt => assert(result.contains(dt), s"$dt not found")
+        }
+    }
+  }
+
+  test("Generate a valid query at hourly grain with datetime between filter with timestamp type for Day") {
+    val cubes = List("k_stats_hourly_grain_ts_dtf")
+    cubes.foreach {
+      cube =>
+        val jsonString =
+          s"""{
+                          "cube": "$cube",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Week"},
+                            {"field": "Keyword ID"},
+                            {"field": "Keyword Value"},
+                            {"field": "Source"},
+                            {"field": "Clicks"},
+                            {"field": "CTR"},
+                            {"field": "Reblogs"},
+                            {"field": "Reblog Rate"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "datetimebetween", "from": "${toDateTimeMinusTwoHours}", "to": "$toDateTime", "format": "$iso8601Format"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "12345"}
+                          ],
+                          "sortBy": [
+                            {"field": "Impressions", "order": "Desc"}
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                        }"""
+        val request: ReportingRequest = getReportingRequestSync(jsonString)
+        val requestModel = getRequestModel(request, defaultRegistry)
+        assert(requestModel.isSuccess, requestModel.errorMessage("Failed to get request model"))
+        val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+        assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+        val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+        assert(result.contains("Day") && result.contains("selector") && result.contains(HourlyGrain.toFullFormattedString(baseDate))
+          , result)
+    }
+  }
+
+  test("Generate a valid query at daily grain with datetime between filter with timestamp type for Day") {
+    val cubes = List("k_stats_daily_grain_ts_dtf")
+    cubes.foreach {
+      cube =>
+        val jsonString =
+          s"""{
+                          "cube": "$cube",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Week"},
+                            {"field": "Keyword ID"},
+                            {"field": "Keyword Value"},
+                            {"field": "Source"},
+                            {"field": "Clicks"},
+                            {"field": "CTR"},
+                            {"field": "Reblogs"},
+                            {"field": "Reblog Rate"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "datetimebetween", "from": "${fromDateTime}", "to": "$toDateTime", "format": "$iso8601Format"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "12345"}
+                          ],
+                          "sortBy": [
+                            {"field": "Impressions", "order": "Desc"}
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                        }"""
+        val request: ReportingRequest = getReportingRequestSync(jsonString)
+        val requestModel = getRequestModel(request, defaultRegistry)
+        assert(requestModel.isSuccess, requestModel.errorMessage("Failed to get request model"))
+        val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+        assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+        val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+        assert(result.contains("Day") && result.contains("selector") && result.contains(DailyGrain.toFullFormattedString(baseDate)), result)
+    }
+  }
+
   test("successfully generate query with sync group by single threaded optimization for non grain or index optimized request") {
     val fromMinute = "00"
     val toMinute = "60"
 
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats_minute_grain",
                           "selectFields": [
                             {"field": "Week"},
@@ -2225,12 +2422,12 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                           "rowsPerPage":100
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Failed to get request model"))
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val expectedJson = """"groupByIsSingleThreaded":false"""
 
@@ -2259,7 +2456,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     DruidQueryGenerator.register(failRegistry, queryOptimizer = new SyncDruidQueryOptimizer(timeout = 5000), useCustomRoundingSumAggregator = true)
   }
   test("Join key should not be included in dimension bundle if it is not in the original request when using druid lookups") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Impressions"},
@@ -2274,7 +2472,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2283,15 +2481,16 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-    
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"extraction","dimension":"advertiser_id","outputName":"Advertiser Status","outputType":"STRING","extractionFn":\{"type":"mahaRegisteredLookup","lookup":"advertiser_lookup","retainMissingValue":false,"replaceMissingValueWith":"MAHA_LOOKUP_EMPTY","injective":false,"optimize":true,"valueColumn":"status","dimensionOverrideMap":\{\},"useQueryLevelCache":false\}\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
 
     result should fullyMatch regex json
   }
 
   test("Join key should be included in dimension bundle if it is not in the original request when druid+oracle") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Impressions"},
@@ -2306,21 +2505,22 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = queryPipelineFactory.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-    
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"id","outputName":"Keyword ID"\,\"outputType\":\"STRING\"}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
 
     result should fullyMatch regex json
   }
 
   test("test theta sketch intersect set operation with filters on theta sketch aggregators") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -2345,18 +2545,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\},\{"type":"or","fields":\[\{"type":"selector","dimension":"ageBucket","value":"18-24"\},\{"type":"selector","dimension":"ageBucket","value":"25-35"\}\]\},\{"type":"or","fields":\[\{"type":"selector","dimension":"woeids","value":"12345"\},\{"type":"selector","dimension":"woeids","value":"6789"\}\]\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"id","outputName":"Keyword ID","outputType":"STRING"\},\{"type":"default","dimension":"ad_id","outputName":"Ad ID","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Clicks","fieldName":"clicks"\},\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"filtered","aggregator":\{"type":"thetaSketch","name":"ageBucket_unique_users","fieldName":"uniqueUserCount","size":16384,"shouldFinalize":true,"isInputThetaSketch":false\},"filter":\{"type":"or","fields":\[\{"type":"selector","dimension":"ageBucket","value":"18-24"\},\{"type":"selector","dimension":"ageBucket","value":"25-35"\}\]\},"name":"ageBucket_unique_users"\},\{"type":"filtered","aggregator":\{"type":"thetaSketch","name":"woeids_unique_users","fieldName":"uniqueUserCount","size":16384,"shouldFinalize":true,"isInputThetaSketch":false\},"filter":\{"type":"or","fields":\[\{"type":"selector","dimension":"woeids","value":"12345"\},\{"type":"selector","dimension":"woeids","value":"6789"\}\]\},"name":"woeids_unique_users"\}\],"postAggregations":\[\{"type":"thetaSketchEstimate","name":"Total Unique User Count","field":\{"type":"thetaSketchSetOp","name":"Total Unique User Count","func":"INTERSECT","size":16384,"fields":\[\{"type":"fieldAccess","name":"ageBucket_unique_users","fieldName":"ageBucket_unique_users"\},\{"type":"fieldAccess","name":"woeids_unique_users","fieldName":"woeids_unique_users"\}\]\}\}\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"ascending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Keyword ID","direction":"ascending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Ad ID","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":101\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
 
     result should fullyMatch regex json
   }
 
   test("const fact column and derived const fact column should not be included in aggregators and post aggregators") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -2375,11 +2576,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"ad_id","outputName":"Ad ID","outputType":"STRING"\},\{"type":"default","dimension":"id","outputName":"Keyword ID","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":101\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
 
@@ -2446,7 +2647,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     require(requestModel.isSuccess, requestModel)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -2456,7 +2657,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     assert(queryPipelineTry.get.queryChain.isInstanceOf[MultiQuery], "Failed to create MultiQuery for Async")
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val expectedJson = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"account_stats"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"stats_date","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"12345"\},\{"type":"selector","dimension":"\{test_flag\}","value":"0"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\},\{"type":"default","dimension":"stats_date","outputName":"Day","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"Spend","fieldName":"spend","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"longSum","name":"clicks","fieldName":"clicks"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Const Der Fact Col A","fn":"/","fields":\[\{"type":"fieldAccess","name":"clicks","fieldName":"clicks"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"ascending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Spend","direction":"descending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Const Der Fact Col A","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":200\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
 
     println(expectedJson)
@@ -2527,7 +2728,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     require(requestModel.isSuccess, requestModel)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
@@ -2535,7 +2736,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val expectedJson = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"account_stats"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"stats_date","value":".*"\},\{"type":"selector","dimension":"advertiser_id","value":"1035663"\},\{"type":"selector","dimension":"\{test_flag\}","value":"0"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\},\{"type":"default","dimension":"stats_date","outputName":"Day","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Impressions","fieldName":"impressions"\},\{"type":"roundingDoubleSum","name":"Spend","fieldName":"spend","scale":10,"enableRoundingDoubleSumAggregatorFactory":true\},\{"type":"longSum","name":"clicks","fieldName":"clicks"\}\],"postAggregations":\[\{"type":"arithmetic","name":"Const Der Fact Col A","fn":"/","fields":\[\{"type":"fieldAccess","name":"clicks","fieldName":"clicks"\},\{"type":"fieldAccess","name":"impressions","fieldName":"Impressions"\}\]\}\],"limitSpec":\{"type":"default","columns":\[\{"dimension":"Impressions","direction":"ascending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Spend","direction":"descending","dimensionOrder":\{"type":"numeric"\}\},\{"dimension":"Const Der Fact Col A","direction":"descending","dimensionOrder":\{"type":"numeric"\}\}\],"limit":200\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
     result should fullyMatch regex expectedJson
 
@@ -2544,7 +2745,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     subSequentQuery should fullyMatch regex expectedSubQueryJson
   }
 
-  test("dimension filter extraction function for decode dim should work for more than 2 mappings"){
+  test("dimension filter extraction function for decode dim should work for more than 2 mappings") {
     val jsonString =
       s"""{
                           "cube": "k_stats_derived_decode_dim",
@@ -2562,7 +2763,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, InternalSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2574,12 +2775,13 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json =
-        """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"123"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"extraction","dimension":"ad_id","outputName":"Derived Ad ID","outputType":"STRING","extractionFn":\{"type":"lookup","lookup":\{"type":"map","map":\{"0":"EMPTY","-3":"EMPTY"\},"isOneToOne":false\},"retainMissingValue":true,"injective":false,"optimize":true\}\},\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\}\],"aggregations":\[\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
+      """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\},\{"type":"selector","dimension":"statsDate","value":".*"\}\]\},\{"type":"selector","dimension":"advertiser_id","value":"123"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"extraction","dimension":"ad_id","outputName":"Derived Ad ID","outputType":"STRING","extractionFn":\{"type":"lookup","lookup":\{"type":"map","map":\{"0":"EMPTY","-3":"EMPTY"\},"isOneToOne":false\},"retainMissingValue":true,"injective":false,"optimize":true\}\},\{"type":"default","dimension":"advertiser_id","outputName":"Advertiser ID","outputType":"STRING"\}\],"aggregations":\[\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"groupByStrategy":"v2","applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}"""
     result should fullyMatch regex json
   }
 
   test("Druid query should be generated successfully with scan query type") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "queryType": "scan",
                           "cube": "k_stats_select",
                           "selectFields": [
@@ -2597,17 +2799,18 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-    val json= """\{"queryType":"scan","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*Z"\]\},"virtualColumns":\[\],"resultFormat":"list","batchSize":20480,"limit":5,"order":"none","filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"columns":\["id","__time","impressions"\],"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"timeout":5000,"queryId":".*"\},"descending":false,"granularity":\{"type":"all"\}\}"""
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val json = """\{"queryType":"scan","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*Z"\]\},"virtualColumns":\[\],"resultFormat":"list","batchSize":20480,"limit":5,"order":"none","filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"columns":\["id","__time","impressions"\],"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"timeout":5000,"queryId":".*"\},"descending":false,"granularity":\{"type":"all"\}\}"""
     result should fullyMatch regex json
   }
 
   test("Druid query should fail to generate with scan query type when sort by requested") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "queryType": "scan",
                           "cube": "k_stats",
                           "selectFields": [
@@ -2627,14 +2830,15 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("query pipeline should fail"))
     assert(queryPipelineTry.failed.toOption.get.getMessage.contains("druid scan query type does not support sort by functionality!"))
   }
 
   test("Druid query should fail to generate with scan query type when derived fact requested") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "queryType": "scan",
                           "cube": "k_stats",
                           "selectFields": [
@@ -2651,14 +2855,15 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("query pipeline should fail"))
     assert(queryPipelineTry.failed.toOption.get.getMessage.contains("druid scan query does not support derived columns : CTR"))
   }
 
   test("Druid query should fail to generate with scan query type when filter on derived fact requested") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "queryType": "scan",
                           "cube": "k_stats",
                           "selectFields": [
@@ -2676,14 +2881,15 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, getDefaultRegistry())
+    val requestModel = getRequestModel(request, getDefaultRegistry())
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("query pipeline should fail"))
     assert(queryPipelineTry.failed.toOption.get.getMessage.contains("druid scan query type does not support filter on derived columns: CTR"))
   }
 
   test("Druid query should fail to generate with scan query type when using druid for dimension joins") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "queryType": "scan",
                           "cube": "k_stats",
                           "selectFields": [
@@ -2701,7 +2907,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString, AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option.apply(1))
+    val requestModel = getRequestModel(request, registry, revision = Option.apply(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2714,7 +2920,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("dimension time extraction function for druid time when no timezone is specified in additional parameters") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "queryType": "groupby",
                           "cube": "k_stats_date_select",
                           "selectFields": [
@@ -2732,18 +2939,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json = """{"type":"extraction","dimension":"__time","outputName":"Day","outputType":"STRING","extractionFn":{"type":"timeFormat","format":"YYYY-MM-dd HH","timeZone":"UTC","granularity":{"type":"none"},"asMillis":false}}"""
     assert(result.contains(json), result)
   }
 
   test("dimension time extraction function for druid time when timezone is specified in the request") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "queryType": "groupby",
                           "cube": "k_stats_date_select",
                           "selectFields": [
@@ -2761,17 +2969,18 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = ReportingRequest.withTimeZone(getReportingRequestSync(jsonString), "America/Los_Angeles")
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = """__time","outputName":"Day","outputType":"STRING","extractionFn":{"type":"timeFormat","format":"YYYY-MM-dd HH","timeZone":"America/Los_Angeles","granularity":{"type":"none"},"asMillis":false}}"""
     assert(result.contains(json), result)
   }
 
   test("Filter on time dimension extracted using request context should render correctly") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "queryType": "scan",
                           "cube": "k_stats_date_select",
                           "selectFields": [
@@ -2789,17 +2998,18 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = ReportingRequest.withTimeZone(getReportingRequestSync(jsonString), "America/Los_Angeles")
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
 
     ColumnContext.withColumnContext { implicit cc =>
       val dayCol = DruidFuncDimCol("Date From Req Context", DateType(), TIME_FORMAT_WITH_REQUEST_CONTEXT("YYYY-MM-dd HH"))
-      val filters = FilterDruid.renderDateDimFilters(requestModel.toOption.get, Map("Day" -> "Day"), Map("Day" -> dayCol))
+      val filters = FilterDruid.renderDateDimFilters(requestModel.toOption.get, Map("Day" -> "Day"), Map("Day" -> dayCol), DailyGrain)
       assert(filters.nonEmpty)
     }
   }
 
   test("Inner should query should not have limitSpec if 'shouldLimitInnerQueries' is set to false") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -2821,19 +3031,19 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", ""))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
-    val druidQueryGenerator =  new DruidQueryGenerator(new SyncDruidQueryOptimizer(timeout = 5000), 40000, shouldLimitInnerQueries = false)
+    val druidQueryGenerator = new DruidQueryGenerator(new SyncDruidQueryOptimizer(timeout = 5000), 40000, shouldLimitInnerQueries = false)
 
     altQueryGeneratorRegistry.register(DruidEngine, druidQueryGenerator)
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory(druidMultiQueryEngineList = List(defaultFactEngine))(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val expect_empty_limitspec_inner_query = """"limitSpec":{"type":"NoopLimitSpec"},"context":{"applyLimitPushDown":"false""""
     val expect_nonempty_limitspec_outer_query = """"limitSpec":{"type":"default","columns":[],"limit":220}"""
     val expect_bound_filter = """{"type":"bound","dimension":"Derived Pricing Type","lower":"1","upper":"20","lowerStrict":false,"upperStrict":false,"ordering":{"type":"numeric"}}"""
@@ -2843,7 +3053,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("should generate nested groupby query if expensive date time filter is present") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats_expensive_date_time",
                           "selectFields": [
                             {"field": "Day"},
@@ -2860,7 +3071,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.withTimeZone(getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "")), "America/Los_Angeles")
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -2870,15 +3081,16 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-//
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    //
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"query","query":\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"},"intervals":\{"type":"intervals","intervals":\[".*"\]},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"advertiser_id","value":"12345"}\]},"granularity":\{"type":"all"},"dimensions":\[\{"type":"extraction","dimension":"__time","outputName":"Day","outputType":"STRING","extractionFn":\{"type":"timeFormat","format":"YYYY-MM-dd HH","timeZone":"America/Los_Angeles","granularity":\{"type":"none"},"asMillis":false}}\],"aggregations":\[\{"type":"longSum","name":"Clicks","fieldName":"clicks"},\{"type":"longSum","name":"Impressions","fieldName":"impressions"}\],"postAggregations":\[\],"limitSpec":\{"type":"NoopLimitSpec"\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"},"descending":false}},"intervals":\{"type":"intervals","intervals":\[".*"\]},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"Day","value":".*"},\{"type":"selector","dimension":"Day","value":".*"},\{"type":"selector","dimension":"Day","value":".*"},\{"type":"selector","dimension":"Day","value":".*"},\{"type":"selector","dimension":"Day","value":".*"},\{"type":"selector","dimension":"Day","value":".*"},\{"type":"selector","dimension":"Day","value":".*"},\{"type":"selector","dimension":"Day","value":".*"}\]}\]},"granularity":\{"type":"all"},"dimensions":\[\{"type":"default","dimension":"Day","outputName":"Day","outputType":"STRING"}\],"aggregations":\[\{"type":"longSum","name":"Clicks","fieldName":"Clicks"},\{"type":"longSum","name":"Impressions","fieldName":"Impressions"}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":120},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"},"descending":false}"""
 
     result should fullyMatch regex json
   }
 
   test("should generate nested groupby query if expensive date time filter is present and inner groupby should include Day even though it's not in the original request") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats_expensive_date_time",
                           "selectFields": [
                             {"field": "Clicks"},
@@ -2894,7 +3106,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.withTimeZone(getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "")), "America/Los_Angeles")
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -2904,15 +3116,16 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-//
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    //
     val json = """\{"queryType":"groupBy","dataSource":\{"type":"query","query":\{"queryType":"groupBy","dataSource":\{"type":"table","name":"fact1"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"selector","dimension":"advertiser_id","value":"12345"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"extraction","dimension":"__time","outputName":"Day","outputType":"STRING","extractionFn":\{"type":"timeFormat","format":"YYYY-MM-dd HH","timeZone":"America/Los_Angeles","granularity":\{"type":"none"\},"asMillis":false\}\}\],"aggregations":\[\{"type":"longSum","name":"Clicks","fieldName":"clicks"\},\{"type":"longSum","name":"Impressions","fieldName":"impressions"\}\],"postAggregations":\[\],"limitSpec":\{"type":"NoopLimitSpec"\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"Day","value":".*"\},\{"type":"selector","dimension":"Day","value":".*"\},\{"type":"selector","dimension":"Day","value":".*"\},\{"type":"selector","dimension":"Day","value":".*"\},\{"type":"selector","dimension":"Day","value":".*"\},\{"type":"selector","dimension":"Day","value":".*"\},\{"type":"selector","dimension":"Day","value":".*"\},\{"type":"selector","dimension":"Day","value":".*"\}\]\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\],"aggregations":\[\{"type":"longSum","name":"Clicks","fieldName":"Clicks"\},\{"type":"longSum","name":"Impressions","fieldName":"Impressions"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":120\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":"abc123"\},"descending":false\}"""
 
     result should fullyMatch regex json
   }
 
   test("populate context with hostname") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -2932,7 +3145,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithHostName(jsonString, "127.1.1.0")
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -2942,7 +3155,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     assert(result.contains(""""hostName":"127.1.1.0""""))
   }
@@ -2966,19 +3179,20 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
     val queryPipeline = queryPipelineTry.toOption.get
-    val query =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     assert(query.contains("""{"type":"extraction","dimension":"Advertiser Last Updated","outputName":"Advertiser Last Updated","outputType":"STRING","extractionFn":{"type":"timeFormat","format":"YYYYMMdd","timeZone":"UTC","granularity":{"type":"none"},"asMillis":true}}"""))
   }
 
   test("Successfully generate a query with HyperUniques Filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -2996,11 +3210,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json = "{\"type\":\"hyperUnique\",\"name\":\"Unique Ad IDs\",\"fieldName\":\"ad_id\",\"isInputHyperUnique\":false,\"round\":true}"
 
@@ -3008,7 +3222,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Successfully generate a query with HyperUniqueCardinalityWrapper") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -3027,17 +3242,18 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     val json = "{\"type\":\"hyperUniqueCardinality\",\"name\":\"Unique Ad IDs Count\",\"fieldName\":\"Unique Ad IDs\"}"
     assert(result.contains(json))
   }
 
   test("Successfully set query priority for async request") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -3053,14 +3269,14 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestAsync(jsonString))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
     altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator(new AsyncDruidQueryOptimizer())) //do not include local time filter
     val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory(druidMultiQueryEngineList = List(defaultFactEngine))(altQueryGeneratorRegistry)
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json = """"priority":-1"""
     assert(result.contains(json), json)
@@ -3089,12 +3305,12 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request1: ReportingRequest = getReportingRequestSync(jsonString_inner).copy(queryType = RowCountQuery)
-    val requestModel1 = RequestModel.from(request1, getDefaultRegistry())
+    val requestModel1 = getRequestModel(request1, getDefaultRegistry())
     val queryPipelineTry1 = generatePipeline(requestModel1.toOption.get)
     assert(queryPipelineTry1.isSuccess, queryPipelineTry1.errorMessage("Fail to get the query pipeline"))
 
     val result1 = queryPipelineTry1.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-//    println(result1)
+    //    println(result1)
     assert(StringUtils.countMatches(result1, """"queryType":"groupBy"""") == 2, "Failed to generate 2-level groupby query")
     assert(!result1.contains(""""limitSpec":{"type":"default","columns":[],"limit":200}"""), "Failed to remove inner limitSpec")
     assert(result1.contains(""""aggregations":[{"type":"count","name":"TOTALROWS"}]"""), "Failed to generate row count aggregator")
@@ -3123,12 +3339,12 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     // request from RowCountCurator will change queryType to RowCountQuery
     val request2: ReportingRequest = getReportingRequestSync(jsonString_outer).copy(queryType = RowCountQuery)
-    val requestModel2 = RequestModel.from(request2, getDefaultRegistry())
+    val requestModel2 = getRequestModel(request2, getDefaultRegistry())
     val queryPipelineTry2 = generatePipeline(requestModel2.toOption.get)
     assert(queryPipelineTry2.isSuccess, queryPipelineTry2.errorMessage("Fail to get the query pipeline"))
 
     val result2 = queryPipelineTry2.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
-//    println(result2)
+    //    println(result2)
     assert(StringUtils.countMatches(result2, """"queryType":"groupBy"""") == 3, "Failed to generate 3-level groupby query")
     assert(!result2.contains(""""limitSpec":{"type":"default","columns":[],"limit":200}"""), "Failed to remove limitSpec")
     assert(result2.contains(""""aggregations":[{"type":"count","name":"TOTALROWS"}]"""), "Failed to generate row count aggregator")
@@ -3156,7 +3372,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3168,7 +3384,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("limit should be set when rowsPerPage is specified for Async") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "user_stats",
                           "selectFields": [
                             {"field": "Impressions"},
@@ -3185,11 +3402,11 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
 
     val json = """limit":22"""
 
@@ -3220,7 +3437,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3258,7 +3475,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3271,7 +3488,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Successfully generate a time extraction function when period granularity is specified") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Keyword ID"},
@@ -3288,7 +3506,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                         }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
@@ -3298,7 +3516,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Successfully generate a filter on an aggregated fact col even when the fact is not in the selected fields") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                       "cube": "k_stats",
                       "selectFields": [
                         {"field": "Keyword ID"},
@@ -3315,7 +3534,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
                     }"""
 
     val request: ReportingRequest = getReportingRequestSyncWithAdditionalParameters(jsonString, RequestContext("abc123", "someUser"))
-    val requestModel = RequestModel.from(request, defaultRegistry)
+    val requestModel = getRequestModel(request, defaultRegistry)
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
@@ -3325,7 +3544,8 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
   }
 
   test("Druid query should be generated with NotLike filter") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -3343,7 +3563,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -3353,13 +3573,14 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     println(result)
     assert(result.contains(""""filter":{"type":"and","fields":[{"type":"not","field":{"type":"search","dimension":"Campaign Name","query":{"type":"insensitive_contains","value":"test","caseSensitive":false}}}]}"""))
   }
 
   test("Druid query with Lookups should contain column alias if available") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -3377,7 +3598,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -3387,12 +3608,13 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     println(result)
   }
 
   test("Druid query should retain missing value if LOOKUP_WITH_EMPTY_VALUE_OVERRIDE is used") {
-    val jsonString = s"""{
+    val jsonString =
+      s"""{
                           "cube": "k_stats",
                           "selectFields": [
                             {"field": "Day"},
@@ -3410,7 +3632,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -3420,7 +3642,7 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
-    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
     assert(result.contains(s""""extractionFn":{"type":"mahaRegisteredLookup","lookup":"campaign_lookup","retainMissingValue":true,"injective":false,"optimize":true,"valueColumn":"name","dimensionOverrideMap":{},"useQueryLevelCache":false}}"""))
   }
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorTest.scala
@@ -39,7 +39,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -53,7 +53,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -70,7 +70,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -88,7 +88,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -103,7 +103,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -118,7 +118,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -133,7 +133,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -147,7 +147,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -162,7 +162,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -182,7 +182,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -199,7 +199,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -214,7 +214,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -230,7 +230,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -246,7 +246,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -261,7 +261,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -276,7 +276,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -310,7 +310,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     assert(requestModel.toOption.get.anyDimHasNonFKNonForceFilter == true)
@@ -328,7 +328,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     assert(requestModel.toOption.get.anyDimHasNonFKNonForceFilter == false)
@@ -346,7 +346,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -380,7 +380,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -436,7 +436,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       """.stripMargin
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -497,7 +497,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
       """.stripMargin
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -524,7 +524,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -565,7 +565,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -610,7 +610,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -657,7 +657,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -721,7 +721,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -765,7 +765,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -810,7 +810,7 @@ class HiveQueryGeneratorTest extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1644,7 +1644,7 @@ GROUP BY a2.mang_ad_status,c1.mang_campaign_name,af0.campaign_id) outergroupby
     val requestRaw = ReportingRequest.deserializeAsync(requestJson.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
     val request = ReportingRequest.forceHive(requestRaw.toOption.get)
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV1Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV1Test.scala
@@ -69,7 +69,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -87,7 +87,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -104,7 +104,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -122,7 +122,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -137,7 +137,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -152,7 +152,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -167,7 +167,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -181,7 +181,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -196,7 +196,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -215,7 +215,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -258,7 +258,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -273,7 +273,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -289,7 +289,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -305,7 +305,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -320,7 +320,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -335,7 +335,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -367,7 +367,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     assert(requestModel.toOption.get.anyDimHasNonFKNonForceFilter == true)
@@ -385,7 +385,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     assert(requestModel.toOption.get.anyDimHasNonFKNonForceFilter == false)
@@ -403,7 +403,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -446,7 +446,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -502,7 +502,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       """.stripMargin
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -563,7 +563,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
       """.stripMargin
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -590,7 +590,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -634,7 +634,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
@@ -664,7 +664,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1673,7 +1673,7 @@ class HiveQueryGeneratorV1Test extends BaseHiveQueryGeneratorTest {
   }
 
   def generateHiveQuery(requestJson: String, registry:Registry): String = {
-    val requestModel = RequestModel.from(getHiveReportingRequest(requestJson), registry)
+    val requestModel = getRequestModel(getHiveReportingRequest(requestJson), registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry: Try[QueryPipeline] = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
@@ -41,7 +41,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -55,7 +55,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -72,7 +72,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -90,7 +90,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -105,7 +105,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -120,7 +120,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -135,7 +135,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -149,7 +149,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -164,7 +164,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -184,7 +184,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -201,7 +201,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -216,7 +216,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -232,7 +232,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -248,7 +248,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -263,7 +263,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -278,7 +278,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -309,7 +309,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     assert(requestModel.toOption.get.anyDimHasNonFKNonForceFilter == true)
@@ -327,7 +327,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     assert(requestModel.toOption.get.anyDimHasNonFKNonForceFilter == false)
@@ -345,7 +345,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -379,7 +379,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -435,7 +435,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       """.stripMargin
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -496,7 +496,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
       """.stripMargin
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -522,7 +522,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -569,7 +569,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -635,7 +635,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -690,7 +690,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -749,7 +749,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -776,6 +776,126 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
   }
 
+  test("successfully generate fact driven query for day grain with datetime between filter") {
+    val jsonString =
+      s"""{
+                          "cube": "s_stats",
+                          "selectFields": [
+                              {"field": "Advertiser Name"},
+                              {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"},
+                              {"field": "Impressions", "operator": ">", "value": "1608"}
+                          ],
+                          "sortBy": [{"field": "Advertiser Name", "order": "Desc"},  {"field": "Impressions", "order": "DESC"}]
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
+
+    val expected =
+      s"""
+         |SELECT CONCAT_WS(',', CAST(NVL(mang_advertiser_name,'') AS STRING),CAST(NVL(mang_impressions,'') AS STRING))
+         |FROM(
+         |SELECT mang_advertiser_name AS mang_advertiser_name, impressions AS mang_impressions
+         |FROM(
+         |SELECT COALESCE(a1.mang_advertiser_name, 'NA') mang_advertiser_name, SUM(impressions) AS impressions
+         |FROM(SELECT account_id, SUM(impressions) impressions
+         |FROM s_stats_fact
+         |WHERE (account_id = 12345) AND (stats_date >= cast('$fromDate' as date) AND stats_date <= cast('$toDate' as date))
+         |GROUP BY account_id
+         |HAVING (SUM(impressions) > 1608)
+         |       )
+         |ssf0
+         |LEFT OUTER JOIN (
+         |SELECT name AS mang_advertiser_name, id a1_id
+         |FROM advertiser_hive
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
+         |)
+         |a1
+         |ON
+         |ssf0.account_id = a1.a1_id
+         |
+         |GROUP BY COALESCE(a1.mang_advertiser_name, 'NA')
+         |ORDER BY mang_advertiser_name DESC, impressions DESC) OgbQueryAlias
+         |) queryAlias LIMIT 200
+         |
+       """.stripMargin
+
+    result should equal (expected) (after being whiteSpaceNormalised)
+
+  }
+
+  test("successfully generate fact driven query for minute grain with datetime between filter") {
+    val jsonString =
+      s"""{
+                          "cube": "s_stats_minute",
+                          "selectFields": [
+                              {"field": "Advertiser Name"},
+                              {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"},
+                              {"field": "Impressions", "operator": ">", "value": "1608"}
+                          ],
+                          "sortBy": [{"field": "Advertiser Name", "order": "Desc"},  {"field": "Impressions", "order": "DESC"}]
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v2)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
+
+    val expected =
+      s"""
+         |SELECT CONCAT_WS(',', CAST(NVL(mang_advertiser_name,'') AS STRING),CAST(NVL(mang_impressions,'') AS STRING))
+         |FROM(
+         |SELECT mang_advertiser_name AS mang_advertiser_name, impressions AS mang_impressions
+         |FROM(
+         |SELECT COALESCE(a1.mang_advertiser_name, 'NA') mang_advertiser_name, SUM(impressions) AS impressions
+         |FROM(SELECT account_id, SUM(impressions) impressions
+         |FROM s_stats_fact
+         |WHERE (account_id = 12345) AND (stats_date >= cast('${fromDateTime.dropRight(1)}' as timestamp) AND stats_date <= cast('${toDateTime.dropRight(1)}' as timestamp))
+         |GROUP BY account_id
+         |HAVING (SUM(impressions) > 1608)
+         |       )
+         |ssf0
+         |LEFT OUTER JOIN (
+         |SELECT name AS mang_advertiser_name, id a1_id
+         |FROM advertiser_hive
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
+         |)
+         |a1
+         |ON
+         |ssf0.account_id = a1.a1_id
+         |
+         |GROUP BY COALESCE(a1.mang_advertiser_name, 'NA')
+         |ORDER BY mang_advertiser_name DESC, impressions DESC) OgbQueryAlias
+         |) queryAlias LIMIT 200
+         |
+       """.stripMargin
+
+    result should equal (expected) (after being whiteSpaceNormalised)
+
+  }
+
   test("generating hive query with sort by") {
     val jsonString =
       s"""{
@@ -796,7 +916,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -853,7 +973,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -913,7 +1033,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -979,7 +1099,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1050,7 +1170,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1119,7 +1239,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1188,7 +1308,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1257,7 +1377,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1297,7 +1417,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1335,7 +1455,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1404,7 +1524,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1446,19 +1566,5 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
        """.stripMargin
 
     result should equal (expected) (after being whiteSpaceNormalised)
-  }
-
-  def generateHiveQuery(requestJson: String): String = {
-    val requestRaw = ReportingRequest.deserializeAsync(requestJson.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
-    val registry = defaultRegistry
-    val request = ReportingRequest.forceHive(requestRaw.toOption.get)
-    val requestModel = RequestModel.from(request, registry)
-    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
-
-    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
-    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-
-    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
-    result
   }
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/oracle/BaseOracleQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/oracle/BaseOracleQueryGeneratorTest.scala
@@ -40,6 +40,7 @@ trait BaseOracleQueryGeneratorTest
     registryBuilder.register(pubfact9(forcedFilters))
     registryBuilder.register(pubFactCombined(forcedFilters))
     registryBuilder.register(pubFact10(forcedFilters))
+    registryBuilder.register(pubFact11(forcedFilters))
 
   }
 
@@ -885,5 +886,102 @@ trait BaseOracleQueryGeneratorTest
       , Set(
         PublicFactCol("num_students", "Students", Equality)
       ), Set.empty, getMaxDaysWindow, getMaxDaysLookBack)
+  }
+
+  def pubFact11(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+    import OracleExpression._
+    ColumnContext.withColumnContext { implicit dc: ColumnContext =>
+      Fact.newFact(
+        "fact1", MinuteGrain, OracleEngine, Set(AdvertiserSchema, ResellerSchema),
+        Set(
+          DimCol("keyword_id", IntType(), annotations = Set(ForeignKey("keyword")))
+          , DimCol("ad_id", IntType(), annotations = Set(ForeignKey("ad")))
+          , DimCol("ad_group_id", IntType(), annotations = Set(ForeignKey("ad_group")))
+          , DimCol("campaign_id", IntType(), annotations = Set(ForeignKey("campaign")))
+          , DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+          , DimCol("stats_source", IntType(3))
+          , DimCol("source_name", IntType(3, (Map(1 -> "Native", 2 -> "Search", -1 -> "UNKNOWN"), "UNKNOWN")), alias = Option("stats_source"))
+          , DimCol("price_type", IntType(3, (Map(1 -> "CPC", 2 -> "CPA", 3 -> "CPM", 6 -> "CPV", 7 -> "CPCV", -10 -> "CPE", -20 -> "CPF"), "NONE")))
+          , DimCol("device_id", IntType(3, (Map(1 -> "Desktop", 2 -> "Tablet", 3 -> "SmartPhone", -1 -> "UNKNOWN"), "UNKNOWN")))
+          , DimCol("network_type", StrType(100, (Map("TEST_PUBLISHER" -> "Test Publisher", "CONTENT_SYNDICATION" -> "Content Syndication", "EXTERNAL" -> "Yahoo Partners" ,  "INTERNAL" -> "Yahoo Properties"), "NONE")))
+          , DimCol("start_time", IntType())
+          , DimCol("landing_page_url", StrType(), annotations = Set(EscapingRequired))
+          , DimCol("target_page_url", StrType(), annotations = Set(CaseInsensitive))
+          , DimCol("stats_date", TimestampType())
+          , DimCol("column_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned")))
+          , DimCol("column2_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned_with_singleton")))
+          , OracleDerDimCol("Ad Group Start Date Full", StrType(), TIMESTAMP_TO_FORMATTED_DATE("{start_time}", "YYYY-MM-dd HH:mm:ss"))
+          , OracleDerDimCol("Month", DateType(), GET_INTERVAL_DATE("{stats_date}", "M"))
+          , OracleDerDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "W"))
+        ),
+        Set(
+          FactCol("impressions", IntType(3, 1))
+          , FactCol("clicks", IntType(3, 0, 1, 800))
+          , FactCol("spend", DecType(0, "0.0"))
+          , FactCol("max_bid", DecType(0, "0.0"), MaxRollup)
+          , FactCol("Average CPC", DecType(), OracleCustomRollup(SUM("{spend}") / SUM("{clicks}")))
+          , FactCol("CTR", DecType(), OracleCustomRollup(SUM("{clicks}" /- "{impressions}")))
+          , FactCol("avg_pos", DecType(3, "0.0", "0.1", "500"), OracleCustomRollup(SUM("{avg_pos}" * "{impressions}") /- SUM("{impressions}")))
+          , FactCol("Count", IntType(), rollupExpression = CountRollup)
+          , FactCol("Avg", IntType(), rollupExpression = AverageRollup, alias = Option("avg_col"))
+          , FactCol("Max", IntType(), rollupExpression = MaxRollup, alias = Option("max_col"))
+          , FactCol("Min", IntType(), rollupExpression = MinRollup, alias = Option("min_col"))
+        ),
+        annotations = Set(
+          OracleFactStaticHint("PARALLEL_INDEX(cb_campaign_k_stats 4)"),
+          OracleFactDimDrivenHint("PUSH_PRED PARALLEL_INDEX(cb_campaign_k_stats 4)")
+        )
+      )
+    }
+      .newRollUp("fact2"
+        , "fact1"
+        , discarding = Set("ad_id")
+        , columnAliasMap = Map("price_type" -> "pricing_type", "source_name" -> "stats_source")
+        , overrideAnnotations = Set(
+          OracleFactConditionalHint(FactCondition(Option(true)), "CONDITIONAL_HINT1")
+          , OracleFactConditionalHint(FactCondition(Option(true), Option(false)), "CONDITIONAL_HINT2")
+          , OracleFactConditionalHint(FactCondition(Option(true), Option(false), Option(true)), "CONDITIONAL_HINT3")
+          , OracleFactConditionalHint(FactCondition(Option(true), Option(false), Option(false), Option(false)), "CONDITIONAL_HINT4")
+          , OracleFactConditionalHint(FactCondition(None, minRowsEstimate = Option(900L))
+            , "CONDITIONAL_HINT5")
+        ), availableOnwardsDate = Some("2010-01-01")
+      ).toPublicFact("k_stats_minute",
+      Set(
+        PubCol("stats_date", "Day", InBetweenEquality),
+        PubCol("keyword_id", "Keyword ID", InEquality),
+        PubCol("ad_id", "Ad ID", InEquality),
+        PubCol("ad_group_id", "Ad Group ID", InEquality),
+        PubCol("campaign_id", "Campaign ID", InEquality),
+        PubCol("advertiser_id", "Advertiser ID", InEquality),
+        PubCol("network_type", "Network Type", InEquality),
+        PubCol("stats_source", "Source", EqualityFieldEquality, incompatibleColumns = Set("Source Name")),
+        PubCol("source_name", "Source Name", InNotInBetweenEqualityNotEqualsGreaterLesser, incompatibleColumns = Set("Source")),
+        PubCol("price_type", "Pricing Type", In),
+        PubCol("landing_page_url", "Destination URL", FieldEquality, isImageColumn = true),
+        PubCol("target_page_url", "Source URL", FieldEquality),
+        PubCol("column_id", "Column ID", Equality),
+        PubCol("column2_id", "Column2 ID", Equality),
+        PubCol("Ad Group Start Date Full", "Ad Group Start Date Full", InEquality),
+        PubCol("Month", "Month", Equality),
+        PubCol("Week", "Week", Equality),
+        PubCol("device_id", "Device ID", InEquality)
+      ),
+      Set(
+        PublicFactCol("impressions", "Impressions", InNotInBetweenEqualityNotEqualsGreaterLesser),
+        PublicFactCol("impressions", "Total Impressions", InBetweenEquality),
+        PublicFactCol("clicks", "Clicks", InBetweenEqualityFieldEquality),
+        PublicFactCol("spend", "Spend", FieldEquality),
+        PublicFactCol("avg_pos", "Average Position", FieldEquality),
+        PublicFactCol("max_bid", "Max Bid", Set.empty),
+        PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
+        PublicFactCol("CTR", "CTR", InBetweenEquality),
+        PublicFactCol("Count", "Count", InBetweenEquality),
+        PublicFactCol("Avg", "Avg", InBetweenEquality),
+        PublicFactCol("Max", "Max", InBetweenEquality),
+        PublicFactCol("Min", "Min", InBetweenEquality)
+      ),
+      Set(EqualityFilter("Source", "2", true, true)),
+      getMaxDaysWindow, getMaxDaysLookBack
+    )
   }
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
@@ -5295,8 +5295,9 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                            ],
                           "filterExpressions": [
                              {"field": "Publisher ID", "operator": "=", "value": "12345"},
-                             {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"}
-                           ],
+                             {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                             {"field": "Hour", "operator": "between", "from": "0", "to": "23"}
+                          ],
                            "paginationStartIndex":0,
                            "rowsPerPage":100
                           }"""

--- a/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
@@ -34,7 +34,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -51,7 +51,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -68,7 +68,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -85,7 +85,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -103,7 +103,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -120,7 +120,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -137,7 +137,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -152,7 +152,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -170,7 +170,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -190,7 +190,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -207,7 +207,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -224,7 +224,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -241,7 +241,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -258,7 +258,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -276,7 +276,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -296,7 +296,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -314,7 +314,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -334,7 +334,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isFactDriven)
 
@@ -358,7 +358,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isFactDriven)
 
@@ -384,7 +384,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isFactDriven)
 
@@ -402,7 +402,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isFactDriven)
 
@@ -446,7 +446,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -518,7 +518,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -595,7 +595,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -663,7 +663,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -693,7 +693,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -723,7 +723,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -753,7 +753,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -783,7 +783,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -798,7 +798,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -814,7 +814,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -848,7 +848,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days window exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max days window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -876,7 +876,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days look back exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max look back window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -904,7 +904,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days window exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max days window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -932,7 +932,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days look back exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max look back window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -960,7 +960,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days look back exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max look back window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -987,7 +987,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1004,7 +1004,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1020,7 +1020,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1037,7 +1037,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1054,7 +1054,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1071,7 +1071,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1106,7 +1106,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1142,7 +1142,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1179,7 +1179,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1254,7 +1254,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1318,7 +1318,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1387,7 +1387,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1419,7 +1419,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1486,7 +1486,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1555,7 +1555,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1634,7 +1634,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1707,7 +1707,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1758,7 +1758,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
       .copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true)))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isDebugEnabled, requestModel.errorMessage("Debug should be enabled!"))
 
@@ -1814,7 +1814,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1879,7 +1879,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1952,7 +1952,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2020,7 +2020,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2089,7 +2089,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("Both fields being compared must be the same Data Type."))
   }
 
@@ -2132,7 +2132,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("Both fields being compared must be the same Data Type."))
   }
 
@@ -2175,7 +2175,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("10009 Field found only in Dimension table is not comparable with Fact fields"))
   }
 
@@ -2217,7 +2217,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("Both fields being compared must be the same Data Type."))
   }
 
@@ -2259,7 +2259,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("10009 Field found only in Dimension table is not comparable with Fact fields"))
   }
 
@@ -2301,7 +2301,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("10009 Field found only in Dimension table is not comparable with Fact fields"))
   }
 
@@ -2345,7 +2345,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2399,7 +2399,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true), Parameter.Distinct -> DistinctValue(true)))
 
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2465,7 +2465,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2542,7 +2542,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeAsync(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
@@ -2626,7 +2626,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2704,7 +2704,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeAsync(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2782,7 +2782,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeAsync(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2848,7 +2848,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2948,7 +2948,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString, ResellerSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3008,7 +3008,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
       .deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
       .copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true), Parameter.TimeZone->TimeZoneValue("PST")))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isDebugEnabled, requestModel.errorMessage("Debug should be enabled!"))
 
@@ -3064,7 +3064,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3123,7 +3123,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3202,7 +3202,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString, ResellerSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3286,7 +3286,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3343,7 +3343,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3379,7 +3379,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3415,7 +3415,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), PublisherSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3462,7 +3462,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), PublisherSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3538,7 +3538,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3611,7 +3611,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3679,7 +3679,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -3759,7 +3759,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3825,7 +3825,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3897,7 +3897,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3961,7 +3961,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -4025,7 +4025,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4078,7 +4078,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4144,7 +4144,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4211,7 +4211,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4276,7 +4276,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4352,7 +4352,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4464,7 +4464,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4569,7 +4569,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4650,7 +4650,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4751,7 +4751,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4820,7 +4820,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4885,7 +4885,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4957,7 +4957,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5024,7 +5024,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5091,7 +5091,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5160,7 +5160,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5224,7 +5224,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString, ResellerSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5304,7 +5304,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), PublisherSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5358,7 +5358,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5472,7 +5472,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5567,7 +5567,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5661,7 +5661,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5766,7 +5766,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5814,7 +5814,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5875,7 +5875,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5960,7 +5960,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -6033,7 +6033,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -6085,7 +6085,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
        """.stripMargin
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -6219,7 +6219,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -6250,5 +6250,264 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
          |""".stripMargin
 
     result should equal (expected)(after being whiteSpaceNormalised)
+  }
+
+  test("successfully generate fact driven query for minute grain with datetime between filter") {
+    val jsonString = s"""{
+                          "cube": "k_stats_minute",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Ad Group Status"},
+                              {"field": "Campaign Status"},
+                              {"field": "Count"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"}
+                          ],
+                          "sortBy": [
+                              {"field": "Campaign Status", "order": "ASC"}
+                          ],
+                          "forceFactDriven": true,
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, "dim fact sync dimension driven query with requested fields in multiple dimensions should not fail")
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
+    val expected =
+      s"""SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT *
+         |FROM (SELECT f0.keyword_id "Keyword ID", ago2.campaign_id "Campaign ID", coalesce(f0."impressions", 1) "Impressions", ago2."Ad Group Status" "Ad Group Status", co1."Campaign Status" "Campaign Status", f0."Count" "Count"
+         |      FROM (SELECT /*+ PARALLEL_INDEX(cb_campaign_k_stats 4) CONDITIONAL_HINT1 CONDITIONAL_HINT2 CONDITIONAL_HINT4 */
+         |                   ad_group_id, campaign_id, keyword_id, SUM(impressions) AS "impressions", COUNT(*) AS "Count"
+         |            FROM fact2 FactAlias
+         |            WHERE (advertiser_id = 12345) AND (stats_source = 2) AND (stats_date >= TO_UTC_TIMESTAMP_TZ('$fromDateTime') AND stats_date <= TO_UTC_TIMESTAMP_TZ('$toDateTime'))
+         |            GROUP BY ad_group_id, campaign_id, keyword_id
+         |
+         |           ) f0
+         |           LEFT OUTER JOIN
+         |           (SELECT /*+ CampaignHint */ DECODE(status, 'ON', 'ON', 'OFF') AS "Campaign Status", id, advertiser_id
+         |            FROM campaign_oracle
+         |            WHERE (advertiser_id = 12345)
+         |             )
+         |           co1 ON (f0.campaign_id = co1.id)
+         |           LEFT OUTER JOIN
+         |           (SELECT  campaign_id, DECODE(status, 'ON', 'ON', 'OFF') AS "Ad Group Status", id, advertiser_id
+         |            FROM ad_group_oracle
+         |            WHERE (advertiser_id = 12345)
+         |             )
+         |           ago2 ON (f0.ad_group_id = ago2.id)
+         |
+         |)
+         |   ORDER BY "Campaign Status" ASC NULLS LAST) WHERE ROWNUM <= 120) D ) WHERE ROW_NUMBER >= 21 AND ROW_NUMBER <= 120
+         |   """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
+  }
+
+  test("successfully generate dimension driven query for minute grain with datetime between filter") {
+    val jsonString = s"""{
+                          "cube": "k_stats_minute",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Ad Group Status"},
+                              {"field": "Campaign Status"},
+                              {"field": "Count"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"}
+                          ],
+                          "sortBy": [
+                              {"field": "Campaign Status", "order": "ASC"}
+                          ],
+                          "forceDimensionDriven": true,
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, "dim fact sync dimension driven query with requested fields in multiple dimensions should not fail")
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
+    val expected =
+      s"""
+         |SELECT *
+         |FROM (SELECT t3.id "Keyword ID", ago2.campaign_id "Campaign ID", coalesce(f0."impressions", 1) "Impressions", ago2."Ad Group Status" "Ad Group Status", co1."Campaign Status" "Campaign Status", f0."Count" "Count"
+         |      FROM (SELECT /*+ PUSH_PRED PARALLEL_INDEX(cb_campaign_k_stats 4) CONDITIONAL_HINT1 CONDITIONAL_HINT2 CONDITIONAL_HINT3 */
+         |                   ad_group_id, campaign_id, keyword_id, SUM(impressions) AS "impressions", COUNT(*) AS "Count"
+         |            FROM fact2 FactAlias
+         |            WHERE (advertiser_id = 12345) AND (stats_source = 2) AND (stats_date >= TO_UTC_TIMESTAMP_TZ('$fromDateTime') AND stats_date <= TO_UTC_TIMESTAMP_TZ('$toDateTime'))
+         |            GROUP BY ad_group_id, campaign_id, keyword_id
+         |
+         |           ) f0
+         |           RIGHT OUTER JOIN
+         |               ( (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  parent_id, id, advertiser_id
+         |            FROM targetingattribute
+         |            WHERE (advertiser_id = 12345)
+         |             ) WHERE ROWNUM <= 120) D ) WHERE ROW_NUMBER >= 21 AND ROW_NUMBER <= 120) t3
+         |          INNER JOIN
+         |            (SELECT  campaign_id, DECODE(status, 'ON', 'ON', 'OFF') AS "Ad Group Status", id, advertiser_id
+         |            FROM ad_group_oracle
+         |            WHERE (advertiser_id = 12345)
+         |             ) ago2
+         |              ON( t3.advertiser_id = ago2.advertiser_id AND t3.parent_id = ago2.id )
+         |               INNER JOIN
+         |            (SELECT /*+ CampaignHint */ DECODE(status, 'ON', 'ON', 'OFF') AS "Campaign Status", id, advertiser_id
+         |            FROM campaign_oracle
+         |            WHERE (advertiser_id = 12345)
+         |             ) co1
+         |              ON( ago2.advertiser_id = co1.advertiser_id AND ago2.campaign_id = co1.id )
+         |               )  ON (f0.keyword_id = t3.id)
+         |
+         |)
+         |   ORDER BY "Campaign Status" ASC NULLS LAST
+      """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
+  }
+
+  test("successfully generate fact driven query for day grain with datetime between filter") {
+    val jsonString = s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Ad Group Status"},
+                              {"field": "Campaign Status"},
+                              {"field": "Count"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"}
+                          ],
+                          "sortBy": [
+                              {"field": "Campaign Status", "order": "ASC"}
+                          ],
+                          "forceFactDriven": true,
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, "dim fact sync dimension driven query with requested fields in multiple dimensions should not fail")
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
+    val expected =
+      s"""SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT *
+         |FROM (SELECT f0.keyword_id "Keyword ID", ago2.campaign_id "Campaign ID", coalesce(f0."impressions", 1) "Impressions", ago2."Ad Group Status" "Ad Group Status", co1."Campaign Status" "Campaign Status", f0."Count" "Count"
+         |      FROM (SELECT /*+ PARALLEL_INDEX(cb_campaign_k_stats 4) CONDITIONAL_HINT1 CONDITIONAL_HINT2 CONDITIONAL_HINT4 */
+         |                   ad_group_id, campaign_id, keyword_id, SUM(impressions) AS "impressions", COUNT(*) AS "Count"
+         |            FROM fact2 FactAlias
+         |            WHERE (advertiser_id = 12345) AND (stats_source = 2) AND (stats_date >= to_date('$fromDate', 'YYYY-MM-DD') AND stats_date <= to_date('$toDate', 'YYYY-MM-DD'))
+         |            GROUP BY ad_group_id, campaign_id, keyword_id
+         |
+         |           ) f0
+         |           LEFT OUTER JOIN
+         |           (SELECT /*+ CampaignHint */ DECODE(status, 'ON', 'ON', 'OFF') AS "Campaign Status", id, advertiser_id
+         |            FROM campaign_oracle
+         |            WHERE (advertiser_id = 12345)
+         |             )
+         |           co1 ON (f0.campaign_id = co1.id)
+         |           LEFT OUTER JOIN
+         |           (SELECT  campaign_id, DECODE(status, 'ON', 'ON', 'OFF') AS "Ad Group Status", id, advertiser_id
+         |            FROM ad_group_oracle
+         |            WHERE (advertiser_id = 12345)
+         |             )
+         |           ago2 ON (f0.ad_group_id = ago2.id)
+         |
+         |)
+         |   ORDER BY "Campaign Status" ASC NULLS LAST) WHERE ROWNUM <= 120) D ) WHERE ROW_NUMBER >= 21 AND ROW_NUMBER <= 120
+         |   """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
+  }
+
+  test("successfully generate dimension driven query for day grain with datetime between filter") {
+    val jsonString = s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Ad Group Status"},
+                              {"field": "Campaign Status"},
+                              {"field": "Count"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"}
+                          ],
+                          "sortBy": [
+                              {"field": "Campaign Status", "order": "ASC"}
+                          ],
+                          "forceDimensionDriven": true,
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+      .copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true), Parameter.TimeZone->TimeZoneValue("America/Los_Angeles")))
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, "dim fact sync dimension driven query with requested fields in multiple dimensions should not fail")
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
+    val expected =
+      s"""
+         |SELECT *
+         |FROM (SELECT t3.id "Keyword ID", ago2.campaign_id "Campaign ID", coalesce(f0."impressions", 1) "Impressions", ago2."Ad Group Status" "Ad Group Status", co1."Campaign Status" "Campaign Status", f0."Count" "Count"
+         |      FROM (SELECT /*+ PUSH_PRED PARALLEL_INDEX(cb_campaign_k_stats 4) CONDITIONAL_HINT1 CONDITIONAL_HINT2 CONDITIONAL_HINT3 */
+         |                   ad_group_id, campaign_id, keyword_id, SUM(impressions) AS "impressions", COUNT(*) AS "Count"
+         |            FROM fact2 FactAlias
+         |            WHERE (advertiser_id = 12345) AND (stats_source = 2) AND (stats_date >= to_date('$fromDate', 'YYYY-MM-DD') AND stats_date <= to_date('$toDate', 'YYYY-MM-DD'))
+         |            GROUP BY ad_group_id, campaign_id, keyword_id
+         |
+         |           ) f0
+         |           RIGHT OUTER JOIN
+         |               ( (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  parent_id, id, advertiser_id
+         |            FROM targetingattribute
+         |            WHERE (advertiser_id = 12345)
+         |             ) WHERE ROWNUM <= 120) D ) WHERE ROW_NUMBER >= 21 AND ROW_NUMBER <= 120) t3
+         |          INNER JOIN
+         |            (SELECT  campaign_id, DECODE(status, 'ON', 'ON', 'OFF') AS "Ad Group Status", id, advertiser_id
+         |            FROM ad_group_oracle
+         |            WHERE (advertiser_id = 12345)
+         |             ) ago2
+         |              ON( t3.advertiser_id = ago2.advertiser_id AND t3.parent_id = ago2.id )
+         |               INNER JOIN
+         |            (SELECT /*+ CampaignHint */ DECODE(status, 'ON', 'ON', 'OFF') AS "Campaign Status", id, advertiser_id
+         |            FROM campaign_oracle
+         |            WHERE (advertiser_id = 12345)
+         |             ) co1
+         |              ON( ago2.advertiser_id = co1.advertiser_id AND ago2.campaign_id = co1.id )
+         |               )  ON (f0.keyword_id = t3.id)
+         |
+         |)
+         |   ORDER BY "Campaign Status" ASC NULLS LAST
+      """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
   }
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/postgres/BasePostgresQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/postgres/BasePostgresQueryGeneratorTest.scala
@@ -39,6 +39,7 @@ trait BasePostgresQueryGeneratorTest
     registryBuilder.register(pubfact8(forcedFilters))
     registryBuilder.register(pubfact9(forcedFilters))
     registryBuilder.register(pubFactCombined(forcedFilters))
+    registryBuilder.register(pubfact11(forcedFilters))
 
   }
 
@@ -855,6 +856,103 @@ trait BasePostgresQueryGeneratorTest
     , Set(
         PublicFactCol("num_students", "Students", Equality)
       ), Set.empty, getMaxDaysWindow, getMaxDaysLookBack)
+  }
+
+  def pubfact11(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+    import PostgresExpression._
+    ColumnContext.withColumnContext { implicit dc: ColumnContext =>
+      Fact.newFact(
+        "fact1", DailyGrain, PostgresEngine, Set(AdvertiserSchema, ResellerSchema),
+        Set(
+          DimCol("keyword_id", IntType(), annotations = Set(ForeignKey("keyword")))
+          , DimCol("ad_id", IntType(), annotations = Set(ForeignKey("ad")))
+          , DimCol("ad_group_id", IntType(), annotations = Set(ForeignKey("ad_group")))
+          , DimCol("campaign_id", IntType(), annotations = Set(ForeignKey("campaign")))
+          , DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+          , DimCol("stats_source", IntType(3))
+          , DimCol("source_name", IntType(3, (Map(1 -> "Native", 2 -> "Search", -1 -> "UNKNOWN"), "UNKNOWN")), alias = Option("stats_source"))
+          , DimCol("price_type", IntType(3, (Map(1 -> "CPC", 2 -> "CPA", 3 -> "CPM", 6 -> "CPV", 7 -> "CPCV", -10 -> "CPE", -20 -> "CPF"), "NONE")))
+          , DimCol("device_id", IntType(3, (Map(1 -> "Desktop", 2 -> "Tablet", 3 -> "SmartPhone", -1 -> "UNKNOWN"), "UNKNOWN")))
+          , DimCol("network_type", StrType(100, (Map("TEST_PUBLISHER" -> "Test Publisher", "CONTENT_SYNDICATION" -> "Content Syndication", "EXTERNAL" -> "Yahoo Partners" ,  "INTERNAL" -> "Yahoo Properties"), "NONE")))
+          , DimCol("start_time", IntType())
+          , DimCol("landing_page_url", StrType(), annotations = Set(EscapingRequired))
+          , DimCol("target_page_url", StrType(), annotations = Set(CaseInsensitive))
+          , DimCol("stats_date", TimestampType())
+          , DimCol("column_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned")))
+          , DimCol("column2_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned_with_singleton")))
+          , PostgresDerDimCol("Ad Group Start Date Full", StrType(), TIMESTAMP_TO_FORMATTED_DATE("{start_time}", "YYYY-MM-dd HH:mm:ss"))
+          , PostgresDerDimCol("Month", DateType(), GET_INTERVAL_DATE("{stats_date}", "M"))
+          , PostgresDerDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "W"))
+        ),
+        Set(
+          FactCol("impressions", IntType(3, 1))
+          , FactCol("clicks", IntType(3, 0, 1, 800))
+          , FactCol("spend", DecType(0, "0.0"))
+          , FactCol("max_bid", DecType(0, "0.0"), MaxRollup)
+          , FactCol("Average CPC", DecType(), PostgresCustomRollup(SUM("{spend}") / SUM("{clicks}")))
+          , FactCol("CTR", DecType(), PostgresCustomRollup(SUM("{clicks}" /- "{impressions}")))
+          , FactCol("avg_pos", DecType(3, "0.0", "0.1", "500"), PostgresCustomRollup(SUM("{avg_pos}" * "{impressions}") /- SUM("{impressions}")))
+          , FactCol("Count", IntType(), rollupExpression = CountRollup, alias = Option("count_col"))
+          , FactCol("Avg", IntType(), rollupExpression = AverageRollup, alias = Option("avg_col"))
+          , FactCol("Max", IntType(), rollupExpression = MaxRollup, alias = Option("max_col"))
+          , FactCol("Min", IntType(), rollupExpression = MinRollup, alias = Option("min_col"))
+        ),
+        annotations = Set(
+          PostgresFactStaticHint("PARALLEL_INDEX(cb_campaign_k_stats 4)"),
+          PostgresFactDimDrivenHint("PUSH_PRED PARALLEL_INDEX(cb_campaign_k_stats 4)")
+        )
+      )
+    }
+      .newRollUp("fact2"
+        , "fact1"
+        , discarding = Set("ad_id")
+        , columnAliasMap = Map("price_type" -> "pricing_type", "source_name" -> "stats_source")
+        , overrideAnnotations = Set(
+          PostgresFactConditionalHint(FactCondition(Option(true)), "CONDITIONAL_HINT1")
+          , PostgresFactConditionalHint(FactCondition(Option(true), Option(false)), "CONDITIONAL_HINT2")
+          , PostgresFactConditionalHint(FactCondition(Option(true), Option(false), Option(true)), "CONDITIONAL_HINT3")
+          , PostgresFactConditionalHint(FactCondition(Option(true), Option(false), Option(false), Option(false)), "CONDITIONAL_HINT4")
+          , PostgresFactConditionalHint(FactCondition(None, minRowsEstimate = Option(900L))
+            , "CONDITIONAL_HINT5")
+        ), availableOnwardsDate = Some("2010-01-01")
+      ).toPublicFact("k_stats_minute",
+      Set(
+        PubCol("stats_date", "Day", InBetweenEquality),
+        PubCol("keyword_id", "Keyword ID", InEquality),
+        PubCol("ad_id", "Ad ID", InEquality),
+        PubCol("ad_group_id", "Ad Group ID", InEquality),
+        PubCol("campaign_id", "Campaign ID", InEquality),
+        PubCol("advertiser_id", "Advertiser ID", InEquality),
+        PubCol("network_type", "Network Type", InEquality),
+        PubCol("stats_source", "Source", EqualityFieldEquality, incompatibleColumns = Set("Source Name")),
+        PubCol("source_name", "Source Name", InNotInBetweenEqualityNotEqualsGreaterLesser, incompatibleColumns = Set("Source")),
+        PubCol("price_type", "Pricing Type", In),
+        PubCol("landing_page_url", "Destination URL", FieldEquality, isImageColumn = true),
+        PubCol("target_page_url", "Source URL", FieldEquality),
+        PubCol("column_id", "Column ID", Equality),
+        PubCol("column2_id", "Column2 ID", Equality),
+        PubCol("Ad Group Start Date Full", "Ad Group Start Date Full", InEquality),
+        PubCol("Month", "Month", Equality),
+        PubCol("Week", "Week", Equality),
+        PubCol("device_id", "Device ID", InEquality)
+      ),
+      Set(
+        PublicFactCol("impressions", "Impressions", InNotInBetweenEqualityNotEqualsGreaterLesser),
+        PublicFactCol("impressions", "Total Impressions", InBetweenEquality),
+        PublicFactCol("clicks", "Clicks", InBetweenEqualityFieldEquality),
+        PublicFactCol("spend", "Spend", FieldEquality),
+        PublicFactCol("avg_pos", "Average Position", FieldEquality),
+        PublicFactCol("max_bid", "Max Bid", Set.empty),
+        PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
+        PublicFactCol("CTR", "CTR", InBetweenEquality),
+        PublicFactCol("Count", "Count", InBetweenEquality),
+        PublicFactCol("Avg", "Avg", InBetweenEquality),
+        PublicFactCol("Max", "Max", InBetweenEquality),
+        PublicFactCol("Min", "Min", InBetweenEquality)
+      ),
+      Set(EqualityFilter("Source", "2", true, true)),
+      getMaxDaysWindow, getMaxDaysLookBack
+    )
   }
 
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGeneratorTest.scala
@@ -138,7 +138,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -156,7 +156,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -174,7 +174,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -192,7 +192,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -229,7 +229,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -247,7 +247,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -265,7 +265,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -281,7 +281,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -300,7 +300,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -321,7 +321,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -339,7 +339,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -357,7 +357,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -375,7 +375,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -393,7 +393,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -412,7 +412,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -433,7 +433,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -452,7 +452,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -473,7 +473,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isFactDriven)
 
@@ -498,7 +498,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isFactDriven)
 
@@ -525,7 +525,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isFactDriven)
 
@@ -544,7 +544,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isFactDriven)
 
@@ -589,7 +589,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -661,7 +661,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -739,7 +739,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -808,7 +808,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -839,7 +839,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -869,7 +869,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -900,7 +900,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -930,7 +930,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -946,7 +946,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -963,7 +963,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1016,7 +1016,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days window exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max days window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -1044,7 +1044,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days look back exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max look back window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -1072,7 +1072,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days window exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max days window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -1100,7 +1100,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days look back exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max look back window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -1128,7 +1128,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure, requestModel.errorMessage("Building request model should failed because days look back exceeds the maximum"))
     assert(requestModel.checkFailureMessage("Max look back window"), requestModel.errorMessage("Invalid error message"))
   }
@@ -1155,7 +1155,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1173,7 +1173,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1190,7 +1190,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1208,7 +1208,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1226,7 +1226,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1244,7 +1244,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .getLines().mkString.replace("{from_date}", fromDate).replace("{to_date}", toDate)
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1280,7 +1280,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1317,7 +1317,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1355,7 +1355,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1431,7 +1431,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1496,7 +1496,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -1566,7 +1566,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1598,7 +1598,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1666,7 +1666,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1736,7 +1736,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1816,7 +1816,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1890,7 +1890,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1939,7 +1939,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
       .copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true)))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isDebugEnabled, requestModel.errorMessage("Debug should be enabled!"))
 
@@ -1995,7 +1995,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2058,7 +2058,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2132,7 +2132,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2201,7 +2201,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2271,7 +2271,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("Both fields being compared must be the same Data Type."))
   }
 
@@ -2314,7 +2314,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("Both fields being compared must be the same Data Type."))
   }
 
@@ -2357,7 +2357,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("10009 Field found only in Dimension table is not comparable with Fact fields"))
   }
 
@@ -2399,7 +2399,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("Both fields being compared must be the same Data Type."))
   }
 
@@ -2441,7 +2441,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("10009 Field found only in Dimension table is not comparable with Fact fields"))
   }
 
@@ -2483,7 +2483,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isFailure && requestModel.failed.get.getMessage.contains("10009 Field found only in Dimension table is not comparable with Fact fields"))
   }
 
@@ -2527,7 +2527,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2582,7 +2582,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true), Parameter.Distinct -> DistinctValue(true)))
 
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2649,7 +2649,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2735,7 +2735,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2814,7 +2814,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeAsync(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2893,7 +2893,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeAsync(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -2960,7 +2960,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3061,7 +3061,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString, ResellerSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3122,7 +3122,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
       .deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
       .copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true), Parameter.TimeZone->TimeZoneValue("PST")))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     assert(requestModel.toOption.get.isDebugEnabled, requestModel.errorMessage("Debug should be enabled!"))
 
@@ -3178,7 +3178,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3238,7 +3238,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3318,7 +3318,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString, ResellerSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3403,7 +3403,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSyncWithFactBias(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3461,7 +3461,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3497,7 +3497,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3533,7 +3533,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), PublisherSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3581,7 +3581,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), PublisherSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3658,7 +3658,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3732,7 +3732,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3801,7 +3801,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -3882,7 +3882,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -3949,7 +3949,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4015,7 +4015,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -4080,7 +4080,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4134,7 +4134,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4201,7 +4201,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4269,7 +4269,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4335,7 +4335,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4411,7 +4411,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4525,7 +4525,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4631,7 +4631,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4709,7 +4709,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4811,7 +4811,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4881,7 +4881,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -4947,7 +4947,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5020,7 +5020,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5088,7 +5088,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5156,7 +5156,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request.toOption.get, registry)
+    val requestModel = getRequestModel(request.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5226,7 +5226,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5291,7 +5291,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString, ResellerSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5371,7 +5371,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), PublisherSchema)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(requestOption.toOption.get, registry)
+    val requestModel = getRequestModel(requestOption.toOption.get, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5426,7 +5426,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5539,7 +5539,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5634,7 +5634,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5728,7 +5728,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5833,7 +5833,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5882,7 +5882,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -5944,7 +5944,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -6029,7 +6029,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                           }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry, revision = Option(1))
+    val requestModel = getRequestModel(request, registry, revision = Option(1))
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -6103,7 +6103,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -6156,7 +6156,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
        """.stripMargin
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -6257,4 +6257,263 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
   }
 
+  test("successfully generate fact driven query for minute grain with datetime between filter") {
+    val jsonString = s"""{
+                          "cube": "k_stats_minute",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Ad Group Status"},
+                              {"field": "Campaign Status"},
+                              {"field": "Count"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"}
+                          ],
+                          "sortBy": [
+                              {"field": "Campaign Status", "order": "ASC"}
+                          ],
+                          "forceFactDriven": true,
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, "dim fact sync dimension driven query with requested fields in multiple dimensions should not fail")
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PostgresQuery].asString
+    val expected =
+      s"""SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT *
+         |FROM (SELECT f0.keyword_id "Keyword ID", agp2.campaign_id "Campaign ID", coalesce(f0."impressions", 1) "Impressions", agp2."Ad Group Status" "Ad Group Status", cp1."Campaign Status" "Campaign Status", f0."count_col" "Count"
+         |      FROM (SELECT /*+ PARALLEL_INDEX(cb_campaign_k_stats 4) CONDITIONAL_HINT1 CONDITIONAL_HINT2 CONDITIONAL_HINT4 */
+         |                   ad_group_id, campaign_id, keyword_id, SUM(impressions) AS "impressions", COUNT(*) AS "count_col"
+         |            FROM fact2 FactAlias
+         |            WHERE (advertiser_id = 12345) AND (stats_source = 2) AND (stats_date >= '$fromDateTime'::timestamptz AND stats_date <= '$toDateTime'::timestamptz)
+         |            GROUP BY ad_group_id, campaign_id, keyword_id
+         |
+         |           ) f0
+         |           LEFT OUTER JOIN
+         |           (SELECT /*+ CampaignHint */ CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Campaign Status", id, advertiser_id
+         |            FROM campaign_postgres
+         |            WHERE (advertiser_id = 12345)
+         |             )
+         |           cp1 ON (f0.campaign_id = cp1.id)
+         |           LEFT OUTER JOIN
+         |           (SELECT  campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id, advertiser_id
+         |            FROM ad_group_postgres
+         |            WHERE (advertiser_id = 12345)
+         |             )
+         |           agp2 ON (f0.ad_group_id = agp2.id)
+         |
+         |) sqalias1
+         |   ORDER BY "Campaign Status" ASC NULLS LAST) sqalias2 LIMIT 120) D ) sqalias3 WHERE ROWNUM >= 21 AND ROWNUM <= 120
+         |   """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
+    testQuery(result)
+  }
+
+  test("successfully generate dimension driven query for minute grain with datetime between filter") {
+    val jsonString = s"""{
+                          "cube": "k_stats_minute",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Ad Group Status"},
+                              {"field": "Campaign Status"},
+                              {"field": "Count"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"}
+                          ],
+                          "sortBy": [
+                              {"field": "Campaign Status", "order": "ASC"}
+                          ],
+                          "forceDimensionDriven": true,
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, "dim fact sync dimension driven query with requested fields in multiple dimensions should not fail")
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PostgresQuery].asString
+    val expected =
+      s"""SELECT *
+         |FROM (SELECT pt3.id "Keyword ID", agp2.campaign_id "Campaign ID", coalesce(f0."impressions", 1) "Impressions", agp2."Ad Group Status" "Ad Group Status", cp1."Campaign Status" "Campaign Status", f0."count_col" "Count"
+         |      FROM (SELECT /*+ PUSH_PRED PARALLEL_INDEX(cb_campaign_k_stats 4) CONDITIONAL_HINT1 CONDITIONAL_HINT2 CONDITIONAL_HINT3 */
+         |                   ad_group_id, campaign_id, keyword_id, SUM(impressions) AS "impressions", COUNT(*) AS "count_col"
+         |            FROM fact2 FactAlias
+         |            WHERE (advertiser_id = 12345) AND (stats_source = 2) AND (stats_date >= '$fromDateTime'::timestamptz AND stats_date <= '$toDateTime'::timestamptz)
+         |            GROUP BY ad_group_id, campaign_id, keyword_id
+         |
+         |           ) f0
+         |           RIGHT OUTER JOIN
+         |               ( (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  parent_id, id, advertiser_id
+         |            FROM pg_targetingattribute
+         |            WHERE (advertiser_id = 12345)
+         |             ) sqalias1 LIMIT 120) D ) sqalias2 WHERE ROWNUM >= 21 AND ROWNUM <= 120) pt3
+         |          INNER JOIN
+         |            (SELECT  campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id, advertiser_id
+         |            FROM ad_group_postgres
+         |            WHERE (advertiser_id = 12345)
+         |             ) agp2
+         |              ON( pt3.advertiser_id = agp2.advertiser_id AND pt3.parent_id = agp2.id )
+         |               INNER JOIN
+         |            (SELECT /*+ CampaignHint */ CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Campaign Status", id, advertiser_id
+         |            FROM campaign_postgres
+         |            WHERE (advertiser_id = 12345)
+         |             ) cp1
+         |              ON( agp2.advertiser_id = cp1.advertiser_id AND agp2.campaign_id = cp1.id )
+         |               )  ON (f0.keyword_id = pt3.id)
+         |
+         |) sqalias3
+         |   ORDER BY "Campaign Status" ASC NULLS LAST
+         |   """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
+    testQuery(result)
+  }
+
+  test("successfully generate fact driven query for day grain with datetime between filter") {
+    val jsonString = s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Ad Group Status"},
+                              {"field": "Campaign Status"},
+                              {"field": "Count"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"}
+                          ],
+                          "sortBy": [
+                              {"field": "Campaign Status", "order": "ASC"}
+                          ],
+                          "forceFactDriven": true,
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, "dim fact sync dimension driven query with requested fields in multiple dimensions should not fail")
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PostgresQuery].asString
+    val expected =
+      s"""SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT *
+         |FROM (SELECT f0.keyword_id "Keyword ID", agp2.campaign_id "Campaign ID", coalesce(f0."impressions", 1) "Impressions", agp2."Ad Group Status" "Ad Group Status", cp1."Campaign Status" "Campaign Status", f0."count_col" "Count"
+         |      FROM (SELECT /*+ PARALLEL_INDEX(cb_campaign_k_stats 4) CONDITIONAL_HINT1 CONDITIONAL_HINT2 CONDITIONAL_HINT4 */
+         |                   ad_group_id, campaign_id, keyword_id, SUM(impressions) AS "impressions", COUNT(*) AS "count_col"
+         |            FROM fact2 FactAlias
+         |            WHERE (advertiser_id = 12345) AND (stats_source = 2) AND (stats_date >= to_date('$fromDate', 'YYYY-MM-DD') AND stats_date <= to_date('$toDate', 'YYYY-MM-DD'))
+         |            GROUP BY ad_group_id, campaign_id, keyword_id
+         |
+         |           ) f0
+         |           LEFT OUTER JOIN
+         |           (SELECT /*+ CampaignHint */ CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Campaign Status", id, advertiser_id
+         |            FROM campaign_postgres
+         |            WHERE (advertiser_id = 12345)
+         |             )
+         |           cp1 ON (f0.campaign_id = cp1.id)
+         |           LEFT OUTER JOIN
+         |           (SELECT  campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id, advertiser_id
+         |            FROM ad_group_postgres
+         |            WHERE (advertiser_id = 12345)
+         |             )
+         |           agp2 ON (f0.ad_group_id = agp2.id)
+         |
+         |) sqalias1
+         |   ORDER BY "Campaign Status" ASC NULLS LAST) sqalias2 LIMIT 120) D ) sqalias3 WHERE ROWNUM >= 21 AND ROWNUM <= 120
+         |   """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
+    testQuery(result)
+  }
+
+  test("successfully generate dimension driven query for day grain with datetime between filter") {
+    val jsonString = s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                              {"field": "Keyword ID"},
+                              {"field": "Campaign ID"},
+                              {"field": "Impressions"},
+                              {"field": "Ad Group Status"},
+                              {"field": "Campaign Status"},
+                              {"field": "Count"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"}
+                          ],
+                          "sortBy": [
+                              {"field": "Campaign Status", "order": "ASC"}
+                          ],
+                          "forceDimensionDriven": true,
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestSync(jsonString)
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+    assert(queryPipelineTry.isSuccess, "dim fact sync dimension driven query with requested fields in multiple dimensions should not fail")
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PostgresQuery].asString
+    val expected =
+      s"""SELECT *
+         |FROM (SELECT pt3.id "Keyword ID", agp2.campaign_id "Campaign ID", coalesce(f0."impressions", 1) "Impressions", agp2."Ad Group Status" "Ad Group Status", cp1."Campaign Status" "Campaign Status", f0."count_col" "Count"
+         |      FROM (SELECT /*+ PUSH_PRED PARALLEL_INDEX(cb_campaign_k_stats 4) CONDITIONAL_HINT1 CONDITIONAL_HINT2 CONDITIONAL_HINT3 */
+         |                   ad_group_id, campaign_id, keyword_id, SUM(impressions) AS "impressions", COUNT(*) AS "count_col"
+         |            FROM fact2 FactAlias
+         |            WHERE (advertiser_id = 12345) AND (stats_source = 2) AND (stats_date >= to_date('$fromDate', 'YYYY-MM-DD') AND stats_date <= to_date('$toDate', 'YYYY-MM-DD'))
+         |            GROUP BY ad_group_id, campaign_id, keyword_id
+         |
+         |           ) f0
+         |           RIGHT OUTER JOIN
+         |               ( (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  parent_id, id, advertiser_id
+         |            FROM pg_targetingattribute
+         |            WHERE (advertiser_id = 12345)
+         |             ) sqalias1 LIMIT 120) D ) sqalias2 WHERE ROWNUM >= 21 AND ROWNUM <= 120) pt3
+         |          INNER JOIN
+         |            (SELECT  campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id, advertiser_id
+         |            FROM ad_group_postgres
+         |            WHERE (advertiser_id = 12345)
+         |             ) agp2
+         |              ON( pt3.advertiser_id = agp2.advertiser_id AND pt3.parent_id = agp2.id )
+         |               INNER JOIN
+         |            (SELECT /*+ CampaignHint */ CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Campaign Status", id, advertiser_id
+         |            FROM campaign_postgres
+         |            WHERE (advertiser_id = 12345)
+         |             ) cp1
+         |              ON( agp2.advertiser_id = cp1.advertiser_id AND agp2.campaign_id = cp1.id )
+         |               )  ON (f0.keyword_id = pt3.id)
+         |
+         |) sqalias3
+         |   ORDER BY "Campaign Status" ASC NULLS LAST
+         |   """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
+    testQuery(result)
+  }
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/presto/BasePrestoQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/presto/BasePrestoQueryGeneratorTest.scala
@@ -40,6 +40,7 @@ trait BasePrestoQueryGeneratorTest
     registryBuilder.register(bidReco())
     registryBuilder.register(pubfact5())
     registryBuilder.register(pubfact2(forcedFilters))
+    registryBuilder.register(pubfact3(forcedFilters))
   }
 
   protected[this] def s_stats_fact(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
@@ -532,6 +533,83 @@ trait BasePrestoQueryGeneratorTest
           PublicFactCol("impression_share_rounded", "Impression Share", InBetweenEquality)
         ),
         forcedFilters,
+        getMaxDaysWindow, getMaxDaysLookBack
+      )
+  }
+
+  def pubfact3(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+    import PrestoExpression._
+    import com.yahoo.maha.core.BasePrestoExpressionTest._
+    ColumnContext.withColumnContext { implicit dc: ColumnContext =>
+      Fact.newFact(
+        "s_stats_fact", MinuteGrain, PrestoEngine, Set(AdvertiserSchema),
+        Set(
+          DimCol("campaign_id", StrType(), annotations = Set(ForeignKey("campaign")))
+          , DimCol("ad_group_id", IntType(), annotations = Set(ForeignKey("ad_group")))
+          , DimCol("account_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+          , DimCol("keyword_id", IntType())
+          , DimCol("keyword", StrType(), annotations = Set(EscapingRequired))
+          , DimCol("search_term", StrType(50,default = "None"))
+          , DimCol("delivered_match_type", IntType(3, (Map(1 -> "Exact", 2 -> "Broad", 3 -> "Phrase"), "UNKNOWN")))
+          , DimCol("stats_source", IntType(3))
+          , DimCol("source_name", IntType(3), alias = Option("stats_source"))
+          , DimCol("price_type", IntType(3, (Map(1 -> "CPC", 2 -> "CPA", 3 -> "CPM", 6 -> "CPV", 7 -> "CPCV", -10 -> "CPE", -20 -> "CPF"), "NONE")))
+          , DimCol("device_id", IntType(3, (Map(11 -> "Desktop", 22 -> "Tablet", 33 -> "SmartPhone", -1 -> "UNKNOWN"), "UNKNOWN")))
+          , DimCol("network_type", StrType(100, (Map("TEST_PUBLISHER" -> "Test Publisher", "CONTENT_S" -> "Content Secured", "EXTERNAL" -> "External Partners" ,  "INTERNAL" -> "Internal Properties"), "NONE")))
+          , DimCol("start_time", IntType())
+          , DimCol("landing_page_url", StrType(), annotations = Set(EscapingRequired))
+          , DimCol("stats_date", TimestampType())
+          , DimCol("column_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned")))
+          , DimCol("column2_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned_with_singleton")))
+          , PrestoDerDimCol("Ad Group Start Date Full", StrType(), TIMESTAMP_TO_FORMATTED_DATE("{start_time}", "YYYY-MM-dd HH:mm:ss"))
+
+        ),
+        Set(
+          FactCol("impressions", IntType(3, 1))
+          , FactCol("clicks", IntType(3, 0, 1, 800))
+          , FactCol("spend", DecType(0, "0.0"))
+          , FactCol("max_bid", DecType(0, "0.0"), MaxRollup)
+          , FactCol("weighted_position", DecType(0, "0.0"))
+          , PrestoDerFactCol("Average CPC", DecType(), "{spend}" /- "{clicks}", rollupExpression = NoopRollup)
+          , PrestoDerFactCol("Average CPC Cents", DecType(), "{Average CPC}" * "100", rollupExpression = NoopRollup)
+          , FactCol("avg_pos", DecType(3, "0.0", "0.1", "500"), PrestoCustomRollup(SUM("{weighted_position}" * "{impressions}") /- SUM("{impressions}")))
+          , ConstFactCol("constantFact", IntType(), "0")
+          , FactCol("Count", IntType(), rollupExpression = CountRollup)
+        ),underlyingTableName = Some("s_stats_fact_underlying")
+      )
+    }
+      .toPublicFact("s_stats_minute",
+        Set(
+          PubCol("stats_date", "Day", InBetweenEquality),
+          PubCol("ad_group_id", "Ad Group ID", InEqualityFieldEquality),
+          PubCol("campaign_id", "Campaign ID", InEquality),
+          PubCol("account_id", "Advertiser ID", InEqualityFieldEquality),
+          PubCol("keyword_id", "Keyword ID", InEquality),
+          PubCol("keyword", "Keyword", InEquality),
+          PubCol("search_term", "Search Term", InEquality),
+          PubCol("delivered_match_type", "Delivered Match Type", InEquality),
+          PubCol("stats_source", "Source", Equality, incompatibleColumns = Set("Source Name")),
+          PubCol("source_name", "Source Name", Equality, incompatibleColumns = Set("Source")),
+          PubCol("price_type", "Pricing Type", In),
+          PubCol("landing_page_url", "Destination URL", Set.empty),
+          PubCol("column_id", "Column ID", Equality),
+          PubCol("column2_id", "Column2 ID", Equality),
+          PubCol("Ad Group Start Date Full", "Ad Group Start Date Full", InEquality),
+          PubCol("network_type", "Network ID", InEquality),
+          PubCol("device_id", "Device ID", InEquality)
+        ),
+        Set(
+          PublicFactCol("impressions", "Impressions", InNotInBetweenEqualityNotEqualsGreaterLesser),
+          PublicFactCol("clicks", "Clicks", InBetweenEquality),
+          PublicFactCol("spend", "Spend", FieldEquality),
+          PublicFactCol("avg_pos", "Average Position", Set.empty),
+          PublicFactCol("constantFact", "Constant Fact", Set.empty),
+          PublicFactCol("max_bid", "Max Bid", FieldEquality),
+          PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
+          PublicFactCol("Average CPC Cents", "Average CPC Cents", InBetweenEquality),
+          PublicFactCol("Count", "Count", InBetweenEquality)
+        ),
+        Set(),
         getMaxDaysWindow, getMaxDaysLookBack
       )
   }

--- a/core/src/test/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorTest.scala
@@ -26,7 +26,7 @@ class PrestoQueryGeneratorTest extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -78,7 +78,7 @@ ORDER BY mang_impressions ASC
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -121,7 +121,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -165,7 +165,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -195,7 +195,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -217,7 +217,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -265,7 +265,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -318,7 +318,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -373,7 +373,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -407,7 +407,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -472,7 +472,7 @@ FROM s_stats_fact_underlying
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorV1Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorV1Test.scala
@@ -25,7 +25,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -77,7 +77,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -120,7 +120,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -163,7 +163,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -192,7 +192,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -213,7 +213,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -261,7 +261,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -313,7 +313,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -368,7 +368,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -402,7 +402,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -467,7 +467,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -536,7 +536,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -607,7 +607,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -678,7 +678,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -762,7 +762,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -815,7 +815,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -897,7 +897,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -974,7 +974,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1043,7 +1043,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1115,7 +1115,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1187,7 +1187,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1256,7 +1256,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1335,7 +1335,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1427,7 +1427,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1525,7 +1525,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1593,7 +1593,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1654,7 +1654,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1719,7 +1719,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1788,7 +1788,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1855,7 +1855,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1921,7 +1921,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -1996,7 +1996,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -2035,7 +2035,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -2106,7 +2106,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -2171,7 +2171,7 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
 
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
 
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
@@ -2210,5 +2210,148 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
          |        queryAlias LIMIT 200
        """.stripMargin
     result should equal(expected)(after being whiteSpaceNormalised)
+  }
+
+  test("successfully generate fact driven query for day grain with datetime between filter") {
+    val jsonString =
+      s"""{
+                          "cube": "s_stats",
+                          "selectFields": [
+                              {"field": "Advertiser Name"},
+                              {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"},
+                              {"field": "Impressions", "operator": ">", "value": "1608"}
+                          ],
+                          "sortBy": [{"field": "Advertiser Name", "order": "Desc"},  {"field": "Impressions", "order": "DESC"}]
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = getRequestModel(request, registry)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v1)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PrestoQuery].asString
+
+    val expected =
+      s"""SELECT CAST(mang_advertiser_name as VARCHAR) AS mang_advertiser_name, CAST(mang_impressions as VARCHAR) AS mang_impressions
+         |FROM(
+         |SELECT mang_advertiser_name AS mang_advertiser_name, impressions AS mang_impressions
+         |FROM(
+         |SELECT COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA') mang_advertiser_name, SUM(impressions) AS impressions
+         |FROM(SELECT account_id, SUM(impressions) impressions
+         |FROM s_stats_fact_underlying
+         |WHERE (account_id = 12345) AND (stats_date >= date('$fromDate') AND stats_date <= date('$toDate'))
+         |GROUP BY account_id
+         |HAVING (SUM(impressions) > 1608)
+         |       )
+         |ssfu0
+         |LEFT OUTER JOIN (
+         |SELECT name AS mang_advertiser_name, id a1_id
+         |FROM advertiser_presto
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
+         |)
+         |a1
+         |ON
+         |ssfu0.account_id = a1.a1_id
+         |
+         |GROUP BY COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA')
+         |ORDER BY mang_advertiser_name DESC, impressions DESC) OgbQueryAlias
+         |)
+         |        queryAlias LIMIT 200
+         |        """.stripMargin
+      s"""
+         |SELECT CONCAT_WS(',', CAST(NVL(mang_advertiser_name,'') AS STRING),CAST(NVL(mang_impressions,'') AS STRING))
+         |FROM(
+         |SELECT mang_advertiser_name AS mang_advertiser_name, impressions AS mang_impressions
+         |FROM(
+         |SELECT COALESCE(a1.mang_advertiser_name, 'NA') mang_advertiser_name, SUM(impressions) AS impressions
+         |FROM(SELECT account_id, SUM(impressions) impressions
+         |FROM s_stats_fact
+         |WHERE (account_id = 12345) AND (stats_date >= cast('$fromDate' as date) AND stats_date <= cast('$toDate' as date))
+         |GROUP BY account_id
+         |HAVING (SUM(impressions) > 1608)
+         |       )
+         |ssf0
+         |LEFT OUTER JOIN (
+         |SELECT name AS mang_advertiser_name, id a1_id
+         |FROM advertiser_hive
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
+         |)
+         |a1
+         |ON
+         |ssf0.account_id = a1.a1_id
+         |
+         |GROUP BY COALESCE(a1.mang_advertiser_name, 'NA')
+         |ORDER BY mang_advertiser_name DESC, impressions DESC) OgbQueryAlias
+         |) queryAlias LIMIT 200
+         |
+       """.stripMargin
+
+    result should equal (expected) (after being whiteSpaceNormalised)
+
+  }
+
+  test("successfully generate fact driven query for minute grain with datetime between filter") {
+    val jsonString =
+      s"""{
+                          "cube": "s_stats_minute",
+                          "selectFields": [
+                              {"field": "Advertiser Name"},
+                              {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "datetimebetween", "from": "$fromDateTime", "to": "$toDateTime", "format": "$iso8601Format"},
+                              {"field": "Impressions", "operator": ">", "value": "1608"}
+                          ],
+                          "sortBy": [{"field": "Advertiser Name", "order": "Desc"},  {"field": "Impressions", "order": "DESC"}]
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = getRequestModel(request, registry)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v1)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PrestoQuery].asString
+
+    val expected =
+      s"""SELECT CAST(mang_advertiser_name as VARCHAR) AS mang_advertiser_name, CAST(mang_impressions as VARCHAR) AS mang_impressions
+         |FROM(
+         |SELECT mang_advertiser_name AS mang_advertiser_name, impressions AS mang_impressions
+         |FROM(
+         |SELECT COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA') mang_advertiser_name, SUM(impressions) AS impressions
+         |FROM(SELECT account_id, SUM(impressions) impressions
+         |FROM s_stats_fact_underlying
+         |WHERE (account_id = 12345) AND (stats_date >= from_iso8601_timestamp('$fromDateTime') AND stats_date <= from_iso8601_timestamp('$toDateTime'))
+         |GROUP BY account_id
+         |HAVING (SUM(impressions) > 1608)
+         |       )
+         |ssfu0
+         |LEFT OUTER JOIN (
+         |SELECT name AS mang_advertiser_name, id a1_id
+         |FROM advertiser_presto
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
+         |)
+         |a1
+         |ON
+         |ssfu0.account_id = a1.a1_id
+         |
+         |GROUP BY COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA')
+         |ORDER BY mang_advertiser_name DESC, impressions DESC) OgbQueryAlias
+         |)
+         |        queryAlias LIMIT 200
+         |        """.stripMargin
+    result should equal (expected) (after being whiteSpaceNormalised)
   }
 }

--- a/core/src/test/scala/com/yahoo/maha/report/JsonRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/report/JsonRowListTest.scala
@@ -49,7 +49,7 @@ class JsonRowListTest extends FunSuite with BaseQueryGeneratorTest with SharedDi
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 
@@ -281,7 +281,7 @@ class JsonRowListTest extends FunSuite with BaseQueryGeneratorTest with SharedDi
 
       val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
       val registry = getDefaultRegistry()
-      val requestModel = RequestModel.from(request, registry)
+      val requestModel = getRequestModel(request, registry)
       assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
@@ -453,7 +453,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -508,7 +508,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = getReportingRequestSync(jsonString).copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true)))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -562,7 +562,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -606,7 +606,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -652,7 +652,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -695,7 +695,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -734,7 +734,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -783,7 +783,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -854,7 +854,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -908,7 +908,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -952,7 +952,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1055,7 +1055,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1122,7 +1122,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1189,7 +1189,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1257,7 +1257,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1324,7 +1324,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1392,7 +1392,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1430,7 +1430,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1492,7 +1492,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1570,7 +1570,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1660,7 +1660,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1740,7 +1740,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1794,7 +1794,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1841,7 +1841,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -1927,7 +1927,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2009,7 +2009,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = getReportingRequestSync(jsonString).copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true)))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2049,7 +2049,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2093,7 +2093,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2178,7 +2178,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSyncWithFactBias(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2255,7 +2255,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2329,7 +2329,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestAsync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2421,7 +2421,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSyncWithFactBias(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2499,7 +2499,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
        """.stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString, InternalSchema))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2603,7 +2603,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
        """.stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2699,7 +2699,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString, AdvertiserLowLatencySchema))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2799,7 +2799,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2863,7 +2863,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2907,7 +2907,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -2950,7 +2950,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -3003,7 +3003,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                         }""".stripMargin
     val request: ReportingRequest = ReportingRequest.forceOracle(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -3047,7 +3047,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
     // request from RowCountCurator has queryType = RowCountQuery
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString)).copy(queryType = RowCountQuery)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry
@@ -3109,7 +3109,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val altQueryGeneratorRegistry = new QueryGeneratorRegistry

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/oracle/src/test/scala/com/yahoo/maha/executor/oracle/OracleQueryExecutorTest.scala
+++ b/oracle/src/test/scala/com/yahoo/maha/executor/oracle/OracleQueryExecutorTest.scala
@@ -619,7 +619,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -674,7 +674,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -728,7 +728,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -794,7 +794,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -861,7 +861,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
       val request: ReportingRequest = getReportingRequestSync(jsonString).copy(additionalParameters = Map(Parameter.Debug -> DebugValue(true)))
       val registry = defaultRegistry
-      val requestModel = RequestModel.from(request, registry)
+      val requestModel = getRequestModel(request, registry)
       assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
       val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -922,7 +922,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
       val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
       val registry = defaultRegistry
-      val requestModel = RequestModel.from(request, registry)
+      val requestModel = getRequestModel(request, registry)
       assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
       val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -977,7 +977,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1021,7 +1021,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1060,7 +1060,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
       //override def query: Query = {q}
@@ -1156,7 +1156,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.383-SNAPSHOT</version>
+    <version>6.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/postgres/src/test/scala/com/yahoo/maha/executor/postgres/PostgresQueryExecutorTest.scala
+++ b/postgres/src/test/scala/com/yahoo/maha/executor/postgres/PostgresQueryExecutorTest.scala
@@ -630,7 +630,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -685,7 +685,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -739,7 +739,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -805,7 +805,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
     val request: ReportingRequest = getReportingRequestSync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -872,7 +872,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
       val request: ReportingRequest = getReportingRequestSync(jsonString).copy(additionalParameters = Map(Parameter.Debug -> DebugValue(true)))
       val registry = defaultRegistry
-      val requestModel = RequestModel.from(request, registry)
+      val requestModel = getRequestModel(request, registry)
       assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
       val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -933,7 +933,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
       val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
       val registry = defaultRegistry
-      val requestModel = RequestModel.from(request, registry)
+      val requestModel = getRequestModel(request, registry)
       assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
       val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -988,7 +988,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1032,7 +1032,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)
@@ -1071,7 +1071,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
       //override def query: Query = {q}
@@ -1167,7 +1167,7 @@ class PostgresQueryExecutorTest extends FunSuite with Matchers with BeforeAndAft
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipeline(requestModel.toOption.get)

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/presto/src/test/scala/com/yahoo/maha/executor/PrestoQueryExecutorTest.scala
+++ b/presto/src/test/scala/com/yahoo/maha/executor/PrestoQueryExecutorTest.scala
@@ -543,7 +543,7 @@ class PrestoQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipeline = queryPipelineFactory.builder(requestModel.toOption.get, QueryAttributes.empty).get.build()
@@ -593,7 +593,7 @@ class PrestoQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipeline = queryPipelineFactory.builder(requestModel.toOption.get, QueryAttributes.empty).get.build()
@@ -658,7 +658,7 @@ class PrestoQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipeline = queryPipelineFactory.builder(requestModel.toOption.get, QueryAttributes.empty, None, BucketParams())._1.get.build()
@@ -714,7 +714,7 @@ class PrestoQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipeline = queryPipelineFactory.builder(requestModel.toOption.get, QueryAttributes.empty, None, BucketParams())._1.get.build()
@@ -843,7 +843,7 @@ class PrestoQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v1)
@@ -898,7 +898,7 @@ class PrestoQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
 
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestAsync(jsonString))
     val registry = getDefaultRegistry()
-    val requestModel = RequestModel.from(request, registry)
+    val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
     val queryPipelineTry = generatePipelineForQgenVersion(registry, requestModel.toOption.get, Version.v1)

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/MahaService.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/MahaService.scala
@@ -287,7 +287,10 @@ case class DefaultMahaService(config: MahaServiceConfig) extends MahaService wit
   override def generateRequestModel(registryName: String, reportingRequest: ReportingRequest, bucketParams: BucketParams): Try[RequestModelResult] = {
     validateRegistry(registryName)
     val registryConfig = config.registry(registryName)
-    return RequestModelFactory.fromBucketSelector(reportingRequest, bucketParams, registryConfig.registry, registryConfig.bucketSelector, utcTimeProvider = registryConfig.utcTimeProvider)
+    RequestModelFactory.fromBucketSelector(
+      reportingRequest, bucketParams, registryConfig.registry, registryConfig.bucketSelector
+      , utcTimeProvider = registryConfig.utcTimeProvider, userTimeZoneProvider = registryConfig.userTimeZoneProvider
+    )
   }
 
   /**

--- a/service/src/main/scala/com/yahoo/maha/service/UserTimeZoneProvider.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/UserTimeZoneProvider.scala
@@ -1,0 +1,12 @@
+package com.yahoo.maha.service
+
+import com.yahoo.maha.core.request.ReportingRequest
+
+trait UserTimeZoneProvider {
+  def getTimeZone(request: ReportingRequest): Option[String]
+}
+
+object NoopUserTimeZoneProvider extends UserTimeZoneProvider {
+  def getTimeZone(request: ReportingRequest): Option[String] = None
+}
+

--- a/service/src/main/scala/com/yahoo/maha/service/factory/Factory.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/factory/Factory.scala
@@ -16,12 +16,11 @@ import com.yahoo.maha.log.MahaRequestLogWriter
 import com.yahoo.maha.parrequest2.CustomRejectPolicy
 import com.yahoo.maha.parrequest2.future.ParallelServiceExecutor
 import com.yahoo.maha.service.MahaServiceConfig.MahaConfigResult
-import com.yahoo.maha.service.config.dynamic.DynamicConfigurations
 import com.yahoo.maha.service.config.{PassThroughPasswordProvider, PasswordProvider}
 import com.yahoo.maha.service.curators.Curator
 import com.yahoo.maha.service.error.{FailedToConstructFactory, MahaServiceError}
 import com.yahoo.maha.service.request._
-import com.yahoo.maha.service.{MahaServiceConfig, MahaServiceConfigContext, NoopUserTimeZoneProvider, UserTimeZoneProvider}
+import com.yahoo.maha.service.{MahaServiceConfig, MahaServiceConfigContext}
 import javax.sql.DataSource
 import org.json4s.JValue
 import org.json4s.JsonAST.JString

--- a/service/src/main/scala/com/yahoo/maha/service/factory/Factory.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/factory/Factory.scala
@@ -21,7 +21,7 @@ import com.yahoo.maha.service.config.{PassThroughPasswordProvider, PasswordProvi
 import com.yahoo.maha.service.curators.Curator
 import com.yahoo.maha.service.error.{FailedToConstructFactory, MahaServiceError}
 import com.yahoo.maha.service.request._
-import com.yahoo.maha.service.{MahaServiceConfig, MahaServiceConfigContext}
+import com.yahoo.maha.service.{MahaServiceConfig, MahaServiceConfigContext, NoopUserTimeZoneProvider, UserTimeZoneProvider}
 import javax.sql.DataSource
 import org.json4s.JValue
 import org.json4s.JsonAST.JString
@@ -53,7 +53,12 @@ trait RejectedExecutionHandlerFactory extends BaseFactory {
   def supportedProperties: List[(String, Boolean)]
 }
 
-trait UTCTimeProvideryFactory extends BaseFactory {
+trait UserTimeZoneProviderFactory extends BaseFactory {
+  def fromJson(config: org.json4s.JValue)(implicit context: MahaServiceConfigContext) : MahaServiceConfig.MahaConfigResult[UserTimeZoneProvider]
+  def supportedProperties: List[(String, Boolean)]
+}
+
+trait UTCTimeProviderFactory extends BaseFactory {
   def fromJson(config: org.json4s.JValue)(implicit context: MahaServiceConfigContext) : MahaServiceConfig.MahaConfigResult[UTCTimeProvider]
   def supportedProperties: List[(String, Boolean)]
 }
@@ -149,11 +154,15 @@ trait AuthHeaderProviderFactory extends BaseFactory {
 }
 
 import scalaz.syntax.validation._
-class PassThroughUTCTimeProviderFactory extends UTCTimeProvideryFactory {
+class NoopUserTimeZoneProviderFactory extends UserTimeZoneProviderFactory {
+  def fromJson(config: org.json4s.JValue)(implicit context: MahaServiceConfigContext) : MahaServiceConfig.MahaConfigResult[UserTimeZoneProvider] = NoopUserTimeZoneProvider.successNel
+  def supportedProperties: List[(String, Boolean)] = List.empty
+}
+class PassThroughUTCTimeProviderFactory extends UTCTimeProviderFactory {
   def fromJson(config: org.json4s.JValue)(implicit context: MahaServiceConfigContext) : MahaServiceConfig.MahaConfigResult[UTCTimeProvider] = PassThroughUTCTimeProvider.successNel
   def supportedProperties: List[(String, Boolean)] = List.empty
 }
-class BaseUTCTimeProviderFactory extends UTCTimeProvideryFactory {
+class BaseUTCTimeProviderFactory extends UTCTimeProviderFactory {
   def fromJson(config: org.json4s.JValue)(implicit context: MahaServiceConfigContext) : MahaServiceConfig.MahaConfigResult[UTCTimeProvider] = new BaseUTCTimeProvider().successNel
   def supportedProperties: List[(String, Boolean)] = List.empty
 }

--- a/service/src/main/scala/com/yahoo/maha/service/request/package.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/request/package.scala
@@ -2,7 +2,6 @@
 // Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
 package com.yahoo.maha.service
 
-import com.netflix.archaius.config.PollingDynamicConfig
 import com.yahoo.maha.service.config.dynamic.DynamicConfigurations
 import com.yahoo.maha.service.config.dynamic.DynamicConfigurationUtils._
 import grizzled.slf4j.Logging

--- a/service/src/test/resources/mahaServiceExampleJson.json
+++ b/service/src/test/resources/mahaServiceExampleJson.json
@@ -17,6 +17,7 @@
         "hive"
       ],
       "bucketingConfigName": "erBucket",
+      "userTimeZoneProviderName": "erUserTimeZone",
       "utcTimeProviderName": "erUTC",
       "parallelServiceExecutorName": "erParallelExec",
       "dimEstimatorFactoryClass": "com.yahoo.maha.service.factory.TestDimCostEstimatoryFactory",
@@ -359,6 +360,20 @@
       ],
       "queryGenerator": [
       ]
+    }
+  },
+  "userTimeZoneProviderMap": {
+    "erUserTimeZone": {
+      "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+      "config": {
+        "k": "v"
+      }
+    },
+    "irUserTimeZone": {
+      "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+      "config": {
+        "k": "v"
+      }
     }
   },
   "utcTimeProviderMap": {

--- a/service/src/test/scala/com/yahoo/maha/service/config/JsonMahaServiceConfigTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/config/JsonMahaServiceConfigTest.scala
@@ -22,6 +22,7 @@ class JsonMahaServiceConfigTest extends FunSuite with Matchers {
                        |			"executors": ["e1", "e2"],
                        |			"generators": ["g1", "g2"],
                        |			"bucketingConfigName": "erBucket",
+                       |			"userTimeZoneProviderName": "erUserTimeZone",
                        |			"utcTimeProviderName": "erUTC",
                        |			"parallelServiceExecutorName": "erPSE",
                        |			"dimEstimatorFactoryClass": "dimEstFactoryClass",
@@ -39,6 +40,7 @@ class JsonMahaServiceConfigTest extends FunSuite with Matchers {
                        |			"executors": ["e1", "e2"],
                        |			"generators": ["g1", "g2"],
                        |			"bucketingConfigName": "irBucket",
+                       |			"userTimeZoneProviderName": "irUserTimeZone",
                        |			"utcTimeProviderName": "irUTC",
                        |			"parallelServiceExecutorName": "irPSE",
                        |			"dimEstimatorFactoryClass": "dimEstFactoryClass",
@@ -93,6 +95,20 @@ class JsonMahaServiceConfigTest extends FunSuite with Matchers {
                        |			}
                        |		}
                        |
+                       |	},
+                       |	"userTimeZoneProviderMap": {
+                       |		"erUserTimeZone": {
+                       |			"factoryClass": "erUserTimeZoneClass",
+                       |			"config": {
+                       |				"k": "v"
+                       |			}
+                       |		},
+                       |		"irUserTimeZone": {
+                       |			"factoryClass": "irUserTimeZoneClass",
+                       |			"config": {
+                       |				"k": "v"
+                       |			}
+                       |		}
                        |	},
                        |	"utcTimeProviderMap": {
                        |		"erUTC": {

--- a/service/src/test/scala/com/yahoo/maha/service/factory/FactoryTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/factory/FactoryTest.scala
@@ -27,7 +27,7 @@ class FactoryTest extends BaseFactoryTest {
   }
 
   test("Test PassThroughUTCTimeProviderFactory ") {
-    val factoryResult = getFactory[UTCTimeProvideryFactory]("com.yahoo.maha.service.factory.PassThroughUTCTimeProviderFactory", closer)
+    val factoryResult = getFactory[UTCTimeProviderFactory]("com.yahoo.maha.service.factory.PassThroughUTCTimeProviderFactory", closer)
     assert(factoryResult.isSuccess)
     val factory = factoryResult.toOption.get
     assert(factory.supportedProperties.isEmpty)
@@ -49,7 +49,7 @@ class FactoryTest extends BaseFactoryTest {
   }
 
   test("Create a BaseUTCTimeProviderFactory") {
-    val factoryResult = getFactory[UTCTimeProvideryFactory]("com.yahoo.maha.service.factory.BaseUTCTimeProviderFactory", closer)
+    val factoryResult = getFactory[UTCTimeProviderFactory]("com.yahoo.maha.service.factory.BaseUTCTimeProviderFactory", closer)
     factoryResult.toOption.get.fromJson(parse("{}"))
     assert(factoryResult.isSuccess, "should successfully instantiate base factory.")
     assert(factoryResult.toOption.get.supportedProperties == List.empty, "No currently supported properties.")

--- a/service/src/test/scala/com/yahoo/maha/service/factory/FactoryTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/factory/FactoryTest.scala
@@ -3,7 +3,7 @@
 package com.yahoo.maha.service.factory
 
 import com.yahoo.maha.service.config.PasswordProvider
-import com.yahoo.maha.core.UTCTimeProvider
+import com.yahoo.maha.core.{UTCTimeProvider, UserTimeZoneProvider}
 import com.yahoo.maha.core.query.ExecutionLifecycleListener
 import com.yahoo.maha.service.{DefaultMahaServiceConfigContext, MahaServiceConfigContext}
 import org.json4s.jackson.JsonMethods._
@@ -55,5 +55,15 @@ class FactoryTest extends BaseFactoryTest {
     assert(factoryResult.toOption.get.supportedProperties == List.empty, "No currently supported properties.")
   }
 
+  test("Test NoopUserTimeZoneProviderFactory ") {
+    val factoryResult = getFactory[UserTimeZoneProviderFactory]("com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory", closer)
+    assert(factoryResult.isSuccess)
+    val factory = factoryResult.toOption.get
+    assert(factory.supportedProperties.isEmpty)
+    val json = parse("{}")
+    val generatorResult = factory.fromJson(json)
+    assert(generatorResult.isSuccess, generatorResult)
+    assert(generatorResult.toList.head.isInstanceOf[UserTimeZoneProvider])
+  }
 
 }

--- a/service/src/test/scala/com/yahoo/maha/service/factory/LiteralMapperTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/factory/LiteralMapperTest.scala
@@ -35,4 +35,25 @@ class LiteralMapperTest extends BaseFactoryTest {
     assert(generatorResult.toList.head.isInstanceOf[DruidLiteralMapper])
   }
 
+  test("Test DefaultPostgresLiteralMapper") {
+    val factoryResult = getFactory[PostgresLiteralMapperFactory]("com.yahoo.maha.service.factory.DefaultPostgresLiteralMapperFactory", closer)
+    assert(factoryResult.isSuccess)
+    val factory = factoryResult.toOption.get
+    assert(factory.supportedProperties.isEmpty)
+    val json = parse("{}")
+    val generatorResult = factory.fromJson(json)
+    assert(generatorResult.isSuccess, generatorResult)
+    assert(generatorResult.toList.head.isInstanceOf[PostgresLiteralMapper])
+  }
+
+  test("Test DefaultPostgresLiteralMapperUsingDriver") {
+    val factoryResult = getFactory[PostgresLiteralMapperFactory]("com.yahoo.maha.service.factory.DefaultPostgresLiteralMapperUsingDriverFactory", closer)
+    assert(factoryResult.isSuccess)
+    val factory = factoryResult.toOption.get
+    assert(factory.supportedProperties.isEmpty)
+    val json = parse("{}")
+    val generatorResult = factory.fromJson(json)
+    assert(generatorResult.isSuccess, generatorResult)
+    assert(generatorResult.toList.head.isInstanceOf[PostgresLiteralMapper])
+  }
 }

--- a/service/src/test/scala/com/yahoo/maha/service/factory/MahaServiceTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/factory/MahaServiceTest.scala
@@ -24,6 +24,7 @@ class MahaServiceTest extends BaseFactoryTest {
                        |			"executors": ["e1", "e2"],
                        |			"generators": ["g1", "g2"],
                        |			"bucketingConfigName": "OtherBucket",
+                       |			"userTimeZoneProviderName": "erUserTimeZone",
                        |			"utcTimeProviderName": "erUTC",
                        |			"parallelServiceExecutorName": "erPSE",
                        |			"dimEstimatorFactoryClass": "dimEstFactoryClass",
@@ -78,6 +79,20 @@ class MahaServiceTest extends BaseFactoryTest {
                        |			}
                        |		}
                        |
+                       |	},
+                       |	"userTimeZoneProviderMap": {
+                       |		"erUserTimeZone": {
+                       |			"factoryClass": "erUserTimeZoneClass",
+                       |			"config": {
+                       |				"k": "v"
+                       |			}
+                       |		},
+                       |		"irUserTimeZone": {
+                       |			"factoryClass": "irUserTimeZoneClass",
+                       |			"config": {
+                       |				"k": "v"
+                       |			}
+                       |		}
                        |	},
                        |	"utcTimeProviderMap": {
                        |		"erUTC": {
@@ -148,6 +163,7 @@ class MahaServiceTest extends BaseFactoryTest {
                        |			"executors": ["e1", "e2"],
                        |			"generators": ["g1", "g2"],
                        |			"bucketingConfigName": "erBucket",
+                       |			"userTimeZoneProviderName": "erUserTimeZone",
                        |			"utcTimeProviderName": "erUTC",
                        |			"parallelServiceExecutorName": "erParallelExec",
                        |			"dimEstimatorFactoryClass": "dimEstFactoryClass",
@@ -202,6 +218,20 @@ class MahaServiceTest extends BaseFactoryTest {
                        |			}
                        |		}
                        |
+                       |	},
+                       |	"userTimeZoneProviderMap": {
+                       |		"erUserTimeZone": {
+                       |			"factoryClass": "erUserTimeZoneClass",
+                       |			"config": {
+                       |				"k": "v"
+                       |			}
+                       |		},
+                       |		"irUserTimeZone": {
+                       |			"factoryClass": "irUserTimeZoneClass",
+                       |			"config": {
+                       |				"k": "v"
+                       |			}
+                       |		}
                        |	},
                        |	"utcTimeProviderMap": {
                        |		"erUTC": {
@@ -286,6 +316,7 @@ class MahaServiceTest extends BaseFactoryTest {
                          |            "druid"
                          |         ],
                          |         "bucketingConfigName": "erBucket",
+                         |         "userTimeZoneProviderName": "erUserTimeZone",
                          |         "utcTimeProviderName": "erUTC",
                          |         "parallelServiceExecutorName": "erParallelExec",
                          |         "dimEstimatorFactoryClass": "com.yahoo.maha.service.factory.DefaultDimCostEstimatorFactory",
@@ -483,6 +514,20 @@ class MahaServiceTest extends BaseFactoryTest {
                          |}]
                          |      }
                          |   },
+                         |   "userTimeZoneProviderMap": {
+                         |      "erUserTimeZone": {
+                         |         "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+                         |         "config": {
+                         |            "k": "v"
+                         |         }
+                         |      },
+                         |      "irUserTimeZone": {
+                         |         "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+                         |         "config": {
+                         |            "k": "v"
+                         |         }
+                         |      }
+                         |   },
                          |   "utcTimeProviderMap": {
                          |      "erUTC": {
                          |         "factoryClass": "com.yahoo.maha.service.factory.PassThroughUTCTimeProviderFactory",
@@ -612,8 +657,9 @@ class MahaServiceTest extends BaseFactoryTest {
 				"presto"
 			],
 			"bucketingConfigName": "commonBucket",
-			"utcTimeProviderName": "commonUTC",
-			"parallelServiceExecutorName": "commonParallelExec",
+			"userTimeZoneProviderName": "commonUserTimeZone",
+      "utcTimeProviderName": "commonUTC",
+      "parallelServiceExecutorName": "commonParallelExec",
 			"dimEstimatorFactoryClass": "com.yahoo.maha.service.factory.DefaultDimCostEstimatorFactory",
 			"dimEstimatorFactoryConfig": {},
 			"factEstimatorFactoryClass": "com.yahoo.maha.service.factory.DefaultFactCostEstimatorFactory",
@@ -802,6 +848,14 @@ class MahaServiceTest extends BaseFactoryTest {
 					}
 				],
 				"queryGenerator": []
+			}
+		}
+	},
+ 	"userTimeZoneProviderMap": {
+		"commonUserTimeZone": {
+			"factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+			"config": {
+				"k": "v"
 			}
 		}
 	},

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.383-SNAPSHOT</version>
+        <version>6.1-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>

--- a/worker/src/test/resources/mahaServiceExampleJson.json
+++ b/worker/src/test/resources/mahaServiceExampleJson.json
@@ -17,6 +17,7 @@
             "hive"
          ],
          "bucketingConfigName": "erBucket",
+         "userTimeZoneProviderName": "erUserTimeZone",
          "utcTimeProviderName": "erUTC",
          "parallelServiceExecutorName": "erParallelExec",
          "dimEstimatorFactoryClass": "com.yahoo.maha.service.factory.TestDimCostEstimatoryFactory",
@@ -269,6 +270,20 @@
 }],
      "queryGenerator": []
     }
+   },
+   "userTimeZoneProviderMap": {
+      "erUserTimeZone": {
+         "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+         "config": {
+            "k": "v"
+         }
+      },
+      "irUserTimeZone": {
+         "factoryClass": "com.yahoo.maha.service.factory.NoopUserTimeZoneProviderFactory",
+         "config": {
+            "k": "v"
+         }
+      }
    },
    "utcTimeProviderMap": {
       "erUTC": {


### PR DESCRIPTION
Add a date time between filter.  Currently we have a confusing array of Day, Hour, Minute filters which make it hard to understand how to query the data at hour or minute grain.  Adding a first class filter for date time makes this more straightforward.  In order to keep it simple, we only add a between filter since that's the most used and can also emulate an equality filter.

We move the time zone method out of UTC provider since it should be provided by a concrete user time zone provider.  It's not the UTC provider's function to provide the user time zone.  This is a breaking change but should be easy to migrate since the concrete implementation can just extend both UTCTimeProvider and UserTimeZoneProvider.

Added tests for all generators.  Note, I purposely changed the RequestModel.from function to require a UserTimeZoneProvider to ensure downstream changes are forced.

I was thinking of changing major versions since there are breaking changes: 6.1

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
