### PR TITLE
Add ability to drilldown by multiple dims

### DIFF
--- a/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownCurator.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownCurator.scala
@@ -128,7 +128,7 @@ class DrilldownCurator (override val requestModelValidator: CuratorRequestModelV
           publicFact.columnsByAlias(filter.field)
       }
     } else IndexedSeq.empty
-    val allSelectedFields : IndexedSeq[Field] = (IndexedSeq(drilldownConfig.dimension, primaryKeyField).filter{_!=null} ++ factFields).distinct
+    val allSelectedFields : IndexedSeq[Field] = ((drilldownConfig.dimensions ++ IndexedSeq(primaryKeyField)).filter{_!=null} ++ factFields).distinct
     val selectedFieldAliasSet:Set[String] = allSelectedFields.map(f=> f.field).toSet
     val drillDownOrdering = reportingRequest.sortBy.filter(sort => selectedFieldAliasSet.contains(sort.field))
     reportingRequest.copy(cube = cube

--- a/service/src/test/scala/com/yahoo/maha/service/RequestCoordinatorTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/RequestCoordinatorTest.scala
@@ -1065,7 +1065,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
                           "curators" : {
                             "drilldown" : {
                               "config" : {
-                                "dimension": "Remarks"
+                                "dimensions": ["Year", "Remarks"]
                               }
                             }
                           },
@@ -1101,15 +1101,15 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     val drillDownCuratorResult: RequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name)
     val expectedSet = Set(
-      "Row(Map(Remarks -> 0, Student ID -> 1, Total Marks -> 2),ArrayBuffer(some comment 1, 213, 125))",
-      "Row(Map(Remarks -> 0, Student ID -> 1, Total Marks -> 2),ArrayBuffer(some comment 2, 213, 180))",
-      "Row(Map(Remarks -> 0, Student ID -> 1, Total Marks -> 2),ArrayBuffer(some comment 3, 213, 175))"
+      "Row(Map(Year -> 0, Remarks -> 1, Student ID -> 2, Total Marks -> 3),ArrayBuffer(Freshman, some comment 1, 213, 125))",
+      "Row(Map(Year -> 0, Remarks -> 1, Student ID -> 2, Total Marks -> 3),ArrayBuffer(Freshman, some comment 2, 213, 180))",
+      "Row(Map(Year -> 0, Remarks -> 1, Student ID -> 2, Total Marks -> 3),ArrayBuffer(Freshman, some comment 3, 213, 175))",
     )
 
     var cnt = 0
     drillDownCuratorResult.queryPipelineResult.rowList.foreach( row => {
       
-      assert(expectedSet.contains(row.toString))
+      assert(expectedSet.contains(row.toString), row.toString)
       cnt+=1
     })
 

--- a/service/src/test/scala/com/yahoo/maha/service/curators/DrilldownConfigTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/curators/DrilldownConfigTest.scala
@@ -55,7 +55,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     assert(drillDownConfig.enforceFilters)
     assert(drillDownConfig.maxRows == 1000)
     assert(drillDownConfig.ordering.contains(SortBy("Class ID", ASC)))
-    assert(drillDownConfig.dimension == Field("Section ID", None, None))
+    assert(drillDownConfig.dimensions == List(Field("Section ID", None, None)))
     assert(drillDownConfig.cube == "")
   }
 
@@ -100,7 +100,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     assert(drillDownConfig.enforceFilters)
     assert(drillDownConfig.maxRows == 1000)
     assert(drillDownConfig.ordering.contains(SortBy("Class ID", DESC)))
-    assert(drillDownConfig.dimension == Field("Section ID", None, None))
+    assert(drillDownConfig.dimensions == List(Field("Section ID", None, None)))
     assert(drillDownConfig.cube == "")
   }
 
@@ -182,7 +182,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val thrown = intercept[Exception] {
       DrilldownConfig.parse(reportingRequest.curatorJsonConfigMap("drilldown"))
     }
-    assert(thrown.getMessage.contains("CuratorConfig for a DrillDown should have a dimension declared"))
+    assert(thrown.getMessage.contains("CuratorConfig for a DrillDown should have a dimension or dimensions declared"))
   }
 
   test("Create a valid DrillDownConfig with Descending order and multiple orderings") {
@@ -228,7 +228,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     assert(drillDownConfig.enforceFilters)
     assert(drillDownConfig.maxRows == 1000)
     assert(drillDownConfig.ordering.contains(SortBy("Section ID", DESC)))
-    assert(drillDownConfig.dimension == Field("Section ID", None, None))
+    assert(drillDownConfig.dimensions == List(Field("Section ID", None, None)))
     assert(drillDownConfig.cube == "")
   }
 
@@ -240,7 +240,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
                             "drilldown" : {
                               "config" : {
                                 "enforceFilters": false,
-                                "dimension": "Day",
+                                "dimensions": ["Day", "Remarks"],
                                 "mr": 1000
                               }
                             }
@@ -268,7 +268,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
 
     assert(!drillDownConfig.enforceFilters)
     assert(drillDownConfig.maxRows == 1000)
-    assert(drillDownConfig.dimension == Field("Day", None, None))
+    assert(drillDownConfig.dimensions == List(Field("Day", None, None), Field("Remarks", None, None)))
     assert(drillDownConfig.cube == "")
   }
 }


### PR DESCRIPTION
Add ability to drilldown by multiple dims, added new config field "dimensions".  If "dimension" and "dimensions" are both provided, new field "dimensions" takes precedence.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
