### PR TITLE
Add rowcount wrapper to fix distinct selects

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryCommon.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryCommon.scala
@@ -34,15 +34,15 @@ trait OracleQueryCommon extends  BaseQueryGenerator[WithOracleEngine] {
   final protected[this] val ADDITIONAL_PAGINATION_COLUMN: IndexedSeq[String] = IndexedSeq(OracleQueryGenerator.ROW_COUNT_ALIAS)
   final protected[this] val PAGINATION_ROW_COUNT: String = s"""Count(*) OVER() ${OracleQueryGenerator.ROW_COUNT_ALIAS}"""
   final protected[this] val supportingDimPostfix: String = "_indexed"
-  final protected[this] val PAGINATION_WRAPPER: String = "SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (%s) %s) D ) WHERE %s"
+  final protected[this] val ROW_NUMBER_ALIAS = "ROWNUM AS ROW_NUMBER"
+  final protected[this] val PAGINATION_WRAPPER: String = s"SELECT * FROM (SELECT D.*, $ROW_NUMBER_ALIAS FROM (SELECT * FROM (%s) %s) D ) WHERE %s"
   final protected[this] val OUTER_PAGINATION_WRAPPER: String = "%s WHERE %s"
   final protected[this] val OUTER_PAGINATION_WRAPPER_WITH_FILTERS: String = "%s AND %s"
-  final protected[this] val PAGINATION_WRAPPER_UNION: String = "SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (%s) D )"
+  final protected[this] val PAGINATION_WRAPPER_UNION: String = s"SELECT * FROM (SELECT D.*, $ROW_NUMBER_ALIAS FROM (%s) D )"
   final protected[this] val UNION_WITHOUT_PAGINATION: String = "SELECT * FROM (SELECT D.* FROM (%s) D )"
   final protected[this] val PAGINATION_ROW_COUNT_COL = ColumnContext.withColumnContext { implicit cc =>
     DimCol(OracleQueryGenerator.ROW_COUNT_ALIAS, IntType())
   }
-  final protected[this] val ROW_NUMBER_ALIAS = "ROWNUM as ROW_NUMBER"
 
   // Definition Prototypes
   def generateDimensionSql(queryContext: QueryContext, queryBuilderContext: QueryBuilderContext, includePagination: Boolean): DimensionSql

--- a/core/src/test/scala/com/yahoo/maha/core/query/DefaultQueryPipelineFactoryTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/DefaultQueryPipelineFactoryTest.scala
@@ -699,14 +699,18 @@ class DefaultQueryPipelineFactoryTest extends FunSuite with Matchers with Before
     val drivingQuery = pipeline.queryChain.drivingQuery.asString
 //    println(drivingQuery)
     val expectedQuery = """SELECT  *
-                          |      FROM (SELECT ao0.id "Advertiser ID", ao0."Advertiser Status" "Advertiser Status", Count(*) OVER() TOTALROWS, ROWNUM as ROW_NUMBER
-                          |            FROM
-                          |                (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
-                          |            FROM advertiser_oracle
-                          |            WHERE (id = 213)
-                          |             ) ao0
-                          |           )
-                          |             WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100""".stripMargin
+                          |      FROM (
+                          |       SELECT "Advertiser ID", "Advertiser Status", "TOTALROWS", ROWNUM AS ROW_NUMBER
+                          |                FROM(SELECT ao0.id "Advertiser ID", ao0."Advertiser Status" "Advertiser Status", Count(*) OVER() TOTALROWS
+                          |                    FROM
+                          |                  (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
+                          |              FROM advertiser_oracle
+                          |              WHERE (id = 213)
+                          |               ) ao0
+                          |
+                          |
+                          |                    ))
+                          |                    WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100""".stripMargin
 
     drivingQuery should equal (expectedQuery) (after being whiteSpaceNormalised)
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGeneratorTest.scala
@@ -2067,8 +2067,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
 
     val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PostgresQuery].asString
     val expected = """SELECT  *
-                     |      FROM (SELECT cp1.id "Campaign ID", adp2.ad_group_id "Ad Group ID", ap0."Advertiser Status" "Advertiser Status", cp1.campaign_name "Campaign Name", adp2.id "Ad ID", Count(*) OVER() "TOTALROWS", ROW_NUMBER() OVER() AS ROWNUM
-                     |            FROM
+                     |      FROM (
+                     |       SELECT "Campaign ID", "Ad Group ID", "Advertiser Status", "Campaign Name", "Ad ID", "TOTALROWS", ROW_NUMBER() OVER() AS ROWNUM
+                     |              FROM(SELECT cp1.id "Campaign ID", adp2.ad_group_id "Ad Group ID", ap0."Advertiser Status" "Advertiser Status", cp1.campaign_name "Campaign Name", adp2.id "Ad ID", Count(*) OVER() "TOTALROWS"
+                     |                  FROM
                      |               ( (SELECT  advertiser_id, campaign_id, ad_group_id, id
                      |            FROM ad_dim_postgres
                      |            WHERE (id = ad_group_id) AND (advertiser_id = 12345)
@@ -2087,8 +2089,8 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                      |              ON( cp1.advertiser_id = ap0.id )
                      |               )
                      |
-                     |           )
-                     |             sqalias1 WHERE ROWNUM >= 1 AND ROWNUM <= 100""".stripMargin
+                     |                  ) sqalias1 ) sqalias2
+                     |                  WHERE ROWNUM >= 1 AND ROWNUM <= 100""".stripMargin
 
     result should equal (expected) (after being whiteSpaceNormalised)
     testQuery(result)
@@ -2593,15 +2595,17 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val expected =
       """
         |SELECT *
-        |      FROM (SELECT DISTINCT ap0."Advertiser Status" "Advertiser Status", ROW_NUMBER() OVER() AS ROWNUM
-        |            FROM
+        |      FROM (
+        |          SELECT "Advertiser Status", ROW_NUMBER() OVER() AS ROWNUM
+        |              FROM (SELECT DISTINCT ap0."Advertiser Status" "Advertiser Status"
+        |                  FROM
         |                (SELECT  CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Advertiser Status", id
         |            FROM advertiser_postgres
         |            WHERE (id = 12345)
         |             ) ap0
         |
         |
-        |           ) sqalias1
+        |                  ) sqalias1 ) sqalias2
         |             WHERE ROWNUM >= 1 AND ROWNUM <= 100
       """.stripMargin
 
@@ -2658,8 +2662,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PostgresQuery].asString
     val expected = """
                      |SELECT  *
-                     |      FROM (SELECT agp2.campaign_id "Campaign ID", agp2.id "Ad Group ID", ap0."Advertiser Status" "Advertiser Status", cp1.campaign_name "Campaign Name", '2' AS "Source", Count(*) OVER() "TOTALROWS", ROW_NUMBER() OVER() AS ROWNUM
-                     |            FROM
+                     |      FROM (
+                     |          SELECT "Campaign ID", "Ad Group ID", "Advertiser Status", "Campaign Name", "Source", "TOTALROWS", ROW_NUMBER() OVER() AS ROWNUM
+                     |              FROM(SELECT agp2.campaign_id "Campaign ID", agp2.id "Ad Group ID", ap0."Advertiser Status" "Advertiser Status", cp1.campaign_name "Campaign Name", '2' AS "Source", Count(*) OVER() "TOTALROWS"
+                     |                  FROM
                      |               ( (SELECT  campaign_id, advertiser_id, id
                      |            FROM ad_group_postgres
                      |            WHERE (advertiser_id = 12345)
@@ -2678,7 +2684,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                      |              ON( cp1.advertiser_id = ap0.id )
                      |               )
                      |
-                     |           ) sqalias1
+                     |                  ) sqalias1 ) sqalias2
                      |             WHERE ROWNUM >= 1 AND ROWNUM <= 100
                      |""".stripMargin
 
@@ -3741,8 +3747,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PostgresQuery].asString
     val expected = """
                      |SELECT  *
-                     |      FROM (SELECT ap0.id "Advertiser ID", cp1.id "Campaign ID", cp1.campaign_name "Campaign Name", agp2.id "Ad Group ID", agp2."Ad Group Status" "Ad Group Status", '2' AS "Source", ROW_NUMBER() OVER() AS ROWNUM
-                     |            FROM
+                     |      FROM (
+                     |          SELECT "Advertiser ID", "Campaign ID", "Campaign Name", "Ad Group ID", "Ad Group Status", "Source", ROW_NUMBER() OVER() AS ROWNUM
+                     |              FROM(SELECT ap0.id "Advertiser ID", cp1.id "Campaign ID", cp1.campaign_name "Campaign Name", agp2.id "Ad Group ID", agp2."Ad Group Status" "Ad Group Status", '2' AS "Source"
+                     |                  FROM
                      |               ( (SELECT  campaign_id, advertiser_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id
                      |            FROM ad_group_postgres
                      |            WHERE (advertiser_id = 12345)
@@ -3761,7 +3769,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                      |              ON( cp1.advertiser_id = ap0.id )
                      |               )
                      |
-                     |           ) sqalias1
+                     |                  ) sqalias1 ) sqalias2
                      |            WHERE ( "Ad Group ID"   IS NULL) AND ROWNUM >= 1 AND ROWNUM <= 100
                      |           """.stripMargin
 
@@ -3959,8 +3967,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PostgresQuery].asString
     val expected = s"""
                       |SELECT  *
-                      |      FROM (SELECT cp1.id "Campaign ID", cp1.campaign_name "Campaign Name", agp2.id "Ad Group ID", ROW_NUMBER() OVER() AS ROWNUM
-                      |            FROM
+                      |      FROM (
+                      |          SELECT "Campaign ID", "Campaign Name", "Ad Group ID", ROW_NUMBER() OVER() AS ROWNUM
+                      |              FROM(SELECT cp1.id "Campaign ID", cp1.campaign_name "Campaign Name", agp2.id "Ad Group ID"
+                      |                  FROM
                       |               ( (SELECT  advertiser_id, campaign_id, id
                       |            FROM ad_group_postgres
                       |
@@ -3979,7 +3989,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
                       |              ON( cp1.advertiser_id = ap0.id )
                       |               )
                       |
-                      |           ) sqalias1
+                      |                  ) sqalias1 ) sqalias2
                       |            WHERE ( "Ad Group ID"   IS NULL) AND ROWNUM >= 1 AND ROWNUM <= 200
                       |""".stripMargin
 
@@ -5460,8 +5470,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val expected =
       s"""
          | (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT  *
-         |      FROM (SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID", '2' AS "Country WOEID"
-         |            FROM
+         |      FROM (
+         |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
+         |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID", '2' AS "Country WOEID"
+         |                  FROM
          |               ( (SELECT  advertiser_id, campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id
          |            FROM ad_group_postgres
          |            WHERE (advertiser_id = 213) AND (id IN (10))
@@ -5480,9 +5492,12 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |              ON( cp1.advertiser_id = ap0.id )
          |               )
          |
-         |           ) sqalias1 ) D ) sqalias2) UNION ALL (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
-         |      FROM (SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID", '2' AS "Country WOEID"
-         |            FROM
+         |                  ) sqalias1 ) sqalias2
+         |            ) D ) sqalias3) UNION ALL (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
+         |      FROM (
+         |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
+         |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID", '2' AS "Country WOEID"
+         |                  FROM
          |               ( (SELECT  advertiser_id, campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id
          |            FROM ad_group_postgres
          |            WHERE (advertiser_id = 213) AND (id NOT IN (10))
@@ -5501,7 +5516,8 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |              ON( cp1.advertiser_id = ap0.id )
          |               )
          |
-         |           ) sqalias3 ) sqalias4 LIMIT 10) D ) sqalias5 WHERE ROWNUM >= 1 AND ROWNUM <= 10)
+         |                  ) sqalias4 ) sqalias5
+         |            ) sqalias6 LIMIT 10) D ) sqalias7 WHERE ROWNUM >= 1 AND ROWNUM <= 10)
        """.stripMargin
     resultSql should equal (expected)(after being whiteSpaceNormalised)
     testQuery(resultSql)
@@ -5577,8 +5593,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val expected =
       s"""
          | SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
-         |      FROM (SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
-         |            FROM
+         |      FROM (
+         |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
+         |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
+         |                  FROM
          |               ( (SELECT  advertiser_id, campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id
          |            FROM ad_group_postgres
          |            WHERE (advertiser_id = 213) AND (id IN (12,19,15,11,13,16,17,14,20,18))
@@ -5597,7 +5615,8 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |              ON( cp1.advertiser_id = ap0.id )
          |               )
          |
-         |           ) sqalias1 ) sqalias2 LIMIT 10) D ) sqalias3 WHERE ROWNUM >= 1 AND ROWNUM <= 10
+         |                  ) sqalias1 ) sqalias2
+         |            ) sqalias3 LIMIT 10) D ) sqalias4 WHERE ROWNUM >= 1 AND ROWNUM <= 10
        """.stripMargin
     resultSql should equal (expected)(after being whiteSpaceNormalised)
     testQuery(resultSql)
@@ -5672,8 +5691,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val expected =
       s"""
          | SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
-         |      FROM (SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
-         |            FROM
+         |      FROM (
+         |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
+         |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
+         |                  FROM
          |               ( (SELECT  advertiser_id, campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id
          |            FROM ad_group_postgres
          |            WHERE (advertiser_id = 213) AND (id IN (45,34,12,51,19,23,40,15,11,44,33,22,55,26,50,37,13,46,24,35,16,48,21,54,43,32,49,36,39,17,25,14,47,31,53,42,20,27,38,18,30,29,41,52,28))
@@ -5692,7 +5713,8 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |              ON( cp1.advertiser_id = ap0.id )
          |               )
          |
-         |           ) sqalias1 ) sqalias2 LIMIT 45) D ) sqalias3 WHERE ROWNUM >= 1 AND ROWNUM <= 45
+         |                  ) sqalias1 ) sqalias2
+         |            ) sqalias3 LIMIT 45) D ) sqalias4 WHERE ROWNUM >= 1 AND ROWNUM <= 45
        """.stripMargin
     resultSql should equal (expected)(after being whiteSpaceNormalised)
     testQuery(resultSql)
@@ -5766,8 +5788,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val expected =
       s"""
          |(SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT  *
-         |      FROM (SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
-         |            FROM
+         |      FROM (
+         |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
+         |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
+         |                  FROM
          |               ( (SELECT  advertiser_id, campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id
          |            FROM ad_group_postgres
          |            WHERE (advertiser_id = 213) AND (id IN (12,19,23,15,11,22,13,24,16,21,17,25,14,20,18))
@@ -5786,10 +5810,12 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |              ON( cp1.advertiser_id = ap0.id )
          |               )
          |
-         |           )
-         |            sqalias1 ) D ) sqalias2) UNION ALL (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
-         |      FROM (SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
-         |            FROM
+         |                  ) sqalias1 ) sqalias2
+         |            ) D ) sqalias3) UNION ALL (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
+         |      FROM (
+         |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
+         |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
+         |                  FROM
          |               ( (SELECT  advertiser_id, campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id
          |            FROM ad_group_postgres
          |            WHERE (advertiser_id = 213) AND (id NOT IN (12,19,23,15,11,22,13,24,16,21,17,25,14,20,18))
@@ -5808,7 +5834,8 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |              ON( cp1.advertiser_id = ap0.id )
          |               )
          |
-         |           ) sqalias3 ) sqalias4 LIMIT 20) D ) sqalias5 WHERE ROWNUM >= 1 AND ROWNUM <= 20)
+         |                  ) sqalias4 ) sqalias5
+         |            ) sqalias6 LIMIT 20) D ) sqalias7 WHERE ROWNUM >= 1 AND ROWNUM <= 20)
        """.stripMargin
     resultSql should equal (expected)(after being whiteSpaceNormalised)
     testQuery(resultSql)
@@ -5978,8 +6005,10 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val expected =
       s"""
          |SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
-         |      FROM (SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
-         |            FROM
+         |      FROM (
+         |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
+         |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"
+         |                  FROM
          |               ( (SELECT  advertiser_id, campaign_id, CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END AS "Ad Group Status", id
          |            FROM ad_group_postgres
          |            WHERE (advertiser_id = 213) AND (id IN (10))
@@ -5998,7 +6027,8 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |              ON( cp1.advertiser_id = ap0.id )
          |               )
          |
-         |           ) sqalias1 ) sqalias2 LIMIT 10) D ) sqalias3 WHERE ROWNUM >= 1 AND ROWNUM <= 10
+         |                  ) sqalias1 ) sqalias2
+         |            ) sqalias3 LIMIT 10) D ) sqalias4 WHERE ROWNUM >= 1 AND ROWNUM <= 10
        """.stripMargin
     resultSql should equal (expected)(after being whiteSpaceNormalised)
     testQuery(resultSql)
@@ -6059,16 +6089,18 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
     val expected =
       s"""
          |SELECT  *
-         |      FROM (SELECT cp0.campaign_name "Campaign Name", cp0.id "Campaign ID", Count(*) OVER() "TOTALROWS", ROW_NUMBER() OVER() AS ROWNUM
-         |            FROM
+         |      FROM (
+         |          SELECT "Campaign Name", "Campaign ID", "TOTALROWS", ROW_NUMBER() OVER() AS ROWNUM
+         |              FROM(SELECT cp0.campaign_name "Campaign Name", cp0.id "Campaign ID", Count(*) OVER() "TOTALROWS"
+         |                  FROM
          |                (SELECT /*+ CampaignHint */ campaign_name, id, advertiser_id
          |            FROM campaign_postgres
          |            WHERE (advertiser_id = 213) AND (CASE WHEN status = 'ON' THEN 'ON' ELSE 'OFF' END NOT IN ('DELETED'))
          |            ORDER BY 1 DESC NULLS LAST, 2 DESC  ) cp0
          |
          |
-         |           )
-         |             sqalias1 WHERE ROWNUM >= 3 AND ROWNUM <= 42
+         |                  ) sqalias1 ) sqalias2
+         |             WHERE ROWNUM >= 3 AND ROWNUM <= 42
        """.stripMargin
     resultSql should equal (expected)(after being whiteSpaceNormalised)
     testQuery(resultSql)

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
@@ -1878,26 +1878,30 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
         val expected =
           """
             | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
-            |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
-            |            FROM
+            |      FROM (
+            |          SELECT "Keyword ID", "Keyword Value"
+            |              FROM(SELECT t0.id "Keyword ID", t0.value "Keyword Value"
+            |                  FROM
             |                (SELECT  value, id, advertiser_id
             |            FROM targetingattribute
             |            WHERE (advertiser_id = 213) AND (id IN (13,14))
             |             ) t0
             |
             |
-            |           )
-            |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
-            |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
-            |            FROM
+            |                  ))
+            |                  ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+            |      FROM (
+            |          SELECT "Keyword ID", "Keyword Value"
+            |              FROM(SELECT t0.id "Keyword ID", t0.value "Keyword Value"
+            |                  FROM
             |                (SELECT  value, id, advertiser_id
             |            FROM targetingattribute
             |            WHERE (advertiser_id = 213) AND (id NOT IN (13,14))
             |             ) t0
             |
             |
-            |           )
-            |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)
+            |                  ))
+            |                  ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)
             |  """.stripMargin
 
         oracleQuery.asString should equal(expected)(after being whiteSpaceNormalised)
@@ -1963,26 +1967,30 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
         val expected =
           s"""
              | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
-             |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
-             |            FROM
+             |      FROM (
+             |          SELECT "Keyword ID", "Keyword Value"
+             |              FROM(SELECT t0.id "Keyword ID", t0.value "Keyword Value"
+             |                  FROM
              |                (SELECT  id, value, advertiser_id
              |            FROM targetingattribute
              |            WHERE (advertiser_id = 213) AND (id IN (13,14))
              |            ORDER BY 1 ASC  ) t0
              |
-                       |
-                       |           )
-             |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
-             |      FROM (SELECT t0.id "Keyword ID", t0.value "Keyword Value"
-             |            FROM
+             |
+             |                  ))
+             |                  ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+             |      FROM (
+             |          SELECT "Keyword ID", "Keyword Value"
+             |              FROM(SELECT t0.id "Keyword ID", t0.value "Keyword Value"
+             |                  FROM
              |                (SELECT  id, value, advertiser_id
              |            FROM targetingattribute
              |            WHERE (advertiser_id = 213) AND (id NOT IN (13,14))
              |            ORDER BY 1 ASC  ) t0
              |
-                       |
-                       |           )
-             |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)  """
+             |
+             |                  ))
+             |                  ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)"""
             .stripMargin
 
         oracleQuery.asString should equal(expected)(after being whiteSpaceNormalised)
@@ -2738,10 +2746,11 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
 
         val expected =
           """
