### PR TITLE
Revert "Remove rowCount when not asked for"

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
@@ -611,10 +611,10 @@ b. Dim Driven
   private[this] def addOuterPaginationWrapper(queryString: String, mr: Int, si: Int, includePagination: Boolean, outerFiltersPresent: Boolean): String = {
     val paginationPredicates: ListBuffer[String] = new ListBuffer[String]()
     val minPosition: Int = if (si < 0) 1 else si + 1
-    paginationPredicates += (if(includePagination) ("ROW_NUMBER >= " + minPosition) else ("ROWNUM >= " + minPosition))
+    paginationPredicates += ("ROW_NUMBER >= " + minPosition)
     if (mr > 0) {
       val maxPosition: Int = if (si <= 0) mr else minPosition - 1 + mr
-      paginationPredicates += (if(includePagination) ("ROW_NUMBER <= " + maxPosition) else ("ROWNUM <= " + maxPosition))
+      paginationPredicates += ("ROW_NUMBER <= " + maxPosition)
     }
     if (outerFiltersPresent)
       String.format(OUTER_PAGINATION_WRAPPER_WITH_FILTERS, queryString, paginationPredicates.toList.mkString(" AND "))
@@ -668,7 +668,7 @@ b. Dim Driven
       }
     }
 
-    val includePagination = queryContext.requestModel.includeRowCount || queryContext.requestModel.reportingRequest.includeRowCount // Include pagination wrapper always
+    val includePagination = true // Include pagination wrapper always
 
     val aliasColumnMapOfRequestCols = new mutable.HashMap[String, Column]()
 

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
@@ -737,7 +737,9 @@ b. Dim Driven
         dimQueryNotIn =>
           val unionTemplate = s" (%s) UNION ALL (%s) "
           String.format(unionTemplate
-            , String.format( if(includePagination) PAGINATION_WRAPPER_UNION else UNION_WITHOUT_PAGINATION
+            , String.format(
+              //if(includePagination)
+              PAGINATION_WRAPPER_UNION
               , String.format(queryStringTemplate, outerColumns.mkString(", "), dimQueryIn, outerWhereClause)
             )
             , addPaginationWrapper(String.format(queryStringTemplate,outerColumns.mkString(", "),dimQueryNotIn, outerWhereClause),maxRows, 0, includePagination)

--- a/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
@@ -2392,8 +2392,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                            ],
                            "paginationStartIndex":0,
                            "rowsPerPage":100,
-                           "forceDimensionDriven": true,
-                           "includeRowCount": false
+                           "forceDimensionDriven": true
                          }"""
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
@@ -2408,11 +2407,10 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
 
     val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
-    println(result)
     val expected =
       """
         |SELECT *
