### PR TITLE
Add UNION ALL rownum fix to Oracle and Postgres

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
@@ -747,7 +747,8 @@ b. Dim Driven
             , String.format(
               //if(includePagination)
               PAGINATION_WRAPPER_UNION
-              , String.format(queryStringTemplate, outerAliases.mkString(", "), outerColumns.mkString(", "), dimQueryIn, outerWhereClause)
+              , String.format(queryStringTemplate, outerAliases.mkString(", "), outerColumns.mkString(", "), dimQueryIn, outerWhereClause),
+              paginationWhereClause(createPaginationPredicates(maxRows, 0, includePagination)._2)
             )
             , addPaginationWrapper(String.format(queryStringTemplate, outerAliases.mkString(", "), outerColumns.mkString(", "),dimQueryNotIn, outerWhereClause),maxRows, 0, includePagination)
           )

--- a/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
@@ -745,6 +745,7 @@ b. Dim Driven
             , String.format(PAGINATION_WRAPPER_UNION
               , String.format(queryStringTemplate, outerAliases.mkString(", "), outerColumns.mkString(", "), dimQueryIn, queryBuilderContext.getSubqueryAlias, queryBuilderContext.getSubqueryAlias, outerWhereClause)
               , queryBuilderContext.getSubqueryAlias
+              , paginationWhereClause(createPaginationPredicates(maxRows, 0, includePagination)._2)
             )
             , addPaginationWrapper(String.format(queryStringTemplate, outerAliases.mkString(", "), outerColumns.mkString(", "),dimQueryNotIn, queryBuilderContext.getSubqueryAlias, queryBuilderContext.getSubqueryAlias, outerWhereClause)
               ,maxRows, 0, includePagination, queryBuilderContext)

--- a/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/oracle/OracleQueryGeneratorTest.scala
@@ -5432,7 +5432,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
          |               )
          |
          |                  ))
-         |                  ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+         |                  ) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 10) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
          |      FROM (
          |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
          |              FROM(SELECT ago2.advertiser_id "Advertiser ID", ago2."Ad Group Status" "Ad Group Status", ago2.id "Ad Group ID", ao0.currency "Advertiser Currency", COALESCE(co1.device_id, 'UNKNOWN') "Campaign Device ID", ago2.campaign_id "Campaign ID", '2' AS "Country WOEID"
@@ -5747,7 +5747,7 @@ class OracleQueryGeneratorTest extends BaseOracleQueryGeneratorTest {
          |               )
          |
          |                  ))
-         |                  ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+         |                  ) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 20) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
          |      FROM (
          |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
          |              FROM(SELECT ago2.advertiser_id "Advertiser ID", ago2."Ad Group Status" "Ad Group Status", ago2.id "Ad Group ID", ao0.currency "Advertiser Currency", COALESCE(co1.device_id, 'UNKNOWN') "Campaign Device ID", ago2.campaign_id "Campaign ID"

--- a/core/src/test/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGeneratorTest.scala
@@ -5493,7 +5493,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |               )
          |
          |                  ) sqalias1 ) sqalias2
-         |            ) D ) sqalias3) UNION ALL (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
+         |            ) D ) sqalias3 WHERE ROWNUM >= 1 AND ROWNUM <= 10) UNION ALL (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
          |      FROM (
          |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
          |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID", '2' AS "Country WOEID"
@@ -5811,7 +5811,7 @@ class PostgresQueryGeneratorTest extends BasePostgresQueryGeneratorTest {
          |               )
          |
          |                  ) sqalias1 ) sqalias2
-         |            ) D ) sqalias3) UNION ALL (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
+         |            ) D ) sqalias3 WHERE ROWNUM >= 1 AND ROWNUM <= 20) UNION ALL (SELECT * FROM (SELECT D.*, ROW_NUMBER() OVER() AS ROWNUM FROM (SELECT * FROM (SELECT  *
          |      FROM (
          |          SELECT "Advertiser ID", "Ad Group Status", "Ad Group ID", "Advertiser Currency", "Campaign Device ID", "Campaign ID"
          |              FROM(SELECT agp2.advertiser_id "Advertiser ID", agp2."Ad Group Status" "Ad Group Status", agp2.id "Ad Group ID", ap0.currency "Advertiser Currency", COALESCE(cp1.device_id, 'UNKNOWN') "Campaign Device ID", agp2.campaign_id "Campaign ID"

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
@@ -1889,7 +1889,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
             |
             |
             |                  ))
-            |                  ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+            |                  ) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
             |      FROM (
             |          SELECT "Keyword ID", "Keyword Value"
             |              FROM(SELECT t0.id "Keyword ID", t0.value "Keyword Value"
@@ -1978,7 +1978,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
              |
              |
              |                  ))
-             |                  ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+             |                  ) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
              |      FROM (
              |          SELECT "Keyword ID", "Keyword Value"
              |              FROM(SELECT t0.id "Keyword ID", t0.value "Keyword Value"
@@ -2764,7 +2764,7 @@ class DruidQueryExecutorTest extends FunSuite with Matchers with BeforeAndAfterA
             |               )
             |
             |                  ))
-            |                  ) D )) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
+            |                  ) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 100) UNION ALL (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  *
             |      FROM (
             |          SELECT "Ad Group ID", "Campaign ID", "Campaign Name"
             |              FROM(SELECT ago1.id "Ad Group ID", co0.id "Campaign ID", co0.campaign_name "Campaign Name"

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.14-SNAPSHOT</version>
+    <version>6.15-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.14-SNAPSHOT</version>
+        <version>6.15-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Currently, queries including UNION ALL term allow for max row limiting on the second half of the union, but the first half comes in completely without limits.  This is an effort to reduce that query such that, given a request with MR=N... Return 2*N rows rather than N + K rows, where K is the number of unfiltered rows.

This may be further reduced by applying this ROWNUM limit to the outer query by creating a wrapper select statement for UNION queries (currently, this option hasn't been tested).

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
