### PR TITLE
Add ability to add filters to drilldown

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
 

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.6-SNAPSHOT</version>
+    <version>6.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.7-SNAPSHOT</version>
+    <version>6.8-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownCurator.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/curators/DrilldownCurator.scala
@@ -3,8 +3,8 @@
 package com.yahoo.maha.service.curators
 
 import com.yahoo.maha.core._
-import com.yahoo.maha.core.bucketing.{BucketParams, CubeBucketSelected, BucketSelector}
-import com.yahoo.maha.core.fact.PublicFact
+import com.yahoo.maha.core.bucketing.{BucketParams, BucketSelector, CubeBucketSelected}
+import com.yahoo.maha.core.fact.{FactBestCandidate, PublicFact}
 import com.yahoo.maha.core.registry.Registry
 import com.yahoo.maha.core.request.{CuratorJsonConfig, Field, ReportingRequest}
 import com.yahoo.maha.parrequest2.GeneralError
@@ -320,9 +320,15 @@ class DrilldownCurator(override val requestModelValidator: CuratorRequestModelVa
                 , ParFunction.fromScala {
                   defaultRequestResult =>
                     try {
-                      val fieldAliasOption = mostGranularPrimaryKeyAlias(
+                      val mostGranularPrimaryKeyOption = mostGranularPrimaryKeyAlias(
                         registryConfig.registry, defaultCuratorResult.requestModelReference.model)
-                      if (fieldAliasOption.isEmpty || !defaultRequestResult.queryPipelineResult.queryPipeline.requestModel.requestColsSet(fieldAliasOption.get)) {
+                        .filter(defaultRequestResult.queryPipelineResult.queryPipeline.requestModel.requestColsSet) //must be requested
+                      //if no fk then maybe a pk in fact itself
+                      val fieldAliasOption = mostGranularPrimaryKeyOption orElse {
+                        val fc: FactBestCandidate = defaultRequestResult.queryPipelineResult.queryPipeline.factBestCandidate.get
+                        fc.nonFkCols.map(fc.fact.columnsByNameMap).find(_.isKey).map(c => fc.dimColMapping(c.name))
+                      }
+                      if (fieldAliasOption.isEmpty) {
                         mahaRequestLogBuilder.logFailed("no primary key alias found in request")
                         withParRequestError(curatorConfig, GeneralError.from(parRequestLabel
                           , "no primary key alias found in request"

--- a/service/src/test/scala/com/yahoo/maha/service/RequestCoordinatorTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/RequestCoordinatorTest.scala
@@ -1236,6 +1236,73 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     assert(expectedSet.size == cnt)
   }
 
+  test("Test successful processing of Drilldown curator with filters") {
+
+    //the Student ID filter in drill down should be ignored in favor of the same filter in outer query
+    val jsonRequest =
+      s"""{
+                          "cube": "student_performance",
+                          "curators" : {
+                            "drilldown" : {
+                              "config" : {
+                                "dimension": "Remarks",
+                                "enforceFilters": true,
+                                "filters": [{
+                                    "field": "Remarks",
+                                    "operator": "IN",
+                                    "values": ["some comment 1", "some comment 2"]
+                                }, {"field": "Student ID", "operator": "=", "value": "100"}]
+                              }
+                            }
+                          },
+                          "selectFields": [
+                            {"field": "Section ID"},
+                            {"field": "Top Student ID"},
+                            {"field": "Total Marks"}
+                          ],
+                          "sortBy": [
+                            {"field": "Total Marks", "order": "Desc"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                            {"field": "Student ID", "operator": "=", "value": "214"}
+                          ],
+                          "includeRowCount": false
+                        }"""
+    val reportingRequestResult = ReportingRequest.deserializeSyncWithFactBias(jsonRequest.getBytes, schema = StudentSchema)
+    require(reportingRequestResult.isSuccess)
+    val reportingRequest = ReportingRequest.enableDebug(reportingRequestResult.toOption.get)
+
+    val bucketParams = BucketParams(UserInfo("uid", isInternal = true))
+
+    val requestCoordinator: RequestCoordinator = DefaultRequestCoordinator(mahaService)
+
+    val mahaRequestContext = MahaRequestContext(REGISTRY,
+      bucketParams,
+      reportingRequest,
+      jsonRequest.getBytes,
+      Map.empty, "rid", "uid")
+    val mahaRequestLogHelper = MahaRequestLogHelper(mahaRequestContext, mahaServiceConfig.mahaRequestLogWriter)
+
+    val requestCoordinatorResult: RequestCoordinatorResult = getRequestCoordinatorResult(requestCoordinator.execute(mahaRequestContext, mahaRequestLogHelper))
+    assert(requestCoordinatorResult.successResults.contains(DefaultCurator.name))
+    assert(requestCoordinatorResult.successResults.contains(DrilldownCurator.name), requestCoordinatorResult.failureResults)
+    val drillDownCuratorResult: RequestResult = requestCoordinatorResult.successResults(DrilldownCurator.name).head.requestResult
+    val expectedSet = Set(
+      "Row(Map(Remarks -> 0, Section ID -> 1, Total Marks -> 2),ArrayBuffer(some comment 1, 311, 225))"
+      , "Row(Map(Remarks -> 0, Section ID -> 1, Total Marks -> 2),ArrayBuffer(some comment 2, 311, 180))"
+    )
+
+    var cnt = 0
+    drillDownCuratorResult.queryPipelineResult.rowList.foreach( row => {
+
+      assert(expectedSet.contains(row.toString))
+      cnt+=1
+    })
+
+    assert(expectedSet.size == cnt)
+  }
+
   test("Test successful processing of Drilldown curator with dim candidates without enforcing filters") {
 
     val jsonRequest = s"""{

--- a/service/src/test/scala/com/yahoo/maha/service/example/SampleSchemaRegistrationFactory.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/example/SampleSchemaRegistrationFactory.scala
@@ -42,7 +42,7 @@ class SampleFactSchemaRegistrationFactory extends FactRegistrationFactory {
           Set(
             DimCol("class_id", IntType(), annotations = Set(ForeignKey("class")))
             , DimCol("student_id", IntType(), annotations = Set(ForeignKey("student")))
-            , DimCol("section_id", IntType(3))
+            , DimCol("section_id", IntType(3), annotations = Set(PrimaryKey))
             , DimCol("year", IntType(3, (Map(1 -> "Freshman", 2 -> "Sophomore", 3 -> "Junior", 4 -> "Senior"), "Other")))
             , DimCol("comment", StrType(), annotations = Set(EscapingRequired))
             , DimCol("date", DateType())

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.7-SNAPSHOT</version>
+        <version>6.8-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.6-SNAPSHOT</version>
+        <version>6.7-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Right now we have ability to enforce filters from outer query into drilldown as long as they are fact filters.  This adds the ability to add further filters per drill down, e.g. if you want to further filter the drilldown dimension values or facts.

Depends on #694 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
