### PR TITLE
Add support for multipe drilldowns in one request

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/api-jersey/src/main/scala/com/yahoo/maha/api/jersey/MahaResource.scala
+++ b/api-jersey/src/main/scala/com/yahoo/maha/api/jersey/MahaResource.scala
@@ -185,6 +185,7 @@ class MahaResource(mahaService: MahaService, baseRequest: BaseRequest, requestVa
             case DruidEngine => ReportingRequest.forceDruid(withDebug)
             case HiveEngine => ReportingRequest.forceHive(withDebug)
             case PrestoEngine => ReportingRequest.forcePresto(withDebug)
+            case PostgresEngine => ReportingRequest.forcePostgres(withDebug)
             case _ => withDebug
           }
         } else {

--- a/api-jersey/src/test/scala/com/yahoo/maha/api/jersey/JsonStreamingOutputTest.scala
+++ b/api-jersey/src/test/scala/com/yahoo/maha/api/jersey/JsonStreamingOutputTest.scala
@@ -13,7 +13,7 @@ import com.yahoo.maha.core.request.ReportingRequest
 import com.yahoo.maha.core.{Engine, OracleEngine, RequestModelResult}
 import com.yahoo.maha.service.curators._
 import com.yahoo.maha.service.datasource.IngestionTimeUpdater
-import com.yahoo.maha.service.{MahaRequestContext, ParRequestResult, RequestCoordinatorResult, RequestResult}
+import com.yahoo.maha.service.{CuratorAndRequestResult, MahaRequestContext, ParRequestResult, RequestCoordinatorResult, RequestResult}
 import org.scalatest.FunSuite
 
 import scala.util.Try
@@ -109,8 +109,10 @@ class JsonStreamingOutputTest extends FunSuite {
     mahaRequestContext.mutableState.put(RowCountCurator.name, 1)
     val curatorResults= IndexedSeq(curatorResult)
     val requestCoordinatorResult = RequestCoordinatorResult(IndexedSeq(defaultCurator)
-      , Map(DefaultCurator.name -> curatorResult)
-      , Map.empty, Map(DefaultCurator.name -> curatorResult.parRequestResultOption.get.prodRun.get().right.get)
+      , Map.empty, Map(DefaultCurator.name -> IndexedSeq(
+        CuratorAndRequestResult(curatorResult,
+          curatorResult.parRequestResultOption.get.prodRun.get().right.get))
+      )
       , mahaRequestContext)
     val jsonStreamingOutput = new JsonStreamingOutput(requestCoordinatorResult
       , Map(OracleEngine-> TestOracleIngestionTimeUpdater(OracleEngine, "testSource")))
@@ -153,10 +155,13 @@ class JsonStreamingOutputTest extends FunSuite {
       jsonRequest.getBytes,
       Map.empty, "rid", "uid")
     val requestCoordinatorResult = RequestCoordinatorResult(IndexedSeq(defaultCurator, testCurator)
-      , Map(DefaultCurator.name -> curatorResult1, "TestCurator" -> curatorResult2)
       , Map.empty
-      , Map(DefaultCurator.name -> curatorResult1.parRequestResultOption.get.prodRun.get().right.get
-        , "TestCurator" -> curatorResult2.parRequestResultOption.get.prodRun.get().right.get
+      , Map(DefaultCurator.name -> IndexedSeq(
+        CuratorAndRequestResult(curatorResult1,
+          curatorResult1.parRequestResultOption.get.prodRun.get().right.get))
+        , "TestCurator" -> IndexedSeq(
+          CuratorAndRequestResult(curatorResult2,
+            curatorResult2.parRequestResultOption.get.prodRun.get().right.get))
       )
       , mahaRequestContext)
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.1-SNAPSHOT</version>
+    <version>6.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownConfig.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownConfig.scala
@@ -6,48 +6,63 @@ import com.yahoo.maha.core.request._
 import com.yahoo.maha.service.MahaServiceConfig
 import com.yahoo.maha.service.factory._
 import org.json4s.JValue
+import org.json4s.JsonAST.{JArray, JObject}
 import org.json4s.scalaz.JsonScalaz
 
 /**
-  * Parse an input JSON and convert it to a DrilldownConfig object.
-  **/
+ * Parse an input JSON and convert it to a DrilldownConfig object.
+ **/
 object DrilldownConfig {
-  val MAXIMUM_ROWS : BigInt = 1000
-  val DEFAULT_ENFORCE_FILTERS : Boolean = true
-
 
   implicit val formats: DefaultFormats.type = DefaultFormats
 
-  def parse(curatorJsonConfig: CuratorJsonConfig) : JsonScalaz.Result[DrilldownConfig] = {
-    import _root_.scalaz.syntax.validation._
-
-    val config: JValue = curatorJsonConfig.json
-
-    val dimensions : List[Field] = assignDim(config)
-
-    val maxRows : BigInt = assignMaxRows(config)
-
-    val enforceFilters : Boolean = assignEnforceFilters(config)
-
-    val ordering : IndexedSeq[SortBy] = assignOrdering(config)
-
-    val cube : String = assignCube(config, "")
-
-    DrilldownConfig(enforceFilters, dimensions.toIndexedSeq, cube, ordering, maxRows).successNel
+  def parse(curatorJsonConfig: CuratorJsonConfig): JsonScalaz.Result[DrilldownConfig] = {
+    curatorJsonConfig.json match {
+      case obj: JObject =>
+        DrilldownRequest.parse(obj).map(r => DrilldownConfig(IndexedSeq(r)))
+      case JArray(arr) =>
+        import scalaz.Scalaz._
+        arr.map(DrilldownRequest.parse).sequence[JsonScalaz.Result, DrilldownRequest].map(l => DrilldownConfig(l.toIndexedSeq))
+    }
   }
 
-  private def assignCube(config: JValue, default: String) : String = {
-    val cubeResult : MahaServiceConfig.MahaConfigResult[String] = fieldExtended[String]("cube")(config)
+}
+
+case class DrilldownConfig(requests: IndexedSeq[DrilldownRequest]) extends CuratorConfig
+
+object DrilldownRequest {
+  val MAXIMUM_ROWS: BigInt = 1000
+  val DEFAULT_ENFORCE_FILTERS: Boolean = true
+
+  def parse(config: JValue): JsonScalaz.Result[DrilldownRequest] = {
+    import _root_.scalaz.syntax.validation._
+
+    val dimensions: List[Field] = assignDim(config)
+
+    val maxRows: BigInt = assignMaxRows(config)
+
+    val enforceFilters: Boolean = assignEnforceFilters(config)
+
+    val ordering: IndexedSeq[SortBy] = assignOrdering(config)
+
+    val cube: String = assignCube(config, "")
+
+    DrilldownRequest(enforceFilters, dimensions.toIndexedSeq, cube, ordering, maxRows).successNel
+  }
+
+
+  private def assignCube(config: JValue, default: String): String = {
+    val cubeResult: MahaServiceConfig.MahaConfigResult[String] = fieldExtended[String]("cube")(config)
     if (cubeResult.isSuccess) {
       cubeResult.toOption.get
     }
-    else{
+    else {
       default
     }
   }
 
   private def assignDim(config: JValue): List[Field] = {
-    val drillDim : MahaServiceConfig.MahaConfigResult[String] = fieldExtended[String]("dimension")(config)
+    val drillDim: MahaServiceConfig.MahaConfigResult[String] = fieldExtended[String]("dimension")(config)
     val drillDims: MahaServiceConfig.MahaConfigResult[List[String]] = fieldExtended[List[String]]("dimensions")(config)
     val dims: MahaServiceConfig.MahaConfigResult[List[String]] = drillDims orElse drillDim.map(s => List(s))
     require(dims.isSuccess, "CuratorConfig for a DrillDown should have a dimension or dimensions declared!")
@@ -57,41 +72,41 @@ object DrilldownConfig {
   }
 
   private def assignMaxRows(config: JValue): BigInt = {
-    val maxRowsLimitResult : MahaServiceConfig.MahaConfigResult[Int] = fieldExtended[Int]("mr")(config)
-    if(maxRowsLimitResult.isSuccess) {
+    val maxRowsLimitResult: MahaServiceConfig.MahaConfigResult[Int] = fieldExtended[Int]("mr")(config)
+    if (maxRowsLimitResult.isSuccess) {
       maxRowsLimitResult.toOption.get
     }
-    else{
+    else {
       MAXIMUM_ROWS
     }
   }
 
   private def assignEnforceFilters(config: JValue): Boolean = {
-    val enforceFiltersResult : MahaServiceConfig.MahaConfigResult[Boolean] = fieldExtended[Boolean]("enforceFilters")(config)
-    if(enforceFiltersResult.isSuccess)
+    val enforceFiltersResult: MahaServiceConfig.MahaConfigResult[Boolean] = fieldExtended[Boolean]("enforceFilters")(config)
+    if (enforceFiltersResult.isSuccess)
       enforceFiltersResult.toOption.get
-    else{
+    else {
       DEFAULT_ENFORCE_FILTERS
     }
   }
 
   private def assignOrdering(config: JValue): IndexedSeq[SortBy] = {
-    val orderingResult : MahaServiceConfig.MahaConfigResult[List[SortBy]] = fieldExtended[List[SortBy]]("ordering")(config)
-    if(orderingResult.isSuccess){
+    val orderingResult: MahaServiceConfig.MahaConfigResult[List[SortBy]] = fieldExtended[List[SortBy]]("ordering")(config)
+    if (orderingResult.isSuccess) {
       orderingResult.toOption.get.toIndexedSeq
-    }else {
-      if(orderingResult.toEither.left.get.toString().contains("order must be asc|desc not")){
-        throw new IllegalArgumentException (orderingResult.toEither.left.get.head.message)
+    } else {
+      if (orderingResult.toEither.left.get.toString().contains("order must be asc|desc not")) {
+        throw new IllegalArgumentException(orderingResult.toEither.left.get.head.message)
       }
-      else{
+      else {
         IndexedSeq.empty
       }
     }
   }
 }
 
-case class DrilldownConfig(enforceFilters: Boolean,
-                           dimensions: IndexedSeq[Field],
-                           cube: String,
-                           ordering: IndexedSeq[SortBy],
-                           maxRows: BigInt) extends CuratorConfig
+case class DrilldownRequest(enforceFilters: Boolean,
+                            dimensions: IndexedSeq[Field],
+                            cube: String,
+                            ordering: IndexedSeq[SortBy],
+                            maxRows: BigInt) extends CuratorConfig

--- a/service/src/main/scala/com/yahoo/maha/service/curators/TimeShiftCurator.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/curators/TimeShiftCurator.scala
@@ -112,13 +112,13 @@ class TimeShiftCurator (override val requestModelValidator: CuratorRequestModelV
     requestModelResultTry
   }
 
-  override def process(resultMap: Map[String, Either[CuratorError, ParRequest[CuratorResult]]]
+  override def process(resultMap: Map[String, Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]]]
                        , mahaRequestContext: MahaRequestContext
                        , mahaService: MahaService
                        , mahaRequestLogBuilder: CuratorMahaRequestLogBuilder
                        , curatorConfig: CuratorConfig
                        , curatorInjector: CuratorInjector
-                      ) : Either[CuratorError, ParRequest[CuratorResult]] = {
+                      ) : Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = {
 
     val parallelServiceExecutor = mahaService.getParallelServiceExecutor(mahaRequestContext)
     val parRequestLabel = "processTimeshiftCurator"

--- a/service/src/main/scala/com/yahoo/maha/service/curators/TotalMetricsCurator.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/curators/TotalMetricsCurator.scala
@@ -61,13 +61,13 @@ case class TotalMetricsCurator(override val requestModelValidator: CuratorReques
       .leftMap[JsonScalaz.Error](t => JsonScalaz.UncategorizedError("parseTotalMetricsConfigValidation", t.getMessage, List.empty)).toValidationNel
   }
 
-  override def process(resultMap: Map[String, Either[CuratorError, ParRequest[CuratorResult]]]
+  override def process(resultMap: Map[String, Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]]]
                        , mahaRequestContext: MahaRequestContext
                        , mahaService: MahaService
                        , mahaRequestLogBuilder: CuratorMahaRequestLogBuilder
                        , curatorConfig: CuratorConfig
                        , curatorInjector: CuratorInjector
-                      ) : Either[CuratorError, ParRequest[CuratorResult]] = {
+                      ) : Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = {
 
     val registryConfig = mahaService.getMahaServiceConfig.registry.get(mahaRequestContext.registryName).get
     val parallelServiceExecutor = registryConfig.parallelServiceExecutor

--- a/service/src/main/scala/com/yahoo/maha/service/output/JsonOutputFormat.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/output/JsonOutputFormat.scala
@@ -6,26 +6,27 @@ import java.io.OutputStream
 
 import com.fasterxml.jackson.core.{JsonEncoding, JsonGenerator}
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.yahoo.maha.core.query.{InMemRowList, QueryRowList, RowList}
+import com.yahoo.maha.core.query.{InMemRowList, QueryPipelineResult, QueryRowList, RowList}
 import com.yahoo.maha.core.request.{ReportingRequest, RowCountQuery}
-import com.yahoo.maha.core.{ColumnInfo, DimColumnInfo, Engine, FactColumnInfo}
+import com.yahoo.maha.core.{ColumnInfo, DimColumnInfo, Engine, FactColumnInfo, RequestModelResult}
 import com.yahoo.maha.service.RequestCoordinatorResult
-import com.yahoo.maha.service.curators.{Curator, DefaultCurator, RowCountCurator}
+import com.yahoo.maha.service.curators.{Curator, CuratorError, CuratorResult, DefaultCurator, RowCountCurator}
 import com.yahoo.maha.service.datasource.{IngestionTimeUpdater, NoopIngestionTimeUpdater}
 import org.json4s.JValue
 import org.slf4j.{Logger, LoggerFactory}
 
 /**
-  * Created by hiral on 4/11/18.
-  */
+ * Created by hiral on 4/11/18.
+ */
 object JsonOutputFormat {
   val objectMapper: ObjectMapper = new ObjectMapper()
   val logger: Logger = LoggerFactory.getLogger(classOf[JsonOutputFormat])
-  val ROW_COUNT : String = "ROW_COUNT"
-  val defaultRenderSet : Set[String] = Set(DefaultCurator.name)
+  val ROW_COUNT: String = "ROW_COUNT"
+  val defaultRenderSet: Set[String] = Set(DefaultCurator.name)
 }
+
 case class JsonOutputFormat(requestCoordinatorResult: RequestCoordinatorResult,
-                            ingestionTimeUpdaterMap : Map[Engine, IngestionTimeUpdater] = Map.empty) {
+                            ingestionTimeUpdaterMap: Map[Engine, IngestionTimeUpdater] = Map.empty) {
 
 
   def writeStream(outputStream: OutputStream): Unit = {
@@ -33,9 +34,9 @@ case class JsonOutputFormat(requestCoordinatorResult: RequestCoordinatorResult,
     jsonGenerator.writeStartObject() // {
     val headOption = requestCoordinatorResult.orderedList.headOption
 
-    if(headOption.exists(_.isSingleton)) {
+    if (headOption.exists(_.isSingleton)) {
       renderDefault(headOption.get.name, requestCoordinatorResult, jsonGenerator, None)
-    } else if(requestCoordinatorResult.successResults.contains(DefaultCurator.name)) {
+    } else if (requestCoordinatorResult.successResults.contains(DefaultCurator.name)) {
       val rowCountOption = RowCountCurator.getRowCount(requestCoordinatorResult.mahaRequestContext)
       renderDefault(DefaultCurator.name, requestCoordinatorResult, jsonGenerator, rowCountOption)
       jsonGenerator.writeFieldName("curators") //"curators" :
@@ -51,17 +52,17 @@ case class JsonOutputFormat(requestCoordinatorResult: RequestCoordinatorResult,
     jsonGenerator.close()
   }
 
-  private def renderDefault(curatorName: String, requestCoordinatorResult: RequestCoordinatorResult, jsonGenerator: JsonGenerator, rowCountOption:Option[Int]): Unit = {
-    if(requestCoordinatorResult.successResults.contains(curatorName)
-      && requestCoordinatorResult.curatorResult.contains(curatorName)) {
-      val curatorResult = requestCoordinatorResult.curatorResult(curatorName)
-      val requestResult = requestCoordinatorResult.successResults(curatorName)
-      val qpr = requestResult.queryPipelineResult
+  private def renderDefault(curatorName: String, requestCoordinatorResult: RequestCoordinatorResult, jsonGenerator: JsonGenerator, rowCountOption: Option[Int]): Unit = {
+    if (requestCoordinatorResult.successResults.contains(curatorName)) {
+      val curatorAndRequestResult = requestCoordinatorResult.successResults(curatorName).head //only 1 result for default
+      val requestResults = curatorAndRequestResult.requestResult
+      val curatorResult = curatorAndRequestResult.curatorResult
+      val qpr = requestResults.queryPipelineResult
       val engine = qpr.queryChain.drivingQuery.engine
       val tableName = qpr.queryChain.drivingQuery.tableName
-      val ingestionTimeUpdater:IngestionTimeUpdater = ingestionTimeUpdaterMap
+      val ingestionTimeUpdater: IngestionTimeUpdater = ingestionTimeUpdaterMap
         .getOrElse(qpr.queryChain.drivingQuery.engine, NoopIngestionTimeUpdater(engine, engine.toString))
-      val dimCols : Set[String]  = if(curatorResult.requestModelReference.model.bestCandidates.isDefined) {
+      val dimCols: Set[String] = if (curatorResult.requestModelReference.model.bestCandidates.isDefined) {
         curatorResult.requestModelReference.model.bestCandidates.get.publicFact.dimCols.map(_.alias)
       } else Set.empty
       writeHeader(jsonGenerator
@@ -77,51 +78,102 @@ case class JsonOutputFormat(requestCoordinatorResult: RequestCoordinatorResult,
     }
   }
 
-  private def renderCurator(curator: Curator, requestCoordinatorResult: RequestCoordinatorResult, jsonGenerator: JsonGenerator) : Unit = {
-    if(requestCoordinatorResult.successResults.contains(curator.name)
-      && requestCoordinatorResult.curatorResult.contains(curator.name)) {
-      val curatorResult = requestCoordinatorResult.curatorResult(curator.name)
-      val requestResult = requestCoordinatorResult.successResults(curator.name)
-      val qpr = requestResult.queryPipelineResult
-      val engine = qpr.queryChain.drivingQuery.engine
-      val tableName = qpr.queryChain.drivingQuery.tableName
-      val ingestionTimeUpdater:IngestionTimeUpdater = ingestionTimeUpdaterMap
-        .getOrElse(qpr.queryChain.drivingQuery.engine, NoopIngestionTimeUpdater(engine, engine.toString))
-      val dimCols : Set[String]  = if(curatorResult.requestModelReference.model.bestCandidates.isDefined) {
-        curatorResult.requestModelReference.model.bestCandidates.get.publicFact.dimCols.map(_.alias)
-      } else Set.empty
-      jsonGenerator.writeFieldName(curatorResult.curator.name) // "curatorName":
-      jsonGenerator.writeStartObject() //{
-      jsonGenerator.writeFieldName("result") // "result":
-      jsonGenerator.writeStartObject() //{
-      writeHeader(jsonGenerator
-        , qpr.rowList.columns
-        , curatorResult.requestModelReference.model.reportingRequest
-        , ingestionTimeUpdater
-        , tableName
-        , dimCols
-        , false
-        , qpr.pagination
-      )
-      writeDataRows(jsonGenerator, qpr.rowList, None, curatorResult.requestModelReference.model.reportingRequest)
-      jsonGenerator.writeEndObject() //}
-      jsonGenerator.writeEndObject() //}
+  private def renderCurator(curator: Curator, requestCoordinatorResult: RequestCoordinatorResult, jsonGenerator: JsonGenerator): Unit = {
+    val curatorAndRequestResults = requestCoordinatorResult.successResults.getOrElse(curator.name, IndexedSeq.empty)
+    val curatorErrors = requestCoordinatorResult.failureResults.getOrElse(curator.name, IndexedSeq.empty)
+    val numResults = curatorAndRequestResults.size + curatorErrors.size
 
-    } else if(requestCoordinatorResult.failureResults.contains(curator.name)) {
-      val curatorError = requestCoordinatorResult.failureResults(curator.name)
-      if(requestCoordinatorResult.mahaRequestContext.reportingRequest.isDebugEnabled){
-        JsonOutputFormat.logger.info(curatorError.toString)
+    if (numResults > 1) {
+      jsonGenerator.writeFieldName(curator.name) // "curatorName":
+      jsonGenerator.writeStartObject() //{
+      if (curatorAndRequestResults.nonEmpty) {
+        jsonGenerator.writeFieldName("results") // "results":
+        jsonGenerator.writeStartArray(curatorAndRequestResults.size) //[
+        curatorAndRequestResults.foreach {
+          crr =>
+            renderSuccessResult(jsonGenerator, crr.curatorResult.index, crr.requestResult.queryPipelineResult
+              , crr.curatorResult.requestModelReference)
+        }
+        jsonGenerator.writeEndArray() //]
       }
+      if (curatorErrors.nonEmpty) {
+        jsonGenerator.writeFieldName("errors") // "errors":
+        jsonGenerator.writeStartArray(curatorErrors.size) //[
+        curatorErrors.foreach {
+          ce =>
+            renderFailureResult(jsonGenerator, ce, ce.index)
+        }
+        jsonGenerator.writeEndArray() //]
+      }
+      jsonGenerator.writeEndObject() //}
 
-      jsonGenerator.writeFieldName(curatorError.curator.name) // "curatorName":
-      jsonGenerator.writeStartObject() //{
-      jsonGenerator.writeFieldName("error") // "error":
-      jsonGenerator.writeStartObject() //{
-      jsonGenerator.writeFieldName("message")
-      jsonGenerator.writeString(curatorError.error.throwableOption.map(_.getMessage).filterNot(_ == null).getOrElse(curatorError.error.message))
-      jsonGenerator.writeEndObject() //}
-      jsonGenerator.writeEndObject() //}
+    } else {
+      if (requestCoordinatorResult.successResults.contains(curator.name)) {
+        val curatorAndRequestResult = curatorAndRequestResults.head //only 1 result possible
+        val requestResult = curatorAndRequestResult.requestResult
+        val curatorResult = curatorAndRequestResult.curatorResult
+        val qpr = requestResult.queryPipelineResult
+        jsonGenerator.writeFieldName(curatorResult.curator.name) // "curatorName":
+        jsonGenerator.writeStartObject() //{
+        jsonGenerator.writeFieldName("result") // "result":
+        renderSuccessResult(jsonGenerator, None, qpr, curatorResult.requestModelReference)
+        jsonGenerator.writeEndObject() //}
+
+      } else if (requestCoordinatorResult.failureResults.contains(curator.name)) {
+        val curatorError = curatorErrors.head //only 1 error possible
+        if (requestCoordinatorResult.mahaRequestContext.reportingRequest.isDebugEnabled) {
+          JsonOutputFormat.logger.info(curatorError.toString)
+        }
+        jsonGenerator.writeFieldName(curatorError.curator.name) // "curatorName":
+        jsonGenerator.writeStartObject() //{
+        jsonGenerator.writeFieldName("error") // "error":
+        renderFailureResult(jsonGenerator, curatorError, None)
+        jsonGenerator.writeEndObject() //}
+      }
     }
+  }
+
+  private def renderSuccessResult(jsonGenerator: JsonGenerator, index: Option[Int]
+                                  , qpr: QueryPipelineResult, requestModelReference: RequestModelResult): Unit = {
+    val engine = qpr.queryChain.drivingQuery.engine
+    val tableName = qpr.queryChain.drivingQuery.tableName
+    val ingestionTimeUpdater: IngestionTimeUpdater = ingestionTimeUpdaterMap
+      .getOrElse(qpr.queryChain.drivingQuery.engine, NoopIngestionTimeUpdater(engine, engine.toString))
+    val dimCols: Set[String] = if (requestModelReference.model.bestCandidates.isDefined) {
+      requestModelReference.model.bestCandidates.get.publicFact.dimCols.map(_.alias)
+    } else Set.empty
+    jsonGenerator.writeStartObject() //{
+    if (index.isDefined) {
+      jsonGenerator.writeFieldName("index")
+      jsonGenerator.writeNumber(index.get)
+    }
+    writeHeader(jsonGenerator
+      , qpr.rowList.columns
+      , requestModelReference.model.reportingRequest
+      , ingestionTimeUpdater
+      , tableName
+      , dimCols
+      , false
+      , qpr.pagination
+    )
+    writeDataRows(jsonGenerator, qpr.rowList, None, requestModelReference.model.reportingRequest)
+    jsonGenerator.writeEndObject() //}
+  }
+
+  private def renderFailureResult(jsonGenerator: JsonGenerator
+                                  , curatorError: CuratorError
+                                  , index: Option[Int]): Unit = {
+    if (requestCoordinatorResult.mahaRequestContext.reportingRequest.isDebugEnabled) {
+      JsonOutputFormat.logger.info(curatorError.toString)
+    }
+    jsonGenerator.writeStartObject() //{
+    if (index.isDefined) {
+      jsonGenerator.writeFieldName("index")
+      jsonGenerator.writeNumber(curatorError.index.get)
+    }
+    jsonGenerator.writeFieldName("message")
+    jsonGenerator.writeString(curatorError.error.throwableOption.map(_.getMessage).filterNot(_ == null).getOrElse(curatorError.error.message))
+    jsonGenerator.writeEndObject() //}
   }
 
   private def writeHeader(jsonGenerator: JsonGenerator
@@ -178,14 +230,14 @@ case class JsonOutputFormat(requestCoordinatorResult: RequestCoordinatorResult,
     jsonGenerator.writeEndArray() // ]
     jsonGenerator.writeFieldName("maxRows")
     jsonGenerator.writeNumber(reportingRequest.rowsPerPage)
-    if(reportingRequest.isDebugEnabled) {
+    if (reportingRequest.isDebugEnabled) {
       jsonGenerator.writeFieldName("debug")
       jsonGenerator.writeStartObject()
-      if(isDefault && reportingRequest.isTestEnabled) {
+      if (isDefault && reportingRequest.isTestEnabled) {
         jsonGenerator.writeFieldName("testName")
         jsonGenerator.writeString(reportingRequest.getTestName.get)
       }
-      if(isDefault && reportingRequest.hasLabels) {
+      if (isDefault && reportingRequest.hasLabels) {
         jsonGenerator.writeFieldName("labels")
         val labels = reportingRequest.getLabels
         jsonGenerator.writeStartArray()
@@ -197,7 +249,7 @@ case class JsonOutputFormat(requestCoordinatorResult: RequestCoordinatorResult,
       }
       jsonGenerator.writeEndObject()
     }
-    if(pagination.nonEmpty) {
+    if (pagination.nonEmpty) {
       jsonGenerator.writeFieldName("pagination")
       jsonGenerator.writeStartObject()
       pagination.foreach {
@@ -211,7 +263,7 @@ case class JsonOutputFormat(requestCoordinatorResult: RequestCoordinatorResult,
     jsonGenerator.writeEndObject()
   }
 
-  private def writeDataRows(jsonGenerator: JsonGenerator, rowList: RowList, rowCountOption: Option[Int], reportingRequest:ReportingRequest): Unit = {
+  private def writeDataRows(jsonGenerator: JsonGenerator, rowList: RowList, rowCountOption: Option[Int], reportingRequest: ReportingRequest): Unit = {
     jsonGenerator.writeFieldName("rows") // "rows":
     jsonGenerator.writeStartArray() // [
     val numColumns = rowList.columns.size
@@ -229,15 +281,15 @@ case class JsonOutputFormat(requestCoordinatorResult: RequestCoordinatorResult,
         row => {
           jsonGenerator.writeStartArray()
           var i = 0
-          while(i < numColumns) {
+          while (i < numColumns) {
             jsonGenerator.writeObject(row.getValue(i))
-            i+=1
+            i += 1
           }
           if (reportingRequest.includeRowCount && rowCountOption.isDefined) {
             jsonGenerator.writeObject(rowCountOption.get)
-          } else if(reportingRequest.includeRowCount && row.aliasMap.contains(QueryRowList.ROW_COUNT_ALIAS)) {
+          } else if (reportingRequest.includeRowCount && row.aliasMap.contains(QueryRowList.ROW_COUNT_ALIAS)) {
             jsonGenerator.writeObject(row.getValue(QueryRowList.ROW_COUNT_ALIAS))
-          } else if(reportingRequest.includeRowCount && rowListSize.isDefined) {
+          } else if (reportingRequest.includeRowCount && rowListSize.isDefined) {
             jsonGenerator.writeObject(rowListSize.get)
           }
           jsonGenerator.writeEndArray()

--- a/service/src/main/scala/com/yahoo/maha/service/utils/MahaRequestLogUtils.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/utils/MahaRequestLogUtils.scala
@@ -47,13 +47,18 @@ trait BaseMahaRequestLogBuilder {
   def setJobIdString(jobIdStr: String)
 }
 
-trait CuratorMahaRequestLogBuilder extends BaseMahaRequestLogBuilder
+trait CuratorMahaRequestLogBuilder extends BaseMahaRequestLogBuilder {
+  def copy(curator: Curator): CuratorMahaRequestLogBuilder
+}
 
 trait MahaRequestLogBuilder extends BaseMahaRequestLogBuilder {
   def curatorLogBuilder(curator: Curator): CuratorMahaRequestLogBuilder
 }
 
-case class CuratorMahaRequestLogHelper(delegate: BaseMahaRequestLogBuilder) extends CuratorMahaRequestLogBuilder {
+case class CuratorMahaRequestLogHelper(delegate: MahaRequestLogBuilder) extends CuratorMahaRequestLogBuilder {
+  def copy(curator: Curator): CuratorMahaRequestLogBuilder = {
+    delegate.curatorLogBuilder(curator)
+  }
   override def logQueryPipeline(queryPipeline: QueryPipeline): Unit =
     delegate.logQueryPipeline(queryPipeline)
 

--- a/service/src/test/scala/com/yahoo/maha/service/MahaSyncRequestProcessorTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/MahaSyncRequestProcessorTest.scala
@@ -50,7 +50,7 @@ class MahaSyncRequestProcessorTest extends BaseMahaServiceTest with BeforeAndAft
       mahaServiceConfig.mahaRequestLogWriter
     )
     mahaRequestProcessor.onSuccess((requestCoordinatorResult: RequestCoordinatorResult) => {
-      assert(requestCoordinatorResult.successResults.head._2.queryPipelineResult.rowList.columns.nonEmpty)
+      assert(requestCoordinatorResult.successResults.head._2.head.requestResult.queryPipelineResult.rowList.columns.nonEmpty)
       assertCount+=1
     })
     mahaRequestProcessor.onFailure((ge) => {

--- a/service/src/test/scala/com/yahoo/maha/service/RequestCoordinatorTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/RequestCoordinatorTest.scala
@@ -158,7 +158,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name)
+    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name).head.requestResult
 
     val requestResultString = defaultCuratorRequestResult.queryPipelineResult.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
 
@@ -215,7 +215,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name)
+    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name).head.requestResult
 
     val requestResultString = defaultCuratorRequestResult.queryPipelineResult.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
 
@@ -360,7 +360,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name)
+    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name).head.requestResult
 
     val defaultExpectedSet = Set(
       "Row(Map(Student ID -> 0, Class ID -> 1, Section ID -> 2, Total Marks -> 3),ArrayBuffer(213, 200, 100, 125))",
@@ -412,7 +412,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name)
+    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name).head.requestResult
 
     val defaultExpectedSet = Set(
       "Row(Map(Student ID -> 0, Section ID -> 1, Total Marks -> 2),ArrayBuffer(213, 100, 305))",
@@ -473,7 +473,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name)
+    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name).head.requestResult
 
     val expectedSeq = IndexedSeq(
       "Row(Map(Total Marks Prev -> 4, Section ID -> 2, Total Marks Pct Change -> 5, Student ID -> 0, Total Marks -> 3, Class ID -> 1),ArrayBuffer(213, 199, 200, 175, 0, 100.0))",
@@ -537,7 +537,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name)
+    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name).head.requestResult
 
     val expectedSeq = IndexedSeq(
       "Row(Map(Total Marks Prev -> 4, Section ID -> 2, Total Marks Pct Change -> 5, Student ID -> 0, Total Marks -> 3, Class ID -> 1),ArrayBuffer(214, 198, 311, 180, 0, 100.0))",
@@ -602,7 +602,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name)
+    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name).head.requestResult
 
     val expectedSeq = IndexedSeq(
       "Row(Map(Total Marks Prev -> 4, Section ID -> 2, Total Marks Pct Change -> 5, Student ID -> 0, Total Marks -> 3, Class ID -> 1),ArrayBuffer(213, 199, 200, 175, 0, 100.0))",
@@ -668,7 +668,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name)
+    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name).head.requestResult
 
     val expectedSeq = IndexedSeq(
       "Row(Map(Total Marks Prev -> 4, Section ID -> 2, Total Marks Pct Change -> 5, Student ID -> 0, Total Marks -> 3, Class ID -> 1),ArrayBuffer(213, 200, 100, 125, 135, -7.41))",
@@ -734,7 +734,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name)
+    val timeShiftCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(TimeShiftCurator.name).head.requestResult
 
     val expectedSeq = IndexedSeq(
       "Row(Map(Total Marks Prev -> 4, Section ID -> 2, Total Marks Pct Change -> 5, Student ID -> 0, Total Marks -> 3, Class ID -> 1),ArrayBuffer(213, 199, 200, 175, 0, 100.0))",
@@ -903,7 +903,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     assert(requestCoordinatorResult.failureResults.size === 1)
     assert(requestCoordinatorResult.failureResults.contains(FailingCurator.name))
-    assert(requestCoordinatorResult.failureResults(FailingCurator.name).error.message === "failed")
+    assert(requestCoordinatorResult.failureResults(FailingCurator.name).head.error.message === "failed")
   }
 
   test("successfully return result when par request for curator result returns error") {
@@ -953,7 +953,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     assert(requestCoordinatorResult.failureResults.size === 1)
     assert(requestCoordinatorResult.failureResults.contains(FailingCurator.name))
-    assert(requestCoordinatorResult.failureResults(FailingCurator.name).error.message === "failed")
+    assert(requestCoordinatorResult.failureResults(FailingCurator.name).head.error.message === "failed")
   }
 
   test("successfully return result when par request for request result returns error") {
@@ -1003,7 +1003,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     assert(requestCoordinatorResult.failureResults.size === 1)
     assert(requestCoordinatorResult.failureResults.contains(FailingCurator.name))
-    assert(requestCoordinatorResult.failureResults(FailingCurator.name).error.message === "failed")
+    assert(requestCoordinatorResult.failureResults(FailingCurator.name).head.error.message === "failed")
   }
 
   test("successfully return result when default curator process returns error") {
@@ -1099,7 +1099,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
-    val drillDownCuratorResult: RequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name)
+    val drillDownCuratorResult: RequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head.requestResult
     val expectedSet = Set(
       "Row(Map(Year -> 0, Remarks -> 1, Student ID -> 2, Total Marks -> 3),ArrayBuffer(Freshman, some comment 1, 213, 125))",
       "Row(Map(Year -> 0, Remarks -> 1, Student ID -> 2, Total Marks -> 3),ArrayBuffer(Freshman, some comment 2, 213, 180))",
@@ -1161,7 +1161,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
-    val drillDownCuratorResult: RequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name)
+    val drillDownCuratorResult: RequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head.requestResult
     val expectedSet = Set(
       "Row(Map(Remarks -> 0, Student ID -> 1, Total Marks -> 2),ArrayBuffer(some comment 1, 213, 125))"
     )
@@ -1221,7 +1221,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
-    val drillDownCuratorResult: RequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name)
+    val drillDownCuratorResult: RequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head.requestResult
     val expectedSet = Set(
       "Row(Map(Remarks -> 0, Student ID -> 1, Total Marks -> 2),ArrayBuffer(some comment 1, 213, 125))",
       "Row(Map(Remarks -> 0, Student ID -> 1, Total Marks -> 2),ArrayBuffer(some comment 2, 213, 180))",
@@ -1280,7 +1280,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
-    val drillDownError: CuratorError = requestCoordinatorResult.failureResults(DrilldownCurator.name)
+    val drillDownError: CuratorError = requestCoordinatorResult.failureResults(DrilldownCurator.name).head
     assert(drillDownError.error.message === """requirement failed: Primary key of most granular dim MUST be present in requested cols to join against : Student ID""")
   }
 
@@ -1326,7 +1326,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
-    val drillDownCuratorError: CuratorError = requestCoordinatorResult.failureResults(DrilldownCurator.name)
+    val drillDownCuratorError: CuratorError = requestCoordinatorResult.failureResults(DrilldownCurator.name).head
     assert(drillDownCuratorError.error.message.contains("Gender"))
   }
 
@@ -1371,7 +1371,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
-    val totalMetricsCuratorResult: RequestResult = requestCoordinatorResult.successResults(TotalMetricsCurator.name)
+    val totalMetricsCuratorResult: RequestResult = requestCoordinatorResult.successResults(TotalMetricsCurator.name).head.requestResult
     val expectedSet = Set("Row(Map(Total Marks -> 0),ArrayBuffer(480))")
 
     var cnt = 0
@@ -1426,7 +1426,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
 
     val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
-    val totalMetricsCuratorResult: RequestResult = requestCoordinatorResult.successResults(TotalMetricsCurator.name)
+    val totalMetricsCuratorResult: RequestResult = requestCoordinatorResult.successResults(TotalMetricsCurator.name).head.requestResult
     val expectedSet = Set("Row(Map(Total Marks -> 0),ArrayBuffer(480))")
 
     var cnt = 0
@@ -1477,8 +1477,8 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
 
     val requestCoordinatorResult: RequestCoordinatorResult = requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper).right.get.get().right.get
-    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name)
-    val rowcountCuratorRequestResult: CuratorError = requestCoordinatorResult.failureResults(RowCountCurator.name)
+    val defaultCuratorRequestResult: RequestResult = requestCoordinatorResult.successResults(DefaultCurator.name).head.requestResult
+    val rowcountCuratorRequestResult: CuratorError = requestCoordinatorResult.failureResults(RowCountCurator.name).head
 
     val defaultExpectedSet = Set(
       "Row(Map(Section ID -> 2, Student Name -> 4, Student ID -> 0, Total Marks -> 3, Class ID -> 1),ArrayBuffer(213, 200, 100, 99, ACTIVE))"
@@ -1640,7 +1640,6 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
 
     val expectedJson = s"""{"message":"MahaServiceBadRequestException: requirement failed: Default revision not found for cube student_performance222 in the registry"}"""
     
-
     assert(result.contains(expectedJson))
   }
 
@@ -1696,7 +1695,8 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     assert(requestCoordinatorResult.successResults.contains(DrilldownCurator.name))
 
-    val drillDownCuratorResult = requestCoordinatorResult.curatorResult(DrilldownCurator.name)
+    val drillDownCuratorAndRequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head
+    val drillDownCuratorResult = drillDownCuratorAndRequestResult.curatorResult
 
     val drillDownReportingRequest = drillDownCuratorResult.requestModelReference.model.reportingRequest
 
@@ -1769,7 +1769,7 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     assert(requestCoordinatorResult.failureResults.contains(DrilldownCurator.name))
 
-    val drillDownCuratorResult = requestCoordinatorResult.failureResults(DrilldownCurator.name)
+    val drillDownCuratorResult = requestCoordinatorResult.failureResults(DrilldownCurator.name).head
     assert(drillDownCuratorResult.error.message.contains("requirement failed: Request must apply filters or enforce ReportingRequest input filters!  Check enforceFilters parameter value."))
   }
 
@@ -1821,7 +1821,8 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     assert(requestCoordinatorResult.successResults.contains(DrilldownCurator.name))
 
-    val drillDownCuratorResult = requestCoordinatorResult.curatorResult(DrilldownCurator.name)
+    val drillDownCuratorAndRequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head
+    val drillDownCuratorResult = drillDownCuratorAndRequestResult.curatorResult
 
     val drillDownReportingRequest = drillDownCuratorResult.requestModelReference.model.reportingRequest
 
@@ -1839,6 +1840,215 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
 
     val expectedJson = s"""{"header":{"cube":"student_performance2","fields":[{"fieldName":"Student ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"},{"fieldName":"Section ID","fieldType":"DIM"}],"maxRows":200,"debug":{}},"rows":[[213,305,100],[213,175,200]],"curators":{"drilldown":{"result":{"header":{"cube":"student_performance2","fields":[{"fieldName":"Section Status","fieldType":"DIM"},{"fieldName":"Section ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"}],"maxRows":1000,"debug":{}},"rows":[[null,0,305],[null,0,175]]}}}}"""
 
+    assert(result === expectedJson)
+  }
+
+  test("DrillDown Curator should work correctly with multiple drilldown requests)") {
+
+    val jsonRequest = s"""{
+                          "cube": "student_performance2",
+                          "curators" : {
+                            "drilldown" : {
+                              "config" : [{
+                                "enforceFilters": true,
+                                "dimension": "Section Status",
+                                "cube": "student_performance2"
+                              },
+                              {
+                                "enforceFilters": true,
+                                "dimension": "Section Start Year",
+                                "cube": "student_performance2"
+                              }]
+                            }
+                          },
+                          "selectFields": [
+                            {"field": "Student ID"},
+                            {"field": "Total Marks"},
+                            {"field": "Section ID"}
+                          ],
+                          "sortBy": [
+                            {"field": "Total Marks", "order": "Desc"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                            {"field": "Student ID", "operator": "=", "value": "213"}
+                          ],
+                          "includeRowCount": false
+                        }"""
+    val reportingRequestResult = ReportingRequest.deserializeSyncWithFactBias(jsonRequest.getBytes, schema = StudentSchema)
+    require(reportingRequestResult.isSuccess)
+    val reportingRequest = reportingRequestResult.toOption.get.copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true)))
+
+    // Revision 1 is druid + oracle case
+    val bucketParams = BucketParams(UserInfo("uid", isInternal = true), forceRevision = Some(10))
+
+    val mahaRequestContext = MahaRequestContext(REGISTRY,
+      bucketParams,
+      reportingRequest,
+      jsonRequest.getBytes,
+      Map.empty, "rid", "uid")
+    val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
+
+    val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
+
+    val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
+
+    assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
+    assert(requestCoordinatorResult.successResults.contains(DrilldownCurator.name))
+
+    val drillDownCuratorAndRequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head
+    val drillDownCuratorResult = drillDownCuratorAndRequestResult.curatorResult
+
+    val drillDownReportingRequest = drillDownCuratorResult.requestModelReference.model.reportingRequest
+
+    assert(drillDownReportingRequest.sortBy.size == 1)
+    assert(drillDownReportingRequest.sortBy.map(_.field).contains("Total Marks"))
+
+    val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult)
+
+    val stringStream =  new StringStream()
+
+    jsonStreamingOutput.writeStream(stringStream)
+    val result = stringStream.toString()
+
+
+
+    val expectedJson = """{"header":{"cube":"student_performance2","fields":[{"fieldName":"Student ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"},{"fieldName":"Section ID","fieldType":"DIM"}],"maxRows":200,"debug":{}},"rows":[[213,305,100],[213,175,200]],"curators":{"drilldown":{"results":[{"index":0,"header":{"cube":"student_performance2","fields":[{"fieldName":"Section Status","fieldType":"DIM"},{"fieldName":"Section ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"}],"maxRows":1000,"debug":{}},"rows":[[null,0,305],[null,0,175]]},{"index":1,"header":{"cube":"student_performance2","fields":[{"fieldName":"Section Start Year","fieldType":"DIM"},{"fieldName":"Section ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"}],"maxRows":1000,"debug":{}},"rows":[[0,0,305],[0,0,175]]}]}}}""".stripMargin
+    assert(result === expectedJson)
+  }
+
+  test("DrillDown Curator should work correctly with multiple drilldown requests with some failed)") {
+
+    val jsonRequest = s"""{
+                          "cube": "student_performance2",
+                          "curators" : {
+                            "drilldown" : {
+                              "config" : [{
+                                "enforceFilters": true,
+                                "dimension": "Section Status",
+                                "cube": "student_performance2"
+                              },
+                              {
+                                "enforceFilters": true,
+                                "dimension": "Section Start Year",
+                                "cube": "student_performance222"
+                              }]
+                            }
+                          },
+                          "selectFields": [
+                            {"field": "Student ID"},
+                            {"field": "Total Marks"},
+                            {"field": "Section ID"}
+                          ],
+                          "sortBy": [
+                            {"field": "Total Marks", "order": "Desc"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                            {"field": "Student ID", "operator": "=", "value": "213"}
+                          ],
+                          "includeRowCount": false
+                        }"""
+    val reportingRequestResult = ReportingRequest.deserializeSyncWithFactBias(jsonRequest.getBytes, schema = StudentSchema)
+    require(reportingRequestResult.isSuccess)
+    val reportingRequest = reportingRequestResult.toOption.get.copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true)))
+
+    // Revision 1 is druid + oracle case
+    val bucketParams = BucketParams(UserInfo("uid", isInternal = true), forceRevision = Some(10))
+
+    val mahaRequestContext = MahaRequestContext(REGISTRY,
+      bucketParams,
+      reportingRequest,
+      jsonRequest.getBytes,
+      Map.empty, "rid", "uid")
+    val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
+
+    val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
+
+    val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
+
+    assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
+    assert(requestCoordinatorResult.successResults.contains(DrilldownCurator.name))
+
+    val drillDownCuratorAndRequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head
+    val drillDownCuratorResult = drillDownCuratorAndRequestResult.curatorResult
+
+    val drillDownReportingRequest = drillDownCuratorResult.requestModelReference.model.reportingRequest
+
+    assert(drillDownReportingRequest.sortBy.size == 1)
+    assert(drillDownReportingRequest.sortBy.map(_.field).contains("Total Marks"))
+
+    val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult)
+
+    val stringStream =  new StringStream()
+
+    jsonStreamingOutput.writeStream(stringStream)
+    val result = stringStream.toString()
+
+
+
+    val expectedJson = """{"header":{"cube":"student_performance2","fields":[{"fieldName":"Student ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"},{"fieldName":"Section ID","fieldType":"DIM"}],"maxRows":200,"debug":{}},"rows":[[213,305,100],[213,175,200]],"curators":{"drilldown":{"results":[{"index":0,"header":{"cube":"student_performance2","fields":[{"fieldName":"Section Status","fieldType":"DIM"},{"fieldName":"Section ID","fieldType":"DIM"},{"fieldName":"Total Marks","fieldType":"FACT"}],"maxRows":1000,"debug":{}},"rows":[[null,0,305],[null,0,175]]}],"errors":[{"index":1,"message":"MahaServiceBadRequestException: requirement failed: Default revision not found for cube student_performance222 in the registry"}]}}}""".stripMargin
+    assert(result === expectedJson)
+  }
+
+  test("DrillDown Curator should fail with no most granular key") {
+
+    val jsonRequest = s"""{
+                          "cube": "student_performance2",
+                          "curators" : {
+                            "drilldown" : {
+                              "config" : [{
+                                "enforceFilters": true,
+                                "dimension": "Section Status",
+                                "cube": "student_performance2"
+                              }]
+                            }
+                          },
+                          "selectFields": [
+                            {"field": "Total Marks"}
+                          ],
+                          "sortBy": [
+                            {"field": "Total Marks", "order": "Desc"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                            {"field": "Student ID", "operator": "=", "value": "213"}
+                          ],
+                          "includeRowCount": false
+                        }"""
+    val reportingRequestResult = ReportingRequest.deserializeSyncWithFactBias(jsonRequest.getBytes, schema = StudentSchema)
+    require(reportingRequestResult.isSuccess)
+    val reportingRequest = reportingRequestResult.toOption.get.copy(additionalParameters = Map(Parameter.Debug -> DebugValue(value = true)))
+
+    // Revision 1 is druid + oracle case
+    val bucketParams = BucketParams(UserInfo("uid", isInternal = true), forceRevision = Some(10))
+
+    val mahaRequestContext = MahaRequestContext(REGISTRY,
+      bucketParams,
+      reportingRequest,
+      jsonRequest.getBytes,
+      Map.empty, "rid", "uid")
+    val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
+
+    val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
+
+    val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
+
+    assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
+    assert(requestCoordinatorResult.failureResults.contains(DrilldownCurator.name))
+
+    val drillDownError = requestCoordinatorResult.failureResults(DrilldownCurator.name).head
+
+    assert(drillDownError.error.message === "no primary key alias found in request", drillDownError.error)
+
+    val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult)
+
+    val stringStream =  new StringStream()
+
+    jsonStreamingOutput.writeStream(stringStream)
+    val result = stringStream.toString()
+
+    val expectedJson = """{"header":{"cube":"student_performance2","fields":[{"fieldName":"Total Marks","fieldType":"FACT"}],"maxRows":200,"debug":{}},"rows":[[480]],"curators":{"drilldown":{"error":{"message":"MahaServiceBadRequestException: No primary key alias found in request"}}}}""".stripMargin
     assert(result === expectedJson)
   }
 
@@ -1890,7 +2100,8 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     assert(requestCoordinatorResult.successResults.contains(DrilldownCurator.name))
 
-    val drillDownCuratorResult = requestCoordinatorResult.curatorResult(DrilldownCurator.name)
+    val drillDownCuratorAndRequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head
+    val drillDownCuratorResult = drillDownCuratorAndRequestResult.curatorResult
 
     val drillDownReportingRequest = drillDownCuratorResult.requestModelReference.model.reportingRequest
 
@@ -1960,7 +2171,8 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
     assert(requestCoordinatorResult.successResults.contains(DrilldownCurator.name))
 
-    val drillDownCuratorResult = requestCoordinatorResult.curatorResult(DrilldownCurator.name)
+    val drillDownCuratorAndRequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head
+    val drillDownCuratorResult = drillDownCuratorAndRequestResult.curatorResult
 
     val drillDownReportingRequest = drillDownCuratorResult.requestModelReference.model.reportingRequest
 

--- a/service/src/test/scala/com/yahoo/maha/service/curators/DefaultCuratorTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/curators/DefaultCuratorTest.scala
@@ -75,7 +75,7 @@ class DefaultCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll{
     val defaultCurator = DefaultCurator(curatorResultPostProcessor = new CuratorCustomPostProcessor)
 
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
-    val defaultParRequest: Either[CuratorError, ParRequest[CuratorResult]] = defaultCurator
+    val defaultParRequest: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = defaultCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(defaultParRequest.isRight)
@@ -94,10 +94,10 @@ class DefaultCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll{
     val defaultCurator = DefaultCurator(curatorResultPostProcessor = new CuratorCustomPostProcessor())
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val defaultParRequest: Either[GeneralError, ParRequest[CuratorResult]] = defaultCurator
+    val defaultParRequest: Either[GeneralError, IndexedSeq[ParRequest[CuratorResult]]] = defaultCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
-    defaultParRequest.right.get.resultMap[CuratorResult](
+    defaultParRequest.right.get.head.resultMap[CuratorResult](
         ParFunction.fromScala(
      (curatorResult: CuratorResult) => {
        assert(curatorResult.parRequestResultOption.get.prodRun.get().isRight)
@@ -112,7 +112,7 @@ class DefaultCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll{
     val defaultCurator = DefaultCurator(new BadTestRequestModelValidator)
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val defaultParRequest: Either[GeneralError, ParRequest[CuratorResult]] = defaultCurator
+    val defaultParRequest: Either[GeneralError, IndexedSeq[ParRequest[CuratorResult]]] = defaultCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(defaultParRequest.isLeft)

--- a/service/src/test/scala/com/yahoo/maha/service/curators/FailingCurator.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/curators/FailingCurator.scala
@@ -21,13 +21,13 @@ class FailingCurator extends Curator {
 
   override def priority: Int = 0
 
-  override def process(resultMap: Map[String, Either[CuratorError, ParRequest[CuratorResult]]]
+  override def process(resultMap: Map[String, Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]]]
                        , mahaRequestContext: MahaRequestContext
                        , mahaService: MahaService
                        , mahaRequestLogBuilder: CuratorMahaRequestLogBuilder
                        , curatorConfig: CuratorConfig
                        , curatorInjector: CuratorInjector
-                      ) : Either[CuratorError, ParRequest[CuratorResult]] = {
+                      ) : Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = {
     val pse = mahaService.getParallelServiceExecutor(mahaRequestContext)
     mahaRequestContext.context.get("faillevel") match {
       case Some("requestresult") =>
@@ -38,11 +38,11 @@ class FailingCurator extends Curator {
         val curatorResultEither: Either[GeneralError, CuratorResult] = new Right(curatorResult)
         val parRequest: ParRequest[CuratorResult] =
           pse.immediateResult("fail", curatorResultEither)
-        new Right(parRequest)
+        new Right(IndexedSeq(parRequest))
       case Some("curatorresult") =>
         val parRequest: ParRequest[CuratorResult] =
           pse.immediateResult("fail", withParRequestError(curatorConfig, GeneralError.from("fail", "failed")))
-        new Right(parRequest)
+        new Right(IndexedSeq(parRequest))
       case _ =>
         withError(curatorConfig, GeneralError.from("fail", "failed"))
     }

--- a/service/src/test/scala/com/yahoo/maha/service/curators/RowCountCuratorTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/curators/RowCountCuratorTest.scala
@@ -103,12 +103,12 @@ class RowCountCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val rowCountCurator = RowCountCurator()
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val rowCountCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = rowCountCurator
+    val rowCountCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = rowCountCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(rowCountCuratorResult.isRight)
 
-    val parRequestCuratorResult = rowCountCuratorResult.right.get.get(1000)
+    val parRequestCuratorResult = rowCountCuratorResult.right.get.head.get(1000)
     assert(parRequestCuratorResult.isRight)
   }
 
@@ -154,12 +154,12 @@ class RowCountCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val rowCountCurator = RowCountCurator()
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val rowCountCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = rowCountCurator
+    val rowCountCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = rowCountCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(rowCountCuratorResult.isRight)
 
-    val parRequestCuratorResult = rowCountCuratorResult.right.get.get(1000)
+    val parRequestCuratorResult = rowCountCuratorResult.right.get.head.get(1000)
     assert(parRequestCuratorResult.isRight)
   }
 
@@ -203,13 +203,13 @@ class RowCountCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val rowCountCurator = RowCountCurator()
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val rowCountCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = rowCountCurator
+    val rowCountCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = rowCountCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(rowCountCuratorResult.isRight)
     val parReq = rowCountCuratorResult.right.get
 
-    val result = parReq.get(1000)
+    val result = parReq.head.get(1000)
     val parReqOption = result.right.get.parRequestResultOption
     assert(parReqOption.isDefined)
 
@@ -358,7 +358,7 @@ class RowCountCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val rowCountCurator = RowCountCurator()
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val rowCountCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = rowCountCurator
+    val rowCountCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = rowCountCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(rowCountCuratorResult.isLeft)
@@ -406,7 +406,7 @@ class RowCountCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val rowCountCurator = RowCountCurator()
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val rowCountCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = rowCountCurator
+    val rowCountCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = rowCountCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(rowCountCuratorResult.isLeft)
@@ -454,7 +454,7 @@ class RowCountCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val rowCountCurator = RowCountCurator(new BadTestRequestModelValidator)
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val rowCountCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = rowCountCurator
+    val rowCountCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = rowCountCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(rowCountCuratorResult.isLeft)
@@ -508,12 +508,12 @@ class RowCountCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val rowCountConfig: RowCountConfig = parseRowCountConfig.toOption.get.asInstanceOf[RowCountConfig]
 
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
-    val rowCountCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = rowCountCurator
+    val rowCountCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = rowCountCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper,rowCountConfig, curatorInjector)
 
     assert(rowCountCuratorResult.isRight)
 
-    val parRequestCuratorResult = rowCountCuratorResult.right.get.get(1000) //Should be CuratorResult Object
+    val parRequestCuratorResult = rowCountCuratorResult.right.get.head.get(1000) //Should be CuratorResult Object
     assert(parRequestCuratorResult.isRight)
   }
 }

--- a/service/src/test/scala/com/yahoo/maha/service/curators/TotalMetricsCuratorTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/curators/TotalMetricsCuratorTest.scala
@@ -105,11 +105,11 @@ class TotalMetricsCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll
     assert(totalMetricsConfig.forceRevision === Option(0))
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val totalMetricsCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = totalMetricsCurator
+    val totalMetricsCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = totalMetricsCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     val queryPipelineResult = totalMetricsCuratorResult
-      .right.get.get().right.get.parRequestResultOption.get.prodRun.get().right.get.queryPipelineResult
+      .right.get.head.get().right.get.parRequestResultOption.get.prodRun.get().right.get.queryPipelineResult
     var rowCount = 0
     queryPipelineResult.rowList.foreach {
       row=>
@@ -159,7 +159,7 @@ class TotalMetricsCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll
     val totalMetricsCurator = TotalMetricsCurator()
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val totalMetricsCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = totalMetricsCurator
+    val totalMetricsCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = totalMetricsCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(totalMetricsCuratorResult.isLeft)
@@ -205,12 +205,12 @@ class TotalMetricsCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll
     val totalMetricsCurator = TotalMetricsCurator()
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val totalMetricsCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = totalMetricsCurator
+    val totalMetricsCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = totalMetricsCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(totalMetricsCuratorResult.isRight)
     val parRequest = totalMetricsCuratorResult.right.get
-    val parRequestResult = parRequest.get(1000)
+    val parRequestResult = parRequest.head.get(1000)
     assert(parRequestResult.right.get.parRequestResultOption.get.prodRun.get(1000).isLeft)
   }
 
@@ -253,7 +253,7 @@ class TotalMetricsCuratorTest extends BaseMahaServiceTest with BeforeAndAfterAll
     val totalMetricsCurator = TotalMetricsCurator(new BadTestRequestModelValidator)
     val curatorInjector = new CuratorInjector(2, mahaService, mahaRequestLogHelper, Set.empty)
 
-    val totalMetricsCuratorResult: Either[CuratorError, ParRequest[CuratorResult]] = totalMetricsCurator
+    val totalMetricsCuratorResult: Either[CuratorError, IndexedSeq[ParRequest[CuratorResult]]] = totalMetricsCurator
       .process(Map.empty, mahaRequestContext, mahaService, curatorMahaRequestLogHelper, NoConfig, curatorInjector)
 
     assert(totalMetricsCuratorResult.isLeft)

--- a/service/src/test/scala/com/yahoo/maha/service/example/MahaServiceExampleTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/example/MahaServiceExampleTest.scala
@@ -150,7 +150,7 @@ class MahaServiceExampleTest extends BaseMahaServiceTest with Logging with Befor
 
     def fn = {
       (requestCoordinatorResult: RequestCoordinatorResult) => {
-        val requestResult = requestCoordinatorResult.successResults.head._2
+        val requestResult = requestCoordinatorResult.successResults.head._2.head.requestResult
         assert(requestResult.queryPipelineResult.rowList.columns.size  ==  4)
         assert(requestResult.queryPipelineResult.rowList.asInstanceOf[QueryRowList].columnNames.contains("Total Marks"))
         logger.info("Inside onSuccess function")

--- a/service/src/test/scala/com/yahoo/maha/service/output/JsonOutputFormatTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/output/JsonOutputFormatTest.scala
@@ -13,7 +13,7 @@ import com.yahoo.maha.service.curators._
 import com.yahoo.maha.service.datasource.IngestionTimeUpdater
 import com.yahoo.maha.service.example.ExampleSchema.StudentSchema
 import com.yahoo.maha.service.utils.MahaRequestLogHelper
-import com.yahoo.maha.service.{BaseMahaServiceTest, CuratorInjector, MahaRequestContext, ParRequestResult, RequestCoordinatorResult, RequestResult}
+import com.yahoo.maha.service.{BaseMahaServiceTest, CuratorAndRequestResult, CuratorInjector, MahaRequestContext, ParRequestResult, RequestCoordinatorResult, RequestResult}
 import org.json4s.JsonAST.{JInt, JObject}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should
@@ -134,8 +134,9 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val curatorResult = CuratorResult(defaultCurator, NoConfig, Option(parRequestResult), requestModelResult)
 
     val requestCoordinatorResult = RequestCoordinatorResult(IndexedSeq(defaultCurator)
-      , Map(DefaultCurator.name -> curatorResult)
-      , Map.empty, Map(DefaultCurator.name -> curatorResult.parRequestResultOption.get.prodRun.get().right.get)
+      , Map.empty
+      , Map(DefaultCurator.name -> IndexedSeq(CuratorAndRequestResult(curatorResult
+        , curatorResult.parRequestResultOption.get.prodRun.get().right.get)))
       , mahaRequestContext)
 
     val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult
@@ -187,10 +188,9 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val curatorResults = IndexedSeq(curatorResult1, curatorResult2)
 
     val requestCoordinatorResult = RequestCoordinatorResult(IndexedSeq(defaultCurator, testCurator)
-      , Map(DefaultCurator.name -> curatorResult1, curatorResult2.curator.name -> curatorResult2)
       , Map.empty
-      , Map(DefaultCurator.name -> curatorResult1.parRequestResultOption.get.prodRun.get().right.get
-        , "TestCurator" -> curatorResult2.parRequestResultOption.get.prodRun.get().right.get
+      , Map(DefaultCurator.name -> IndexedSeq(CuratorAndRequestResult(curatorResult1, curatorResult1.parRequestResultOption.get.prodRun.get().right.get))
+        , "TestCurator" -> IndexedSeq(CuratorAndRequestResult(curatorResult2, curatorResult2.parRequestResultOption.get.prodRun.get().right.get))
       )
       , mahaRequestContext)
     val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult)
@@ -229,9 +229,8 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val curatorResults = IndexedSeq(curatorResult1, curatorResult2)
 
     val requestCoordinatorResult = RequestCoordinatorResult(IndexedSeq(defaultCurator, failingCurator)
-      , Map(DefaultCurator.name -> curatorResult1)
-      , Map(failingCurator.name -> curatorResult2.left.get)
-      , Map(DefaultCurator.name -> curatorResult1.parRequestResultOption.get.prodRun.get().right.get)
+      , Map(failingCurator.name -> IndexedSeq(curatorResult2.left.get))
+      , Map(DefaultCurator.name -> IndexedSeq(CuratorAndRequestResult(curatorResult1, curatorResult1.parRequestResultOption.get.prodRun.get().right.get)))
       , mahaRequestContext)
     val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult)
 
@@ -267,9 +266,8 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val curatorResults = IndexedSeq(curatorResult1)
 
     val requestCoordinatorResult = RequestCoordinatorResult(IndexedSeq(defaultCurator)
-      , Map(DefaultCurator.name -> curatorResult1)
       , Map.empty
-      , Map(DefaultCurator.name -> curatorResult1.parRequestResultOption.get.prodRun.get().right.get)
+      , Map(DefaultCurator.name -> IndexedSeq(CuratorAndRequestResult(curatorResult1, curatorResult1.parRequestResultOption.get.prodRun.get().right.get)))
       , mahaRequestContext)
     val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult)
 
@@ -304,9 +302,8 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val curatorResults = IndexedSeq(curatorResult1)
 
     val requestCoordinatorResult = RequestCoordinatorResult(IndexedSeq(defaultCurator)
-      , Map(DefaultCurator.name -> curatorResult1)
       , Map.empty
-      , Map(DefaultCurator.name -> curatorResult1.parRequestResultOption.get.prodRun.get().right.get)
+      , Map(DefaultCurator.name -> IndexedSeq(CuratorAndRequestResult(curatorResult1, curatorResult1.parRequestResultOption.get.prodRun.get().right.get)))
       , mahaRequestContext)
     val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult)
 
@@ -372,10 +369,10 @@ class JsonOutputFormatTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     val curatorResult2 = CuratorResult(rowCountCurator, NoConfig, Option(parRequestResult), requestModelResult)
 
     val requestCoordinatorResult = RequestCoordinatorResult(IndexedSeq(defaultCurator, rowCountCurator)
-      , Map(DefaultCurator.name -> curatorResult1, RowCountCurator.name -> curatorResult2)
       , Map.empty
-      , Map(DefaultCurator.name -> curatorResult1.parRequestResultOption.get.prodRun.get().right.get,
-            RowCountCurator.name -> curatorResult2.parRequestResultOption.get.prodRun.get().right.get)
+      , Map(DefaultCurator.name -> IndexedSeq(CuratorAndRequestResult(curatorResult1, curatorResult1.parRequestResultOption.get.prodRun.get().right.get)),
+            RowCountCurator.name -> IndexedSeq(CuratorAndRequestResult(curatorResult2, curatorResult2.parRequestResultOption.get.prodRun.get().right.get))
+      )
       , mahaRequestContext)
     val jsonStreamingOutput = JsonOutputFormat(requestCoordinatorResult)
 

--- a/service/src/test/scala/com/yahoo/maha/service/utils/MahaRequestLogHelperTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/utils/MahaRequestLogHelperTest.scala
@@ -10,7 +10,7 @@ import com.yahoo.maha.core.bucketing.{BucketParams, UserInfo}
 import com.yahoo.maha.core.query._
 import com.yahoo.maha.core.request.ReportingRequest
 import com.yahoo.maha.log.MahaRequestLogWriter
-import com.yahoo.maha.service.curators.DefaultCurator
+import com.yahoo.maha.service.curators.{DefaultCurator, DrilldownCurator}
 import com.yahoo.maha.service.{MahaRequestContext, MahaServiceConfig}
 import org.apache.druid.common.config.NullHandling
 import org.mockito.Mockito._
@@ -149,7 +149,7 @@ class MahaRequestLogHelperTest extends FunSuite with Matchers {
     mahaRequestLogHelper.setJobId(12345)
     mahaRequestLogHelper.logQueryStats(queryAttributeBuilder.build)
     val curatorLogBuilder = mahaRequestLogHelper.curatorLogBuilder(new DefaultCurator())
-    val curatorHelper = CuratorMahaRequestLogHelper(curatorLogBuilder)
+    val curatorHelper = curatorLogBuilder.copy(new DrilldownCurator())
     curatorHelper.setJobIdString("abcd")
     curatorHelper.logFailed("a second new error message")
   }

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.1-SNAPSHOT</version>
+        <version>6.2-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
The changes should be backwards compatible.  However, the changes to Curator interface may require some changes to handle a IndexedSeq[CuratorResult] instead of just CuratorResult per curator for any custom Curator implementations.

This PR depends on #665 so once that is merged I can merge master to get the real diff.

New multi drilldown request looks like this:

```
{
    "cube": "student_performance2",
    "curators": {
        "drilldown": {
            "config": [
                {
                    "enforceFilters": true,
                    "dimension": "Section Status",
                    "cube": "student_performance2"
                },
                {
                    "enforceFilters": true,
                    "dimension": "Section Start Year",
                    "cube": "student_performance2"
                }
            ]
        }
    },
    "selectFields": [
        {
            "field": "Student ID"
        },
        {
            "field": "Total Marks"
        },
        {
            "field": "Section ID"
        }
    ],
    "sortBy": [
        {
            "field": "Total Marks",
            "order": "Desc"
        }
    ],
    "filterExpressions": [
        {
            "field": "Day",
            "operator": "between",
            "from": "$fromDate",
            "to": "$toDate"
        },
        {
            "field": "Student ID",
            "operator": "=",
            "value": "213"
        }
    ],
    "includeRowCount": false
}
```

The change is the config can now be a list of objects or a single request via just an object.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
