### PR TITLE
startIndex fix for druid subsequent query

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryPipeline.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryPipeline.scala
@@ -910,10 +910,13 @@ OuterGroupBy operation has to be applied only in the following cases
             val values = irl.keys.toList.map(_.toString)
             val filter = InFilter(field, values)
             val injectedFactBestCandidate = factOnlyInjectFilter(factBestCandidateOption.get, filter)
-            val query = getFactQuery(injectedFactBestCandidate, requestModel, indexAlias, List(indexAlias), queryGenVersion, Some(bestDimCandidates))
+            // druid subsequentQuery should use startIndex = 0 to prevent wrongly row drop
+            val factRequestModel = requestModel.copy(startIndex = 0)
+            val query = getFactQuery(injectedFactBestCandidate, factRequestModel, indexAlias, List(indexAlias), queryGenVersion, Some(bestDimCandidates))
             irl.addSubQuery(query)
             query
         }
+
         new QueryPipelineBuilder(
           MultiEngineQuery(
             dimQuery,


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
_I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner._

This PR aims to fix the misuse of startIndex for subsequent query in MultiEngineQuery.  

Currently, if we have greater than 0 startIndex, it will pass to both drivingQuery as well as the subsequent one, which will cause unwanted row drop in druid for the following places:
https://github.com/yahoo/maha/blob/master/druid/src/main/scala/com/yahoo/maha/executor/druid/DruidQueryExecutor.scala#L237
https://github.com/yahoo/maha/blob/master/druid/src/main/scala/com/yahoo/maha/executor/druid/DruidQueryExecutor.scala#L264-L269

This PR modifies the RequestModel for subsequent queries.  If this is not ideal, another option is modify the startIndex specific for druid query:
https://github.com/yahoo/maha/blob/master/druid/src/main/scala/com/yahoo/maha/executor/druid/DruidQueryExecutor.scala#L164-L168
For this option we can either check dimdriven-related parameters or check if the previous rowList is empty.