### PR TITLE
Allow drilldown on primary key

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.6-SNAPSHOT</version>
+    <version>6.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownCurator.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownCurator.scala
@@ -3,8 +3,8 @@
 package com.yahoo.maha.service.curators
 
 import com.yahoo.maha.core._
-import com.yahoo.maha.core.bucketing.{BucketParams, CubeBucketSelected, BucketSelector}
-import com.yahoo.maha.core.fact.PublicFact
+import com.yahoo.maha.core.bucketing.{BucketParams, BucketSelector, CubeBucketSelected}
+import com.yahoo.maha.core.fact.{FactBestCandidate, PublicFact}
 import com.yahoo.maha.core.registry.Registry
 import com.yahoo.maha.core.request.{CuratorJsonConfig, Field, ReportingRequest}
 import com.yahoo.maha.parrequest2.GeneralError
@@ -320,9 +320,15 @@ class DrilldownCurator(override val requestModelValidator: CuratorRequestModelVa
                 , ParFunction.fromScala {
                   defaultRequestResult =>
                     try {
-                      val fieldAliasOption = mostGranularPrimaryKeyAlias(
+                      val mostGranularPrimaryKeyOption = mostGranularPrimaryKeyAlias(
                         registryConfig.registry, defaultCuratorResult.requestModelReference.model)
-                      if (fieldAliasOption.isEmpty || !defaultRequestResult.queryPipelineResult.queryPipeline.requestModel.requestColsSet(fieldAliasOption.get)) {
+                        .filter(defaultRequestResult.queryPipelineResult.queryPipeline.requestModel.requestColsSet) //must be requested
+                      //if no fk then maybe a pk in fact itself
+                      val fieldAliasOption = mostGranularPrimaryKeyOption orElse {
+                        val fc: FactBestCandidate = defaultRequestResult.queryPipelineResult.queryPipeline.factBestCandidate.get
+                        fc.nonFkCols.map(fc.fact.columnsByNameMap).find(_.isKey).map(c => fc.dimColMapping(c.name))
+                      }
+                      if (fieldAliasOption.isEmpty) {
                         mahaRequestLogBuilder.logFailed("no primary key alias found in request")
                         withParRequestError(curatorConfig, GeneralError.from(parRequestLabel
                           , "no primary key alias found in request"

--- a/service/src/test/scala/com/yahoo/maha/service/example/SampleSchemaRegistrationFactory.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/example/SampleSchemaRegistrationFactory.scala
@@ -42,7 +42,7 @@ class SampleFactSchemaRegistrationFactory extends FactRegistrationFactory {
           Set(
             DimCol("class_id", IntType(), annotations = Set(ForeignKey("class")))
             , DimCol("student_id", IntType(), annotations = Set(ForeignKey("student")))
-            , DimCol("section_id", IntType(3))
+            , DimCol("section_id", IntType(3), annotations = Set(PrimaryKey))
             , DimCol("year", IntType(3, (Map(1 -> "Freshman", 2 -> "Sophomore", 3 -> "Junior", 4 -> "Senior"), "Other")))
             , DimCol("comment", StrType(), annotations = Set(EscapingRequired))
             , DimCol("date", DateType())

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Currently, drilldown only works on foreign keys.  In general this works fine for facts where we mainly have foreign keys.  In cases where we are creating summaries, we may have primary key on the fact and being able to drilldown on this primary key to get to more granular data is useful.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