-        |      FROM (SELECT DISTINCT ao0."Advertiser Status" "Advertiser Status"
+        |      FROM (SELECT DISTINCT ao0."Advertiser Status" "Advertiser Status", ROWNUM as ROW_NUMBER
         |            FROM
         |                (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
         |            FROM advertiser_oracle
@@ -2421,7 +2419,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
         |
         |
         |           )
-        |             WHERE ROWNUM >= 1 AND ROWNUM <= 100
+        |             WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100
       """.stripMargin
 
     result should equal (expected) (after being whiteSpaceNormalised)
@@ -3608,9 +3606,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                            ],
                            "paginationStartIndex":0,
                            "rowsPerPage":100,
-                           "forceDimensionDriven": false,
-                           "includeRowCount" : true
-
+                           "forceDimensionDriven": false
                           }"""
 
     val requestOption = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema)
@@ -3624,7 +3620,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
     val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
     val expected = """
                      |SELECT  *
-                     |      FROM (SELECT ao0.id "Advertiser ID", co1.id "Campaign ID", co1.campaign_name "Campaign Name", ago2.id "Ad Group ID", ago2."Ad Group Status" "Ad Group Status", '2' AS "Source", Count(*) OVER() TOTALROWS, ROWNUM as ROW_NUMBER
+                     |      FROM (SELECT ao0.id "Advertiser ID", co1.id "Campaign ID", co1.campaign_name "Campaign Name", ago2.id "Ad Group ID", ago2."Ad Group Status" "Ad Group Status", '2' AS "Source", ROWNUM as ROW_NUMBER
                      |            FROM
                      |               ( (SELECT  campaign_id, advertiser_id, DECODE(status, 'ON', 'ON', 'OFF') AS "Ad Group Status", id
                      |            FROM ad_group_oracle
@@ -3824,9 +3820,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                               {"field": "Reseller ID", "operator": "=", "value": "12345"},
                               {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"}
                            ],
-                           "forceDimensionDriven": true,
-                          "paginationStartIndex":0,
-                          "includeRowCount" : true
+                           "forceDimensionDriven": true
                          }"""
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
@@ -3841,7 +3835,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
     val expected = s"""
                       |SELECT  *
-                      |      FROM (SELECT co1.id "Campaign ID", co1.campaign_name "Campaign Name", ago2.id "Ad Group ID", Count(*) OVER() TOTALROWS, ROWNUM as ROW_NUMBER
+                      |      FROM (SELECT co1.id "Campaign ID", co1.campaign_name "Campaign Name", ago2.id "Ad Group ID", ROWNUM as ROW_NUMBER
                       |            FROM
                       |               ( (SELECT  advertiser_id, campaign_id, id
                       |            FROM ad_group_oracle
@@ -3898,9 +3892,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
                               {"field": "Reseller ID", "operator": "=", "value": "12345"},
                               {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"}
                            ],
-                           "forceDimensionDriven": true,
-                           "paginationStartIndex":0,
-                           "includeRowCount" : true
+                           "forceDimensionDriven": true
                          }"""
 
     val request: ReportingRequest = ReportingRequest.deserializeSyncWithFactBias(jsonString.getBytes(StandardCharsets.UTF_8), ResellerSchema).toOption.get
@@ -3914,7 +3906,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[OracleQuery].asString
     val expected = s"""
                       |SELECT  *
-                      |      FROM (SELECT ado2.ad_group_id "Ad Group ID", co1.campaign_name "Campaign Name", ado2.title "Ad Title", Count(*) OVER() TOTALROWS, ROWNUM as ROW_NUMBER
+                      |      FROM (SELECT ado2.ad_group_id "Ad Group ID", co1.campaign_name "Campaign Name", ado2.title "Ad Title", ROWNUM as ROW_NUMBER
                       |            FROM
                       |               ( (SELECT  campaign_id, id, title, ad_group_id, advertiser_id
                       |            FROM ad_dim_oracle

--- a/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
@@ -5747,7 +5747,8 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
     resultSql should equal (expected)(after being whiteSpaceNormalised)
   }
 
-  test("Generate dim only query wit union all for last page, verify rowCount false works") {
+  //pending proper wrapper for includePagination
+  ignore("Generate dim only query wit union all for last page, verify rowCount false works") {
     import DefaultQueryPipelineFactoryTest._
     val jsonString = s"""{
                           "cube": "k_stats",

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
@@ -1837,8 +1837,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                             {"field": "Impressions", "order": "Asc"}
                           ],
                           "paginationStartIndex":0,
-                          "rowsPerPage":100,
-                          "includeRowCount" : true
+                          "rowsPerPage":100
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
@@ -1924,8 +1923,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                             {"field": "Keyword ID", "order": "Asc"}
                           ],
                           "paginationStartIndex":0,
-                          "rowsPerPage":100,
-                          "includeRowCount" : true
+                          "rowsPerPage":100
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
     val registry = defaultRegistry
@@ -2697,8 +2695,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
                           ],
                           "paginationStartIndex":0,
                           "rowsPerPage":100,
-                          "isDimDriven" : true,
-                          "includeRowCount" : true
+                          "isDimDriven" : true
                         }"""
     val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString, AdvertiserLowLatencySchema))
     val registry = defaultRegistry

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/oracle/src/test/scala/com/yahoo/maha/executor/oracle/OracleQueryExecutorTest.scala
+++ b/oracle/src/test/scala/com/yahoo/maha/executor/oracle/OracleQueryExecutorTest.scala
@@ -917,8 +917,7 @@ class OracleQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfter
                             {"field": "Impressions", "order": "Desc"}
                           ],
                           "paginationStartIndex":0,
-                          "rowsPerPage":100,
-                          "includeRowCount" : true
+                          "rowsPerPage":100
                         }"""
 
       val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.10-SNAPSHOT</version>
+    <version>6.11-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Reverts yahoo/maha#692

Temporarily revert this, as non-paginated nested queries in Oracle with a SI > 1 will fail.  The fix will be to include rownum as row_number on an actual wrapper mid-select (coming later)