### PR TITLE
[maha-druid-lookup] use previousLastUpdateTimestamp when lastUpdates() call failed

### DIFF
--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
@@ -235,10 +235,16 @@ public class JDBCExtractionNamespaceCacheFactory
         if (!namespace.isFirstTimeCaching() && isFollower)
             return namespace.getPreviousLastUpdateTimestamp();
 
-        final Timestamp lastUpdatedTimeStamp =
+        try {
+            final Timestamp lastUpdatedTimeStamp =
                 (Timestamp) getMaxValFromColumn(id, namespace, CustomizedTimestampMapper.getInstance(namespace), tsColumn, table,
-                        namespace.hasSecondaryTsColumn() ? formatSecondTsWhereClause(namespace, maxTsCache[0], SECONDARY_TS_COL_ONLY_WHERE_CLAUSE) : "");
-        return lastUpdatedTimeStamp;
+                                                namespace.hasSecondaryTsColumn() ? formatSecondTsWhereClause(namespace, maxTsCache[0], SECONDARY_TS_COL_ONLY_WHERE_CLAUSE) : "");
+            return lastUpdatedTimeStamp;
+        } catch (Exception e) {
+            LOG.error(e, "Exception caught while getting last updated timestamp. Using previous timestamp [%s] instead.", namespace.getPreviousLastUpdateTimestamp());
+            return namespace.getPreviousLastUpdateTimestamp();
+        }
+
 
     }
 

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/JDBCExtractionNamespaceCacheFactory.java
@@ -84,7 +84,7 @@ public class JDBCExtractionNamespaceCacheFactory
                                                     secondaryTsWhereCondition);
                         } catch (Throwable t) {
                             LOG.error(t, "Failed to populate RowList From JDBC [s%]", id);
-                            throw Throwables.propagate(t);
+                            throw t;
                         }
                         return null;
                     }
@@ -247,8 +247,8 @@ public class JDBCExtractionNamespaceCacheFactory
                 (Timestamp) getMaxValFromColumn(id, namespace, CustomizedTimestampMapper.getInstance(namespace), tsColumn, table,
                                                 namespace.hasSecondaryTsColumn() ? formatSecondTsWhereClause(namespace, maxTsCache[0], SECONDARY_TS_COL_ONLY_WHERE_CLAUSE) : "");
             return lastUpdatedTimeStamp;
-        } catch (Throwable t) {
-            LOG.error(t, "Exception caught while getting last updated timestamp. Using previous timestamp [%s] instead.", namespace.getPreviousLastUpdateTimestamp());
+        } catch (Exception e) {
+            LOG.error(e, "Exception caught while getting last updated timestamp. Using previous timestamp [%s] instead.", namespace.getPreviousLastUpdateTimestamp());
             return namespace.getPreviousLastUpdateTimestamp();
         }
 


### PR DESCRIPTION
Fixing intermittent NullPointerException with `ojdbc8-12.2.0.1` when getting last updated timestamp through jdbc connection. It will use `previousLastUpdateTimestamp` stored in namespace instead of killing the entire thread.
```
2021-01-28 21:34:39,275 ERROR c.y.m.m.s.l.n.c.MahaNamespaceExtractionCacheManager [MahaNamespaceExtractionCacheManager-21] Failed update namespace [JDBCExtractionNamespace{connectorConfig=DbConnectorConfig{createTables=false, connectURI='jdbc:oracle:thin:@cbrptprod_bf1', user='na_reporting_ws', passwordProvider=abc}, table='table, tsColumn='last_updated', pollPeriod=PT1M, columnList=[id, name], primaryKeyColumn='id', cacheEnabled=true, lookupName='my_lookup', firstTimeCaching=false, previousLastUpdateTimestamp=2021-01-28 19:09:10.327, kerberosProperties=null, tsColumnConfig=null, kerberosPropertiesEnabled=false}]
java.lang.NullPointerException: null
	at java.time.chrono.ChronoLocalDateTime.compareTo(ChronoLocalDateTime.java:500) ~[?:1.8.0_251]
	at java.time.LocalDateTime.compareTo(LocalDateTime.java:1823) ~[?:1.8.0_251]
	at oracle.net.nt.DownHostsCache.refreshCache(DownHostsCache.java:147) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.net.nt.DownHostsCache.reorderAddresses(DownHostsCache.java:183) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.net.nt.ConnStrategy.execute(ConnStrategy.java:432) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.net.resolver.AddrResolution.resolveAndExecute(AddrResolution.java:521) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.net.ns.NSProtocol.establishConnection(NSProtocol.java:660) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.net.ns.NSProtocol.connect(NSProtocol.java:286) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.jdbc.driver.T4CConnection.connect(T4CConnection.java:1438) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.jdbc.driver.T4CConnection.logon(T4CConnection.java:518) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.jdbc.driver.PhysicalConnection.connect(PhysicalConnection.java:688) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.jdbc.driver.T4CDriverExtension.getConnection(T4CDriverExtension.java:39) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at oracle.jdbc.driver.OracleDriver.connect(OracleDriver.java:691) ~[ojdbc8-12.2.0.1.jar:12.2.0.1.0]
	at java.sql.DriverManager.getConnection(DriverManager.java:664) ~[?:1.8.0_251]
	at java.sql.DriverManager.getConnection(DriverManager.java:247) ~[?:1.8.0_251]
	at org.skife.jdbi.v2.DBI$3.openConnection(DBI.java:140) ~[jdbi-2.63.1.jar:2.63.1]
	at org.skife.jdbi.v2.DBI.open(DBI.java:212) ~[jdbi-2.63.1.jar:2.63.1]
	at org.skife.jdbi.v2.DBI.withHandle(DBI.java:279) ~[jdbi-2.63.1.jar:2.63.1]
	at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.JDBCExtractionNamespaceCacheFactory.getMaxValFromColumn(JDBCExtractionNamespaceCacheFactory.java:251) ~[maha-druid-lookups-6.21.jar:?]
	at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.JDBCExtractionNamespaceCacheFactory.lastUpdates(JDBCExtractionNamespaceCacheFactory.java:239) ~[maha-druid-lookups-6.21.jar:?]
	at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.JDBCExtractionNamespaceCacheFactory.getCachePopulator(JDBCExtractionNamespaceCacheFactory.java:61) ~[maha-druid-lookups-6.21.jar:?]
	at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.JDBCExtractionNamespaceCacheFactory.getCachePopulator(JDBCExtractionNamespaceCacheFactory.java:30) ~[maha-druid-lookups-6.21.jar:?]
	at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.cache.MahaNamespaceExtractionCacheManager$3.run(MahaNamespaceExtractionCacheManager.java:326) [maha-druid-lookups-6.21.jar:?]
	at com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask.run(MoreExecutors.java:582) [guava-16.0.1.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_251]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_251]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_251]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_251]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_251]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_251]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_251]
```
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
