### PR TITLE
Modifying rowcount curator response if required

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
@@ -105,6 +105,7 @@ trait RowList extends RowListLifeCycle {
   def getTotalRowCount : Int = {
     0
   }
+  def setTotalRowCount(respLen : Int) = {}
 
   def length: Int = {
     0
@@ -212,6 +213,17 @@ trait InMemRowList extends QueryRowList {
   }
 
   def size: Int = list.size
+
+  override def setTotalRowCount(respLen : Int) = {
+    val listAttempt = Try {
+      val firstRow = list.head
+      val totalrow_col = firstRow.aliasMap(ROW_COUNT_ALIAS)
+      firstRow.cols(totalrow_col) = respLen
+    }
+    if (!listAttempt.isSuccess) {
+      logger.warn("Failed to modify total row count.\n" + listAttempt)
+    }
+  }
 
   //def javaForeach(fn: ParCallable)
   override def getTotalRowCount: Int = {

--- a/service/src/main/scala/com/yahoo/maha/service/RequestCoordinator.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/RequestCoordinator.scala
@@ -237,6 +237,7 @@ case class DefaultRequestCoordinator(protected val mahaService: MahaService) ext
                           .map(_.asInstanceOf[CombinableRequest[RequestResult]]).toList.asJava
                         pse.combineListEither(futures)
                       }
+                      var responseLength = 0
                       combinedRequestResultList.map("combinedRequestResultListMap",
                         ParFunction.fromScala {
                           javaRequestResult =>
@@ -270,6 +271,7 @@ case class DefaultRequestCoordinator(protected val mahaService: MahaService) ext
                                 }
                               } else {
                                 val result = errorOrResult.right.get
+                                responseLength = curatorMap(curatorResult.curator.name).checkCuratorResponse(responseLength, result)
                                 if(!successResults.contains(curatorResult.curator.name)) {
                                   val newList = new scala.collection.mutable.ArrayBuffer[CuratorAndRequestResult]()
                                   newList += CuratorAndRequestResult(curatorResult, result)

--- a/service/src/test/scala/com/yahoo/maha/service/RequestCoordinatorTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/RequestCoordinatorTest.scala
@@ -2,20 +2,28 @@
 // Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
 package com.yahoo.maha.service
 
+import com.yahoo.maha.core.{Column, DimColumnInfo, RequestModel}
 import com.yahoo.maha.core.bucketing.{BucketParams, UserInfo}
-import com.yahoo.maha.core.query.OracleQuery
+import com.yahoo.maha.core.dimension.DimCol
+import com.yahoo.maha.core.query.{CompleteRowList, DimOnlyQuery, DimQueryContext, InMemRowList, OracleQuery, QueryContext, QueryPipelineResult, Row}
 import com.yahoo.maha.core.request._
 import com.yahoo.maha.jdbc.{Seq, _}
-import com.yahoo.maha.parrequest2.future.ParRequest
+import com.yahoo.maha.parrequest2.future.{ParRequest, ParRequestListEither}
 import com.yahoo.maha.service.curators._
 import com.yahoo.maha.service.error.MahaServiceExecutionException
 import com.yahoo.maha.service.example.ExampleSchema.StudentSchema
 import com.yahoo.maha.service.output.{JsonOutputFormat, StringStream}
 import com.yahoo.maha.service.utils.MahaRequestLogHelper
+import org.apache.derby.impl.sql.execute.ColumnInfo
+import org.h2.result.RowList
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
+import org.mockito.Mockito.{mock, when}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers._
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll {
 
@@ -2376,12 +2384,73 @@ class RequestCoordinatorTest extends BaseMahaServiceTest with BeforeAndAfterAll 
     val stringStream =  new StringStream()
     jsonStreamingOutput.writeStream(stringStream)
     val result = stringStream.toString()
-//
+    println(result)
 
     val expectedJson = """\{"header":\{"cube":"student_performance","fields":\[\{"fieldName":"Student ID","fieldType":"DIM"\},\{"fieldName":"Class ID","fieldType":"DIM"\},\{"fieldName":"Section ID","fieldType":"DIM"\},\{"fieldName":"Total Marks","fieldType":"FACT"\}\],"maxRows":200\},"rows":\[\[213,200,100,99\]\],"curators":\{"rowcount":\{"result":\{"header":\{"cube":"student_performance","fields":\[\{"fieldName":"TOTALROWS","fieldType":"FACT"\}\],"maxRows":1\},"rows":\[\[.*\]\]\}\}\}\}"""
 
     result should fullyMatch regex expectedJson
 
   }
+  test("Test RowCountCurator for wrong rowCount response") {
+
+    val setDefaultRespLength = 3
+    val defaultRespLength = createMockDefaultResponse(setDefaultRespLength)
+    assert(defaultRespLength == setDefaultRespLength)
+
+    // case 1 : Total RowCount lesser than number of rows returned by DefaultCurator
+    val setTotalRowCount1 = 2
+    val rowCountRespLength1 = createMockRowCountResult(setTotalRowCount1, setDefaultRespLength)
+    assert(rowCountRespLength1 == defaultRespLength)
+
+    // case 2 : Total RowCount more than number of rows returned by DefaultCurator
+    val setTotalRowCount2 = 4
+    val rowCountRespLength2 = createMockRowCountResult(setTotalRowCount2, setDefaultRespLength)
+    assert(rowCountRespLength2 != defaultRespLength)
+  }
+  def createMockDefaultResponse(setResponseLength: Int): Int = {
+    //mocking defaultCurator result to test 'checkCuratorResponse' method
+    val defaultRowList = mock(classOf[CompleteRowList])
+    when(defaultRowList.length).thenReturn(setResponseLength)
+    val defaultQueryPipeline = QueryPipelineResult(null,null,defaultRowList,null,null)
+    val defaultRequestResult = RequestResult(defaultQueryPipeline)
+    val mockDefaultCurator = mahaService.getMahaServiceConfig.curatorMap("default")
+    val respLength = mockDefaultCurator.checkCuratorResponse(0,defaultRequestResult)
+    respLength
+  }
+
+  def createMockRowCountResult(setTotalRowCount : Int, setDefaultRespLength : Int): Int = {
+
+    //Creating test requestModel
+    val reqModel = mock(classOf[RequestModel])
+    val colInfo = IndexedSeq(DimColumnInfo(alias = "col1"))
+    when(reqModel.maxRows).thenReturn(100)
+    when(reqModel.requestCols).thenReturn(colInfo)
+
+    //Creating test query
+    val indexaliasOp = Option("col1")
+    val queryContext = DimQueryContext(null, reqModel, indexaliasOp, null, null)
+    val addCols = IndexedSeq("col1")
+    val column = mock(classOf[Column])
+    val colAliasMap = Map("TOTALROWS" -> column)
+    val query = OracleQuery(queryContext, null, null, colAliasMap, addCols, null)
+
+
+    //Creating a test row instance
+    val aliasMap = Map("TOTALROWS" -> 0)
+    val anyValue : Any = setTotalRowCount
+    val cols = mutable.ArrayBuffer(anyValue)
+    val row = Row(aliasMap, cols)
+
+    //mocking rowCountCurator result to test 'checkCuratorResponse' method
+    val rowCountRowList = CompleteRowList(query)
+    rowCountRowList.addRow(row)
+    val rowCountQueryPipeline = QueryPipelineResult(null,null,rowCountRowList,null,null)
+    val rowCountRequestResult = RequestResult(rowCountQueryPipeline)
+
+    val mockRowCountCurator = mahaService.getMahaServiceConfig.curatorMap("rowcount")
+    val respLength = mockRowCountCurator.checkCuratorResponse(setDefaultRespLength, rowCountRequestResult)
+    rowCountRequestResult.queryPipelineResult.rowList.getTotalRowCount
+  }
+
 }
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Design doc: [https://docs.google.com/document/d/15esKzNl4nHnqA30ncir4qkBB9LAhrcjRHqCIagubEzM/edit#](url)

Target Problem: Sometimes, rowCount Curator's response is lesser than the number of queries returned by the Default Curator(Main Query). This is possibly happening in cases when the rowCount curator returns its response faster than the main query in which time gap, more entries get added to the tables.

Solution: After the responses of the curators are combined, if the rowCount response is less, we set it to the length of the list of rows returned by the Default Curator.