### PR TITLE
Add reportFormat while calculating hash

### DIFF
--- a/service/src/main/scala/com/yahoo/maha/service/MahaRequestContext.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/MahaRequestContext.scala
@@ -17,10 +17,11 @@ case class MahaRequestContext(registryName: String
                               , requestId: String
                               , userId: String
                               , requestStartTime: Long = System.currentTimeMillis()
+                              , reportFormat: String = "json"
                              ) {
   lazy val mutableState = new TrieMap[String, Any]()
   lazy val requestHashOption: Option[String] = if(rawJson!=null) {
-      Some(DigestUtils.md5Hex(rawJson))
+      Some(DigestUtils.md5Hex(rawJson ++ reportFormat.getBytes()))
     } else {
       None
     }

--- a/service/src/test/scala/com/yahoo/maha/service/utils/MahaRequestLogHelperTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/utils/MahaRequestLogHelperTest.scala
@@ -82,7 +82,7 @@ class MahaRequestLogHelperTest extends AnyFunSuite with Matchers {
     assert(proto.getUserId == "abc")
     assert(MahaRequestLogHelper.hostname.isDefined)
     assert(MahaRequestLogHelper.logger.isErrorEnabled)
-    assert(proto.getRequestHash == "be92d6566e6030cb42a061f42765875c")
+    assert(proto.getRequestHash == "752b0377de572a57abe93e0b2fd5cf26")
   }
 
   test("Test MahaRequestLogHelper LogFailed with status") {


### PR DESCRIPTION
- A query is made, first with reportFormat A, data is cached in format A.
- Next, when the same query is made but with reportFormat B, it causes a cache hit and returns data in format A instead.
- This is because the reportFormat is not considered while calculating the hash for a query. This PR adds that.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
