### PR TITLE
Add ability add facts or provide new list of facts for drilldown

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.3-SNAPSHOT</version>
+    <version>6.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/test/scala/com/yahoo/maha/service/curators/DrilldownConfigTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/curators/DrilldownConfigTest.scala
@@ -21,7 +21,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
                           "curators" : {
                             "drilldown" : {
                               "config" : {
-                                "enforceFilters": "true",
+                                "enforceFilters": true,
                                 "dimension": "Section ID",
                                 "ordering": [{
                                               "field": "Class ID",
@@ -66,7 +66,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
                           "curators" : {
                             "drilldown" : {
                               "config" : {
-                                "enforceFilters": "true",
+                                "enforceFilters": true,
                                 "dimension": "Section ID",
                                 "ordering": [{
                                               "field": "Class ID",
@@ -111,7 +111,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
                           "curators" : {
                             "drilldown" : {
                               "config" : [{
-                                "enforceFilters": "true",
+                                "enforceFilters": true,
                                 "dimension": "Section ID",
                                 "ordering": [{
                                               "field": "Class ID",
@@ -120,7 +120,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
                                 "mr": 1000
                               }
                               , {
-                                "enforceFilters": "true",
+                                "enforceFilters": true,
                                 "dimension": "Section ID",
                                 "ordering": [{
                                               "field": "Class ID",
@@ -172,7 +172,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
                           "curators" : {
                             "drilldown" : {
                               "config" : {
-                                "enforceFilters": "true",
+                                "enforceFilters": true,
                                 "dimension": "Section ID",
                                 "ordering": [{
                                               "field": "Class ID",
@@ -200,10 +200,8 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     require(reportingRequestResult.isSuccess)
     val reportingRequest = reportingRequestResult.toOption.get
 
-    val thrown = intercept[Exception] {
-      DrilldownConfig.parse(reportingRequest.curatorJsonConfigMap("drilldown"))
-    }
-    assert(thrown.getMessage.contains("order must be asc|desc not willfail"))
+    val result = DrilldownConfig.parse(reportingRequest.curatorJsonConfigMap("drilldown"))
+    assert(result.toEither.left.get.head.toString.contains("order must be asc|desc not willfail"))
   }
 
   test("DrildownConfig with one request error should error") {
@@ -213,7 +211,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
                           "curators" : {
                             "drilldown" : {
                               "config" : [{
-                                "enforceFilters": "true",
+                                "enforceFilters": true,
                                 "dimension": "Section ID",
                                 "ordering": [{
                                               "field": "Class ID",
@@ -249,10 +247,8 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     require(reportingRequestResult.isSuccess, reportingRequestResult)
     val reportingRequest = reportingRequestResult.toOption.get
 
-    val thrown = intercept[Exception] {
-      DrilldownConfig.parse(reportingRequest.curatorJsonConfigMap("drilldown"))
-    }
-    assert(thrown.getMessage.contains("CuratorConfig for a DrillDown should have a dimension or dimensions declared"), thrown.getMessage)
+    val result = DrilldownConfig.parse(reportingRequest.curatorJsonConfigMap("drilldown"))
+    assert(result.toEither.left.get.head.toString.contains("NoSuchFieldError(dimension,"))
   }
 
   test("DrillDownConfig should throw error on no dimension.") {
@@ -262,7 +258,7 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
                           "curators" : {
                             "drilldown" : {
                               "config" : {
-                                "enforceFilters": "true",
+                                "enforceFilters": true,
                                 "ordering": [{
                                               "field": "Class ID",
                                               "order": "asc"
@@ -289,10 +285,8 @@ class DrilldownConfigTest extends BaseMahaServiceTest with BeforeAndAfterAll {
     require(reportingRequestResult.isSuccess)
     val reportingRequest = reportingRequestResult.toOption.get
 
-    val thrown = intercept[Exception] {
-      DrilldownConfig.parse(reportingRequest.curatorJsonConfigMap("drilldown"))
-    }
-    assert(thrown.getMessage.contains("CuratorConfig for a DrillDown should have a dimension or dimensions declared"))
+    val result = DrilldownConfig.parse(reportingRequest.curatorJsonConfigMap("drilldown"))
+    assert(result.toEither.left.get.head.toString.contains("NoSuchFieldError(dimension,"))
   }
 
   test("Create a valid DrillDownConfig with Descending order and multiple orderings") {

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.3-SNAPSHOT</version>
+        <version>6.4-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Drilldown by default reuses the fact fields from original request.  In some use cases we may want to drill down along different or more facts then original request.  This adds support for providing "facts" and "additiveFacts" to support this functionality.

DrillDownConfig
-Revamped parse method to bubble up parse errors

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
