### PR TITLE
Bump Maha version from 6.32-SNAPSHOT to 6.33-SNAPSHOT and bump Druid version from 0.17.1 to 0.20.0

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/README.md
+++ b/druid-lookups/README.md
@@ -27,7 +27,7 @@ An extension to druid which provides for MongoDB, JDBC and RocksDB (for high car
 Here is tutorial of how to set up maha-druid-lookups as an extensions of Druid in your local box.  
 For convenience, we use `/druid` as our druid root path for the following document.
 ### Requirement
-* [druid-0.17.1](http://druid.io/docs/0.17.1/tutorials/quickstart.html)
+* [druid-0.20.0](http://druid.io/docs/0.20.0/tutorials/quickstart.html)
 * zookeeper
 * your local datasource (mysql, oracle, etc.)
 
@@ -141,7 +141,7 @@ This is caused by lack of Hadoop dependency.
 
 **Solution:** 
 
-For Druid-0.17.1, it already has the hadoop client jars under `hadoop-dependencies/hadoop-client/2.8.5/*`.  Just make sure you have included the path in `bin/run-druid`
+For Druid-0.20.0, it already has the hadoop client jars under `hadoop-dependencies/hadoop-client/2.8.5/*`.  Just make sure you have included the path in `bin/run-druid`
 
 ### Registering Druid Lookups
 Druid lookups are managed using APIs on coordinators.  Refer [here](http://druid.io/docs/latest/querying/lookups.html).
@@ -184,7 +184,7 @@ Example Lookup JSON:
 }
 ```
 
-_NOTE1: for the details of parameters, please check [here](http://druid.io/docs/0.17.1/development/extensions-core/lookups-cached-global.html)._
+_NOTE1: for the details of parameters, please check [here](http://druid.io/docs/0.20.0/development/extensions-core/lookups-cached-global.html)._
 
 _NOTE2: set "cacheEnabled" to true for building cache(hasmap) in the node._
 

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -111,11 +111,11 @@
                     <artifactId>httpcore</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core-asl</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
                 <exclusion>
@@ -284,7 +284,7 @@
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-server</artifactId>
-            <version>0.17.1</version>
+            <version>0.20.0</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/JDBCLookupExtractor.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/JDBCLookupExtractor.java
@@ -21,4 +21,14 @@ public class JDBCLookupExtractor<U extends List<String>> extends OnlineDatastore
     protected Logger LOGGER() {
         return LOG;
     }
+
+    @Override
+    public boolean canIterate() {
+        return false;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> iterable() {
+        return null;
+    }
 }

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/JDBCLookupExtractorWithLeaderAndFollower.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/JDBCLookupExtractorWithLeaderAndFollower.java
@@ -21,4 +21,14 @@ public class JDBCLookupExtractorWithLeaderAndFollower<U extends List<String>> ex
     protected Logger LOGGER() {
         return LOG;
     }
+
+    @Override
+    public boolean canIterate() {
+        return false;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> iterable() {
+        return null;
+    }
 }

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MahaRegisteredLookupExtractionFn.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MahaRegisteredLookupExtractionFn.java
@@ -222,17 +222,16 @@ public class MahaRegisteredLookupExtractionFn implements ExtractionFn {
             // http://www.javamex.com/tutorials/double_checked_locking.shtml
             synchronized (delegateLock) {
                 if (null == delegate) {
+                    Preconditions.checkArgument(manager.get(getLookup()).isPresent(), "Lookup [%s] not found", getLookup());
                     delegate = new MahaLookupExtractionFn(
-                            Preconditions.checkNotNull(manager.get(getLookup())
-                                    , "Lookup [%s] not found", getLookup()
-                            ).getLookupExtractorFactory().get()
-                            , isRetainMissingValue()
-                            , getReplaceMissingValueWith()
-                            , isInjective()
-                            , isOptimize()
-                            , valueColumn
-                            , decodeConfig
-                            , dimensionOverrideMap
+                            manager.get(getLookup()).get().getLookupExtractorFactory().get(),
+                            isRetainMissingValue(),
+                            getReplaceMissingValueWith(),
+                            isInjective(),
+                            isOptimize(),
+                            valueColumn,
+                            decodeConfig,
+                            dimensionOverrideMap
                     );
                 }
             }

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MongoLookupExtractor.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MongoLookupExtractor.java
@@ -22,4 +22,13 @@ public class MongoLookupExtractor<U extends List<String>> extends OnlineDatastor
         return LOG;
     }
 
+    @Override
+    public boolean canIterate() {
+        return false;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> iterable() {
+        return null;
+    }
 }

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/RocksDBLookupExtractor.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/RocksDBLookupExtractor.java
@@ -33,4 +33,14 @@ public class RocksDBLookupExtractor<U> extends BaseRocksDBLookupExtractor<U> {
     public byte[] getCacheByteValue(String key, String valueColumn, Optional<DecodeConfig> decodeConfigOptional, RocksDB db) {
        return cacheActionRunner.getCacheValue(key, Optional.of(valueColumn), decodeConfigOptional, db, schemaFactory, lookupService, serviceEmitter, extractionNamespace);
     }
+
+    @Override
+    public boolean canIterate() {
+        return false;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> iterable() {
+        return null;
+    }
 }

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/RocksDBLookupExtractorWithFlatBuffer.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/query/lookup/RocksDBLookupExtractorWithFlatBuffer.java
@@ -33,4 +33,14 @@ public class RocksDBLookupExtractorWithFlatBuffer<U> extends BaseRocksDBLookupEx
     public byte[] getCacheByteValue(String key, String valueColumn, Optional<DecodeConfig> decodeConfigOptional, RocksDB db) {
         return cacheActionRunner.getCacheValue(key, Optional.of(valueColumn), decodeConfigOptional, db, schemaFactory, lookupService, serviceEmitter, extractionNamespace);
     }
+
+    @Override
+    public boolean canIterate() {
+        return false;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> iterable() {
+        return null;
+    }
 }

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/cache/MahaNamespaceExtractionCacheManager.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/cache/MahaNamespaceExtractionCacheManager.java
@@ -163,7 +163,7 @@ public abstract class MahaNamespaceExtractionCacheManager<U> {
         final NamespaceImplData implDatum = implData.get(namespaceName);
         if (implDatum == null) {
             // Delete but we don't have it?
-            log.wtf("Asked to delete something I just lost [%s]", namespaceName);
+            log.error("Asked to delete something I just lost [%s]", namespaceName);
             return false;
         }
         return delete(namespaceName);
@@ -373,7 +373,7 @@ public abstract class MahaNamespaceExtractionCacheManager<U> {
                 throw new IAE("Namespace [%s] already exists! Leaving prior running", namespace);
             } else {
                 if (!me.enabled.compareAndSet(false, true)) {
-                    log.wtf("How did someone enable this before ME?");
+                    log.error("How did someone enable this before ME?");
                 }
                 log.debug("I own namespace [%s]", id);
                 return future;

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MahaLookupExtractionFactoryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MahaLookupExtractionFactoryTest.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.mockito.Matchers.any;
@@ -128,7 +129,8 @@ public class MahaLookupExtractionFactoryTest extends TestMongoServer {
         assertEquals(mahaExtractor.apply("5ad10906fc7b6ecac8d41081", "name", null, null), "advertiser1");
 
         lookupReferencesManager = mock(LookupReferencesManager.class);
-        when(lookupReferencesManager.get(any())).thenReturn(container);
+        Optional<LookupExtractorFactoryContainer> containerOptional = Optional.of(container);
+        when(lookupReferencesManager.get(any())).thenReturn(containerOptional);
 
         MahaRegisteredLookupExtractionFn fn = objectMapper
                 .readValue(Thread.currentThread()

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MahaRegisteredLookupExtractionFnTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/query/lookup/MahaRegisteredLookupExtractionFnTest.java
@@ -51,9 +51,10 @@ public class MahaRegisteredLookupExtractionFnTest {
         when(lef.get()).thenReturn(jdbcLookupExtractor);
 
         LookupExtractorFactoryContainer lefc = mock(LookupExtractorFactoryContainer.class);
+        Optional<LookupExtractorFactoryContainer> lefcOptional = Optional.of(lefc);
         when(lefc.getLookupExtractorFactory()).thenReturn(lef);
         LookupReferencesManager lrm = mock(LookupReferencesManager.class);
-        when(lrm.get(anyString())).thenReturn(lefc);
+        when(lrm.get(anyString())).thenReturn(lefcOptional);
 
         MahaRegisteredLookupExtractionFn fn = spy(new MahaRegisteredLookupExtractionFn(lrm, "advertiser_lookup", false, "", false, false, "status", null, null, true));
         Assert.assertNull(fn.cache);
@@ -77,9 +78,10 @@ public class MahaRegisteredLookupExtractionFnTest {
         when(lef.get()).thenReturn(jdbcLookupExtractor);
 
         LookupExtractorFactoryContainer lefc = mock(LookupExtractorFactoryContainer.class);
+        Optional<LookupExtractorFactoryContainer> lefcOptional = Optional.of(lefc);
         when(lefc.getLookupExtractorFactory()).thenReturn(lef);
         LookupReferencesManager lrm = mock(LookupReferencesManager.class);
-        when(lrm.get(anyString())).thenReturn(lefc);
+        when(lrm.get(anyString())).thenReturn(lefcOptional);
 
         MahaRegisteredLookupExtractionFn fn = spy(new MahaRegisteredLookupExtractionFn(lrm, "advertiser_lookup", false, "", false, false, "status", null, null, true));
 
@@ -105,9 +107,10 @@ public class MahaRegisteredLookupExtractionFnTest {
         when(lef.get()).thenReturn(jdbcLookupExtractor);
 
         LookupExtractorFactoryContainer lefc = mock(LookupExtractorFactoryContainer.class);
+        Optional<LookupExtractorFactoryContainer> lefcOptional = Optional.of(lefc);
         when(lefc.getLookupExtractorFactory()).thenReturn(lef);
         LookupReferencesManager lrm = mock(LookupReferencesManager.class);
-        when(lrm.get(anyString())).thenReturn(lefc);
+        when(lrm.get(anyString())).thenReturn(lefcOptional);
 
         MahaRegisteredLookupExtractionFn fn = spy(new MahaRegisteredLookupExtractionFn(lrm, "advertiser_lookup", false, "", false, false, "status", null, null, false));
 
@@ -132,9 +135,10 @@ public class MahaRegisteredLookupExtractionFnTest {
         when(lef.get()).thenReturn(jdbcLookupExtractor);
 
         LookupExtractorFactoryContainer lefc = mock(LookupExtractorFactoryContainer.class);
+        Optional<LookupExtractorFactoryContainer> lefcOptional = Optional.of(lefc);
         when(lefc.getLookupExtractorFactory()).thenReturn(lef);
         LookupReferencesManager lrm = mock(LookupReferencesManager.class);
-        when(lrm.get(anyString())).thenReturn(lefc);
+        when(lrm.get(anyString())).thenReturn(lefcOptional);
 
         MahaRegisteredLookupExtractionFn fn = spy(new MahaRegisteredLookupExtractionFn(lrm, "advertiser_lookup", false, "", false, false, "status", null, null, true));
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.32-SNAPSHOT</version>
+    <version>6.33-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>
@@ -34,7 +34,7 @@
         <httpclient.version>4.5.12</httpclient.version>
         <guava.version>29.0-jre</guava.version>
         <jodatime.version>2.10.6</jodatime.version>
-        <druid.version>0.17.1</druid.version>
+        <druid.version>0.20.0</druid.version>
         <scala.arm.version>2.0</scala.arm.version>
         <opencsv.version>3.8</opencsv.version>
         <esapi.version>2.2.1.1</esapi.version>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.32-SNAPSHOT</version>
+        <version>6.33-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
## Problem

Recently, Druid [released 0.20.0](https://github.com/apache/druid/releases/tag/druid-0.20.0) which contains some new features. So this PR majorly bumps the Druid version in Maha from 0.17.1 to 0.20.0.

To be more specific, the PR includes the following changes:
1. Bump Maha version from 6.32-SNAPSHOT to 6.33-SNAPSHOT
2. Bump Druid version from 0.17.1 to 0.20.0
3. Fix some unit tests, logs, and Jackson package in pom file.

## Test

I build the package in local machine, here are the artifacts:

```
╰─$ mvn clean install
[INFO]
[INFO] <<< scoverage-maven-plugin:1.4.1:report (coverage) < [scoverage]test @ maha-api-example <<<
[INFO]
[INFO]
[INFO] --- scoverage-maven-plugin:1.4.1:report (coverage) @ maha-api-example ---
[INFO] Reading scoverage instrumentation [/Users/jchome/src/github.com/drinkbeer/maha/api-example/target/scoverage-data/scoverage.coverage]...
[INFO] Reading scoverage measurements [/Users/jchome/src/github.com/drinkbeer/maha/api-example/target/scoverage-data/scoverage.measurements.*]...
[INFO] Generating coverage reports...
[INFO] Written Cobertura XML report [/Users/jchome/src/github.com/drinkbeer/maha/api-example/target/cobertura.xml]
[INFO] Written XML coverage report [/Users/jchome/src/github.com/drinkbeer/maha/api-example/target/scoverage.xml]
[INFO] Written HTML coverage report [/Users/jchome/src/github.com/drinkbeer/maha/api-example/target/site/scoverage/index.html]
[INFO] Statement coverage.: 98.52%
[INFO] Branch coverage....: 83.33%
[INFO] Coverage reports completed.
[INFO] Found 12 subproject scoverage data directories.
[INFO] Generating coverage aggregated reports...
[INFO] Written Cobertura XML report [/Users/jchome/src/github.com/drinkbeer/maha/target/cobertura.xml]
[INFO] Written XML coverage report [/Users/jchome/src/github.com/drinkbeer/maha/target/scoverage.xml]
[INFO] Written HTML coverage report [/Users/jchome/src/github.com/drinkbeer/maha/target/site/scoverage/index.html]
[INFO] Statement coverage.: 90.38%
[INFO] Branch coverage....: 83.49%
[INFO] Coverage aggregated reports completed.
[INFO]
[INFO] --- scoverage-maven-plugin:1.4.1:check-only (coverage) @ maha-api-example ---
[INFO] Statement coverage.: 98.52%
[INFO] Branch coverage....: 83.33%
[INFO] Coverage is above minimum [98.52% >= 90.00%]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for maha parent 6.33-SNAPSHOT:
[INFO]
[INFO] maha parent ........................................ SUCCESS [  0.772 s]
[INFO] maha-par-request-2 ................................. SUCCESS [ 47.521 s]
[INFO] maha db ............................................ SUCCESS [ 35.487 s]
[INFO] maha request log ................................... SUCCESS [ 29.025 s]
[INFO] maha-druid-lookups ................................. SUCCESS [ 30.974 s]
[INFO] maha core .......................................... SUCCESS [02:49 min]
[INFO] maha job service ................................... SUCCESS [ 21.415 s]
[INFO] maha druid executor ................................ SUCCESS [ 58.452 s]
[INFO] maha oracle executor ............................... SUCCESS [ 29.260 s]
[INFO] maha presto executor ............................... SUCCESS [ 31.331 s]
[INFO] maha postgres executor ............................. SUCCESS [ 37.343 s]
[INFO] maha service ....................................... SUCCESS [01:26 min]
[INFO] maha worker ........................................ SUCCESS [ 36.809 s]
[INFO] maha api-jersey .................................... SUCCESS [ 41.732 s]
[INFO] maha api-example ................................... SUCCESS [ 35.495 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11:31 min
[INFO] Finished at: 2020-12-07T19:47:43-05:00
[INFO] ------------------------------------------------------------------------
```
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
