### PR TITLE
add missed serialize function for not like filter

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/FilterOperation.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/FilterOperation.scala
@@ -1463,6 +1463,12 @@ object Filter extends Logging {
             :: ("operator" -> toJSON(filter.operator.toString))
             :: ("value" -> toJSON(value))
             :: Nil)
+      case NotLikeFilter(field, value, _, _) =>
+        makeObj(
+          ("field" -> toJSON(field))
+            :: ("operator" -> toJSON(filter.operator.toString))
+            :: ("value" -> toJSON(value))
+            :: Nil)
       case NotEqualToFilter(field, value, _, _) =>
         makeObj(
           ("field" -> toJSON(field))

--- a/core/src/test/scala/com/yahoo/maha/core/FilterTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/FilterTest.scala
@@ -751,4 +751,19 @@ class FilterTest extends FunSuite with Matchers {
     assert(thrown.getMessage.contains("The field alias set for the input filter is undefined. "))
 
   }
+
+  test("Test serialization/deserialization for Not like filter") {
+    val notLikeFilter: Filter = NotLikeFilter("testField", "testValue")
+    val renderedFilter = Filter.filterJSONW.write(notLikeFilter)
+    val  expectedRenderedJson : JObject =
+      new JObject(List[(String, JValue)](
+                  ("field", JString("testField"))
+                  , ("operator", JString("Not Like"))
+                  , ("value", JString("testValue"))
+                )
+              )
+    renderedFilter shouldEqual expectedRenderedJson
+    val readJsonFilter = Filter.filterJSONR.read(renderedFilter)
+    readJsonFilter.isSuccess shouldBe true
+  }
 }

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>5.372-SNAPSHOT</version>
+    <version>5.373-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>5.372-SNAPSHOT</version>
+        <version>5.373-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

fixing issue when request falling back to async and see the following message:
`2020-06-17 23:19:46.670  [maha-async-report-service-21] WARN  com.yahoo.maha.core.Filter$ - [requestId=XXX] [userId=XXX] Unsupported filter for json serialize JSONW[Filter] : NotLikeFilter(Policy Group Block Status,ACCEPTED,false,false)`