-            |
-            | (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
-            |      FROM (SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"
-            |            FROM
+            |(SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT  *
+            |      FROM (
+            |          SELECT "Ad Group ID", "Campaign ID", "Campaign Name"
+            |              FROM(SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"
+            |                  FROM
             |               ( (SELECT  campaign_id, id, advertiser_id
             |            FROM ad_group_oracle
             |            WHERE (advertiser_id = 213) AND (id IN (113,114)) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
@@ -2754,10 +2763,12 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
             |              ON( ago1.advertiser_id = co0.advertiser_id AND ago1.campaign_id = co0.id )
             |               )
             |
-            |           )
-            |            ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
-            |      FROM (SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"
-            |            FROM
+            |                  ))
+            |                  ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+            |      FROM (
+            |          SELECT "Ad Group ID", "Campaign ID", "Campaign Name"
+            |              FROM(SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"
+            |                  FROM
             |               ( (SELECT  campaign_id, id, advertiser_id
             |            FROM ad_group_oracle
             |            WHERE (advertiser_id = 213) AND (id NOT IN (113,114)) AND (DECODE(status, 'ON', 'ON', 'OFF') NOT IN ('DELETED'))
@@ -2770,8 +2781,8 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
             |              ON( ago1.advertiser_id = co0.advertiser_id AND ago1.campaign_id = co0.id )
             |               )
             |
-            |           )
-            |            ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)
+            |                  ))
+            |                  ) WHERE ROWNUM <= 100) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100)
             |  """.stripMargin
 
         oracleQuery.asString should equal(expected)(after being whiteSpaceNormalised)

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.11-SNAPSHOT</version>
+    <version>6.12-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Currently, when users request distinct Dimension values via Parameter, the ROWNUM as ROW_NUMBER attribute prevents distinct values from truly being returned, as such:
```
SELECT *
      FROM (
            SELECT DISTINCT ao0."Advertiser Status" "Advertiser Status", ROWNUM AS ROW_NUMBER
                    FROM
                (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
            FROM advertiser_oracle
            WHERE (id = 12345)
             ) ao0


                    )
             WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100
```

This adds a wrapper around this code to bring out this distinct value:
```
SELECT *
      FROM (
            SELECT "Advertiser Status", ROWNUM AS ROW_NUMBER
                FROM (SELECT DISTINCT ao0."Advertiser Status" "Advertiser Status"
                    FROM
                (SELECT  DECODE(status, 'ON', 'ON', 'OFF') AS "Advertiser Status", id
            FROM advertiser_oracle
            WHERE (id = 12345)
             ) ao0


                    ))
             WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
