### PR TITLE
Code to enable Same Dim Level Join

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -16,7 +16,6 @@ import com.yahoo.maha.utils.DaysUtils
 import grizzled.slf4j.Logging
 import org.joda.time.DateTimeZone
 import org.slf4j.LoggerFactory
-import scala.collection.mutable.ArrayBuffer
 import scala.collection.{SortedSet, mutable}
 import scala.util.{Failure, Success, Try}
 
@@ -1235,16 +1234,16 @@ object RequestModel extends Logging {
     if (indexedSeqVar.nonEmpty) {
       var prevPubDim = indexedSeqVar.head
       var startIdx = 0
-      val endIdx = indexedSeqVar.size - 1
       indexedSeqVar.zipWithIndex.foreach {
         case(currentPubDim, currentIdx) => {
           if(currentIdx > 0) {
-            if (currentPubDim.dimLevel != prevPubDim.dimLevel || currentIdx == endIdx) {
+            if (currentPubDim.dimLevel != prevPubDim.dimLevel || currentIdx == indexedSeqVar.size - 1) {
               var sameDimLevelPDSeq = Seq[PublicDimension]()
-              // reversing the slice so that when output map is traversed from right to left, alphabetical order is ascending.
+              // reversing the slice so that when output map is traversed from
+              // right to left, ascending alphabetical order is preserved.
               if (currentPubDim.dimLevel == prevPubDim.dimLevel)
                 sameDimLevelPDSeq = indexedSeqVar.drop(startIdx).reverse
-              else if (currentPubDim.dimLevel != prevPubDim.dimLevel)
+              else
                 sameDimLevelPDSeq = indexedSeqVar.slice(startIdx, currentIdx).reverse
               if (sameDimLevelPDSeq.size > 1) {
                 val sameDimLevelFKMap = new mutable.LinkedHashMap[PublicDimension, List[PublicDimension]]()

--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -1226,7 +1226,7 @@ object RequestModel extends Logging {
     }
   }
 
-  // assigns secondaryDimLevel to PublicDimensions
+  // sortOnSameDimLevel assigns secondaryDimLevel to PublicDimensions
   // if a and b have same dimLevels and a has a foreign key to b, then a.secondaryDimLevel > b.secondaryDimLevel
 
   def sortOnSameDimLevel(indexedSeqVar: IndexedSeq[PublicDimension]):mutable.LinkedHashMap[PublicDimension, Int] = {

--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -1242,11 +1242,11 @@ object RequestModel extends Logging {
             if (currentPubDim.dimLevel != prevPubDim.dimLevel || currentIdx == endIdx) {
               var sameDimLevelPDSeq = Seq[PublicDimension]()
               // reversing the slice so that when output map is traversed from right to left, alphabetical order is ascending.
-              if (currentIdx == endIdx && currentPubDim.dimLevel == prevPubDim.dimLevel)
-                sameDimLevelPDSeq = indexedSeqVar.drop(startIdx - 1).reverse
-              else
-                  sameDimLevelPDSeq = indexedSeqVar.slice(startIdx, currentIdx).reverse
-              if(sameDimLevelPDSeq.size > 1) {
+              if (currentPubDim.dimLevel == prevPubDim.dimLevel)
+                sameDimLevelPDSeq = indexedSeqVar.drop(startIdx).reverse
+              else if (currentPubDim.dimLevel != prevPubDim.dimLevel)
+                sameDimLevelPDSeq = indexedSeqVar.slice(startIdx, currentIdx).reverse
+              if (sameDimLevelPDSeq.size > 1) {
                 val sameDimLevelFKMap = new mutable.LinkedHashMap[PublicDimension, List[PublicDimension]]()
                 sameDimLevelPDSeq.foreach {
                   pubDim => sameDimLevelFKMap.put(pubDim,

--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -1205,15 +1205,15 @@ object RequestModel extends Logging {
   }
 
   def sortOnForeignKeyUtil(sameDimLevelFKMap:mutable.LinkedHashMap[PublicDimension, List[PublicDimension]], dim:PublicDimension, visited: mutable.HashMap[PublicDimension, Int], indexedSeqVarSorted: ArrayBuffer[PublicDimension], tempVisited: mutable.Set[PublicDimension]): Unit = {
-    var subDimLevel = 0
+    var secondaryDimLevel = 0
     tempVisited += dim
     sameDimLevelFKMap.get(dim).get.foreach{ pd =>
       if(!visited.contains(pd) && !tempVisited.contains(pd))
         sortOnForeignKeyUtil(sameDimLevelFKMap, pd, visited, indexedSeqVarSorted, tempVisited)
-      subDimLevel = Math.max(subDimLevel, visited.getOrElse(pd, 0) + 1)
+      secondaryDimLevel = Math.max(secondaryDimLevel, visited.getOrElse(pd, 0) + 1)
     }
-    visited.put(dim, subDimLevel)
-    dim.secondaryDimLevel = subDimLevel
+    visited.put(dim, secondaryDimLevel)
+    dim.secondaryDimLevel = secondaryDimLevel
     indexedSeqVarSorted.prepend(dim)
   }
 
@@ -1223,10 +1223,10 @@ object RequestModel extends Logging {
       if(!visitedSubDimMap.contains(pd)) sortOnForeignKeyUtil(sameDimLevelFKMap, pd, visitedSubDimMap, indexedSeqVarSorted, mutable.Set[PublicDimension]())
     }
   }
-  // assigns subDimLevel to PublicDimensions and orders them in desc order of dimLevel and subDimLevel
-  // a.subDimLevel > b.subDimLevel if a has a foreign key to b
+  // assigns secondaryDimLevel to PublicDimensions and orders them in desc order of dimLevel and secondaryDimLevel
+  // a.secondaryDimLevel > b.secondaryDimLevel if a has a foreign key to b
   def sortOnSameDimLevel(indexedSeqVar: IndexedSeq[PublicDimension]):IndexedSeq[PublicDimension] = {
-    val indexedSeqVarSorted = new ArrayBuffer[PublicDimension]() //using ArrayBuffer instead of IndexedSeq[PublicDimension] so that it accepts the public dimensions in order of subDimLevel instead of alphabetically.
+    val indexedSeqVarSorted = new ArrayBuffer[PublicDimension]() //using ArrayBuffer instead of IndexedSeq[PublicDimension] so that it accepts the public dimensions in order of secondaryDimLevel instead of alphabetically.
     if(indexedSeqVar.nonEmpty) {
       var prevPubDim = indexedSeqVar.head
       var startIdx = 0

--- a/core/src/main/scala/com/yahoo/maha/core/dimension/Dimension.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/dimension/Dimension.scala
@@ -969,8 +969,6 @@ trait PublicDimension extends PublicTable {
 
   def dimLevel: DimLevel
 
-  var secondaryDimLevel: Int = 0
-
   def schemas: Set[Schema]
 
   def schemaRequiredAlias(schema: Schema): Option[RequiredAlias]

--- a/core/src/main/scala/com/yahoo/maha/core/dimension/Dimension.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/dimension/Dimension.scala
@@ -969,6 +969,8 @@ trait PublicDimension extends PublicTable {
 
   def dimLevel: DimLevel
 
+  var secondaryDimLevel: Int = 0
+
   def schemas: Set[Schema]
 
   def schemaRequiredAlias(schema: Schema): Option[RequiredAlias]

--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryContext.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryContext.scala
@@ -112,6 +112,7 @@ case class DimensionBundle(dim: Dimension
                            , hasPKRequested: Boolean
                            , hasNonFKNonForceFilters: Boolean
                            , hasLowCardinalityFilter: Boolean
+                           , secondaryDimLevel : Int = 0
                             ) {
   //only filtering on primary key alias then subquery candidate
   lazy val filterFields: SortedSet[String] = for (filter <- filters) yield {
@@ -143,7 +144,7 @@ case class DimensionBundle(dim: Dimension
 }
 
 object DimensionBundle {
-  implicit val ordering: Ordering[DimensionBundle] = Ordering.by(dc => s"${dc.dim.dimLevel.level}-${dc.dim.name}")
+  implicit val ordering: Ordering[DimensionBundle] = Ordering.by(dc => s"${dc.dim.dimLevel.level}-${dc.publicDim.secondaryDimLevel}-${dc.dim.name}")
 }
 
 class QueryContextBuilder(queryType: QueryType, requestModel: RequestModel) {

--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryContext.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryContext.scala
@@ -144,7 +144,7 @@ case class DimensionBundle(dim: Dimension
 }
 
 object DimensionBundle {
-  implicit val ordering: Ordering[DimensionBundle] = Ordering.by(dc => s"${dc.dim.dimLevel.level}-${dc.publicDim.secondaryDimLevel}-${dc.dim.name}")
+  implicit val ordering: Ordering[DimensionBundle] = Ordering.by(dc => s"${dc.dim.dimLevel.level}-${dc.secondaryDimLevel}-${dc.dim.name}")
 }
 
 class QueryContextBuilder(queryType: QueryType, requestModel: RequestModel) {

--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryPipeline.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryPipeline.scala
@@ -673,7 +673,7 @@ object DefaultQueryPipelineFactory extends Logging {
           , hasPKRequested = dc.hasPKRequested
           , hasNonFKNonForceFilters = dc.hasNonFKNonForceFilters
           , hasLowCardinalityFilter = dc.hasLowCardinalityFilter
-          , dc.dim.secondaryDimLevel
+          , dc.secondaryDimLevel
         )
       }
     }

--- a/core/src/main/scala/com/yahoo/maha/core/query/QueryPipeline.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/QueryPipeline.scala
@@ -659,6 +659,7 @@ object DefaultQueryPipelineFactory extends Logging {
           , hasPKRequested = dc.hasPKRequested
           , hasNonFKNonForceFilters = dc.hasNonFKNonForceFilters
           , hasLowCardinalityFilter = dc.hasLowCardinalityFilter
+          , dc.dim.secondaryDimLevel
         )
       }
     }

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
@@ -105,7 +105,7 @@ b. Dim Driven
       //add subquery filters
       subqueryBundles.foreach {
         subqueryBundle =>
-          require(primaryDimLevel > subqueryBundle.dim.dimLevel,
+          require(primaryDimLevel >= subqueryBundle.dim.dimLevel,
             s"level of primary dimension must be greater than subquery dimension, dim=${dimBundle.publicDim.name}, subquery dim=${subqueryBundle.publicDim.name}")
           require(dimBundle.publicDim.columnsByAlias(subqueryBundle.publicDim.primaryKeyByAlias),
             s"subquery dim primary key not found in primary dimension, dim=${dimBundle.publicDim.name}, subquery dim=${subqueryBundle.publicDim.name}")

--- a/service/src/test/scala/com/yahoo/maha/service/example/MahaServiceExampleTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/example/MahaServiceExampleTest.scala
@@ -448,7 +448,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
     val expected = s"""SELECT  *
                       |      FROM (
                       |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
@@ -516,7 +516,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -589,7 +589,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -663,7 +663,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -727,7 +727,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -800,7 +800,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -873,7 +873,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -947,7 +947,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1022,7 +1022,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1101,7 +1101,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1172,7 +1172,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1256,7 +1256,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1332,7 +1332,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1408,7 +1408,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1505,7 +1505,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1584,7 +1584,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1673,7 +1673,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1763,7 +1763,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1844,7 +1844,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -1931,7 +1931,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -2026,7 +2026,7 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected =
       s"""
@@ -2122,13 +2122,13 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
     val expected = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"dr_student_performance"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\}\]\},\{"type":"selector","dimension":"student_id","value":"213"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"name","outputName":"Researcher Name","outputType":"STRING"\},\{"type":"default","dimension":"status","outputName":"Researcher Status","outputType":"STRING"\},\{"type":"default","dimension":"name","outputName":"Student Name","outputType":"STRING"\},\{"type":"default","dimension":"status","outputName":"Tutor Status","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Marks Obtained","fieldName":"obtained_marks"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":400\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}""".r
     result should fullyMatch regex expected
   }
 
-  test("Test") {
+  test("Test: Columns from multiple same dimLevel dimensions") {
     val jsonString =
       s"""
          |{
@@ -2182,10 +2182,59 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
-    println(result)
+    //println(result)
 
-    //val expected = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"dr_student_performance"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\}\]\},\{"type":"selector","dimension":"student_id","value":"213"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"name","outputName":"Researcher Name","outputType":"STRING"\},\{"type":"default","dimension":"status","outputName":"Researcher Status","outputType":"STRING"\},\{"type":"default","dimension":"name","outputName":"Student Name","outputType":"STRING"\},\{"type":"default","dimension":"status","outputName":"Tutor Status","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Marks Obtained","fieldName":"obtained_marks"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":400\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}""".r
-    //result should fullyMatch regex expected
+    val expected = s"""SELECT  *
+                      |      FROM (
+                      |          SELECT "Student Name", "Researcher Name", "Class Volunteer Name", "Science Lab Volunteer Name", "Tutor Name", "Section Name", "Class Name", ROWNUM AS ROW_NUMBER
+                      |              FROM(SELECT sv3.name "Student Name", r5.name "Researcher Name", cv2.name "Class Volunteer Name", slv4.name "Science Lab Volunteer Name", t6.name "Tutor Name", s1.name "Section Name", c0.name "Class Name"
+                      |                  FROM
+                      |               ( (SELECT  class_id, student_id, name, id
+                      |            FROM section
+                      |            WHERE (student_id = 213)
+                      |             ) s1
+                      |          INNER JOIN
+                      |            (SELECT  class_volunteer_id, researcher_id, name, id
+                      |            FROM student_v1
+                      |
+                      |             ) sv3
+                      |              ON( s1.student_id = sv3.id )
+                      |               INNER JOIN
+                      |            (SELECT  science_lab_volunteer_id, tutor_id, name, id
+                      |            FROM researcher
+                      |
+                      |             ) r5
+                      |              ON( sv3.researcher_id = r5.id )
+                      |               INNER JOIN
+                      |            (SELECT  name, id
+                      |            FROM tutor
+                      |
+                      |             ) t6
+                      |              ON( r5.tutor_id = t6.id )
+                      |               INNER JOIN
+                      |            (SELECT  name, id
+                      |            FROM science_lab_volunteer
+                      |
+                      |             ) slv4
+                      |              ON( r5.science_lab_volunteer_id = slv4.id )
+                      |               INNER JOIN
+                      |            (SELECT  name, id
+                      |            FROM class_volunteer
+                      |
+                      |             ) cv2
+                      |              ON( sv3.class_volunteer_id = cv2.id )
+                      |               INNER JOIN
+                      |            (SELECT  name, id
+                      |            FROM class
+                      |
+                      |             ) c0
+                      |              ON( s1.class_id = c0.id )
+                      |               )
+                      |
+                      |                  ))
+                      |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+                      |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
 }

--- a/service/src/test/scala/com/yahoo/maha/service/example/MahaServiceExampleTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/example/MahaServiceExampleTest.scala
@@ -444,7 +444,31 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+    val expected = s"""SELECT  *
+                      |      FROM (
+                      |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
+                      |              FROM(SELECT sv1.name "Student Name", r0.name "Researcher Name"
+                      |                  FROM
+                      |               ( (SELECT  researcher_id, name, id
+                      |            FROM student_v1
+                      |            WHERE (id = 213)
+                      |             ) sv1
+                      |          INNER JOIN
+                      |            (SELECT  name, id
+                      |            FROM researcher
+                      |
+                      |             ) r0
+                      |              ON( sv1.researcher_id = r0.id )
+                      |               )
+                      |
+                      |                  ))
+                      |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+                      |""".stripMargin
   }
 
   test("Test: 2 same dim level tables join, with Student Name as filter, should succeed") {
@@ -488,7 +512,36 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r0.name "Researcher Name"
+         |                  FROM
+         |               ( (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213) AND (name = 'testName1')
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 2 same dim level tables join, with Researcher Name as filter, should succeed") {
@@ -532,7 +585,36 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r0.name "Researcher Name"
+         |                  FROM
+         |               ( (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |            WHERE (name = 'testName1')
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   /*
@@ -577,7 +659,30 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv0.name "Student Name"
+         |                  FROM
+         |               ( (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (researcher_id IN (SELECT id FROM researcher WHERE (name = 'testName1'))) AND (id = 213)
+         |             ) sv0
+         |          )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 2 same dim level tables join, with Student Name as filter but not in requested field, should succeed") {
@@ -618,7 +723,36 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Researcher Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT r0.name "Researcher Name"
+         |                  FROM
+         |               ( (SELECT  researcher_id, id
+         |            FROM student_v1
+         |            WHERE (id = 213) AND (name = 'testName1')
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 2 same dim level tables join, with Student Status as filter, should succeed") {
@@ -662,7 +796,36 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r0.name "Researcher Name"
+         |                  FROM
+         |               ( (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213) AND (status = 'admitted')
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 2 same dim level tables join, with Researcher Status as filter, should succeed") {
@@ -706,7 +869,36 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r0.name "Researcher Name"
+         |                  FROM
+         |               ( (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |            WHERE (status = 'admitted')
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 2 same dim level tables join, order by Student Name, should succeed") {
@@ -751,7 +943,36 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r0.name "Researcher Name"
+         |                  FROM
+         |               ( (SELECT  name, researcher_id, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |            ORDER BY 1 ASC NULLS LAST ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   // generated query does not contain order by Researcher Name, but similar issues exist in maha-cdw too.
@@ -797,7 +1018,36 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r0.name "Researcher Name"
+         |                  FROM
+         |               ( (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   // generated query does not contain order by Reseacher Name, but similar issues exist in maha-cdw too.
@@ -847,7 +1097,36 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r0.name "Researcher Name"
+         |                  FROM
+         |               ( (SELECT  name, researcher_id, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |            ORDER BY 1 ASC NULLS LAST ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Testing same level join with four dims") {
@@ -889,8 +1168,50 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Lab Name", "Researcher Name", "Section Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", l3.name "Lab Name", r0.name "Researcher Name", s2.name "Section Name"
+         |                  FROM
+         |               ( (SELECT  lab_id, student_id, name, id
+         |            FROM section
+         |            WHERE (student_id = 213)
+         |             ) s2
+         |          INNER JOIN
+         |            (SELECT  researcher_id, name, id
+         |            FROM lab
+         |
+         |             ) l3
+         |              ON( s2.lab_id = l3.id )
+         |               INNER JOIN
+         |            (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |
+         |             ) sv1
+         |              ON( s2.student_id = sv1.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |
+         |             ) r0
+         |              ON( sv1.researcher_id = r0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
+
 
   test("Test: 3 same level dim tables join should be succeed (student, researchers, class_volunteers)") {
     val jsonString : String =
@@ -931,7 +1252,41 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", "Class Volunteer Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r2.name "Researcher Name", cv0.name "Class Volunteer Name"
+         |                  FROM
+         |               ( (SELECT  class_volunteer_id, researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM researcher
+         |
+         |             ) r2
+         |              ON( sv1.researcher_id = r2.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM class_volunteer
+         |
+         |             ) cv0
+         |              ON( sv1.class_volunteer_id = cv0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 3 same level dim tables join should be succeed (student, researchers, science_lab_volunteers)") {
@@ -973,7 +1328,41 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", "Science Lab Volunteer Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv2.name "Student Name", r1.name "Researcher Name", slv0.name "Science Lab Volunteer Name"
+         |                  FROM
+         |               ( (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) sv2
+         |          INNER JOIN
+         |            (SELECT  science_lab_volunteer_id, name, id
+         |            FROM researcher
+         |
+         |             ) r1
+         |              ON( sv2.researcher_id = r1.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM science_lab_volunteer
+         |
+         |             ) slv0
+         |              ON( r1.science_lab_volunteer_id = slv0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 3 same level dim tables join should be succeed (researchers, science_lab_volunteers, tutor)") {
@@ -1015,7 +1404,41 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"should not fail on same level join")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Researcher Name", "Science Lab Volunteer Name", "Tutor Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT r1.name "Researcher Name", slv0.name "Science Lab Volunteer Name", t2.name "Tutor Name"
+         |                  FROM
+         |               ( (SELECT  science_lab_volunteer_id, tutor_id, name, id
+         |            FROM researcher
+         |
+         |             ) r1
+         |          INNER JOIN
+         |            (SELECT  name, id
+         |            FROM tutor
+         |
+         |             ) t2
+         |              ON( r1.tutor_id = t2.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM science_lab_volunteer
+         |
+         |             ) slv0
+         |              ON( r1.science_lab_volunteer_id = slv0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 3 same level dim tables join should be succeed, with more fields, filters") {
@@ -1078,7 +1501,41 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", "Science Lab Volunteer Name", "Student Status", "Science Lab Volunteer Status", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv2.name "Student Name", r1.name "Researcher Name", slv0.name "Science Lab Volunteer Name", sv2.status "Student Status", slv0.status "Science Lab Volunteer Status"
+         |                  FROM
+         |               ( (SELECT  researcher_id, name, status, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) sv2
+         |          INNER JOIN
+         |            (SELECT  science_lab_volunteer_id, name, id
+         |            FROM researcher
+         |            WHERE (name = 'testName') AND (status = 'admitted')
+         |             ) r1
+         |              ON( sv2.researcher_id = r1.id )
+         |               INNER JOIN
+         |            (SELECT  name, status, id
+         |            FROM science_lab_volunteer
+         |            WHERE (status = 'admitted')
+         |             ) slv0
+         |              ON( r1.science_lab_volunteer_id = slv0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: 4 same level dim tables join should be succeed (student, researchers, class_volunteers, science_lab_volunteers)") {
@@ -1123,7 +1580,47 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Class Volunteer Name", "Researcher Name", "Science Lab Volunteer Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", cv0.name "Class Volunteer Name", r3.name "Researcher Name", slv2.name "Science Lab Volunteer Name"
+         |                  FROM
+         |               ( (SELECT  class_volunteer_id, researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  science_lab_volunteer_id, name, id
+         |            FROM researcher
+         |
+         |             ) r3
+         |              ON( sv1.researcher_id = r3.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM science_lab_volunteer
+         |
+         |             ) slv2
+         |              ON( r3.science_lab_volunteer_id = slv2.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM class_volunteer
+         |
+         |             ) cv0
+         |              ON( sv1.class_volunteer_id = cv0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   // sometimes failed, because of random order between science lab volunteer and class volunteer
@@ -1172,7 +1669,53 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT  *
+         |      FROM (
+         |          SELECT "Student Name", "Researcher Name", "Class Volunteer Name", "Science Lab Volunteer Name", "Tutor Name", ROWNUM AS ROW_NUMBER
+         |              FROM(SELECT sv1.name "Student Name", r3.name "Researcher Name", cv0.name "Class Volunteer Name", slv2.name "Science Lab Volunteer Name", t4.name "Tutor Name"
+         |                  FROM
+         |               ( (SELECT  class_volunteer_id, researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) sv1
+         |          INNER JOIN
+         |            (SELECT  science_lab_volunteer_id, tutor_id, name, id
+         |            FROM researcher
+         |
+         |             ) r3
+         |              ON( sv1.researcher_id = r3.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM tutor
+         |
+         |             ) t4
+         |              ON( r3.tutor_id = t4.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM science_lab_volunteer
+         |
+         |             ) slv2
+         |              ON( r3.science_lab_volunteer_id = slv2.id )
+         |               INNER JOIN
+         |            (SELECT  name, id
+         |            FROM class_volunteer
+         |
+         |             ) cv0
+         |              ON( sv1.class_volunteer_id = cv0.id )
+         |               )
+         |
+         |                  ))
+         |                   WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200
+         |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: fact table join with 2 same dim level tables should succeed") {
@@ -1216,7 +1759,39 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT *
+         |FROM (SELECT sv2.name "Student Name", r1.name "Researcher Name", r1.status "Researcher Status", sp0."total_marks" "Total Marks"
+         |      FROM (SELECT
+         |                   student_id, researcher_id, SUM(total_marks) AS "total_marks"
+         |            FROM student_performance FactAlias
+         |            WHERE (date >= trunc(to_date('$fromDate', 'YYYY-MM-DD')) AND date <= trunc(to_date('$toDate', 'YYYY-MM-DD')))
+         |            GROUP BY student_id, researcher_id
+         |
+         |           ) sp0
+         |           LEFT OUTER JOIN
+         |               ( (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) WHERE ROWNUM <= 200) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200) sv2
+         |          LEFT OUTER JOIN
+         |            (SELECT  name, status, id
+         |            FROM researcher
+         |
+         |             ) r1
+         |              ON( sv2.researcher_id = r1.id )
+         |               )  ON (sp0.student_id = sv2.id)
+         |
+         |)
+         |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: fact table join with 2 same dim level tables, with filter from the 3rd same dim level table should succeed") {
@@ -1265,7 +1840,45 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
     assert(res.isSuccess, s"Building request model failed.")
 
     val queryPipelineTry = generatePipeline(res.toOption.get)
-    assert(queryPipelineTry.isFailure, queryPipelineTry.errorMessage("Same dim level join should be failed"))
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT *
+         |FROM (SELECT sv3.name "Student Name", r2.name "Researcher Name", r2.status "Researcher Status", sp0."total_marks" "Total Marks"
+         |      FROM (SELECT
+         |                   tutor_id, student_id, researcher_id, SUM(total_marks) AS "total_marks"
+         |            FROM student_performance FactAlias
+         |            WHERE (date >= trunc(to_date('$fromDate', 'YYYY-MM-DD')) AND date <= trunc(to_date('$toDate', 'YYYY-MM-DD')))
+         |            GROUP BY tutor_id, student_id, researcher_id
+         |
+         |           ) sp0
+         |           INNER JOIN
+         |               ( (SELECT * FROM (SELECT D.*, ROWNUM AS ROW_NUMBER FROM (SELECT * FROM (SELECT  researcher_id, name, id
+         |            FROM student_v1
+         |            WHERE (id = 213)
+         |             ) WHERE ROWNUM <= 200) D ) WHERE ROW_NUMBER >= 1 AND ROW_NUMBER <= 200) sv3
+         |          INNER JOIN
+         |            (SELECT  tutor_id, name, status, id
+         |            FROM researcher
+         |
+         |             ) r2
+         |              ON( sv3.researcher_id = r2.id )
+         |               INNER JOIN
+         |            (SELECT  id
+         |            FROM tutor
+         |            WHERE (status = 'admitted')
+         |             ) t1
+         |              ON( r2.tutor_id = t1.id )
+         |               )  ON (sp0.student_id = sv3.id)
+         |
+         |)
+         |""".stripMargin
+    result should equal(expected)(after being whiteSpaceNormalised)
   }
 
   test("Test: fact table join with 2 same dim level tables in Hive should succeed") {
@@ -1318,12 +1931,13 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
 
     val expected =
       s"""
          |SELECT CONCAT_WS(",",NVL(CAST(mang_student_name AS STRING), ''), NVL(CAST(mang_researcher_name AS STRING), ''), NVL(CAST(mang_researcher_status AS STRING), ''), NVL(CAST(mang_marks_obtained AS STRING), ''))
          |FROM(
-         |SELECT COALESCE(s2.mang_student_name, "NA") mang_student_name, COALESCE(r1.mang_researcher_name, "NA") mang_researcher_name, COALESCE(r1.mang_researcher_status, "NA") mang_researcher_status, COALESCE(obtained_marks, 0L) mang_marks_obtained
+         |SELECT COALESCE(s3.mang_student_name, "NA") mang_student_name, COALESCE(r2.mang_researcher_name, "NA") mang_researcher_name, COALESCE(r2.mang_researcher_status, "NA") mang_researcher_status, COALESCE(obtained_marks, 0L) mang_marks_obtained
          |FROM(SELECT tutor_id, student_id, researcher_id, SUM(obtained_marks) obtained_marks
          |FROM hive_student_performance
          |WHERE (student_id = 213) AND (date >= '$fromDateHive' AND date <= '$toDateHive')
@@ -1332,29 +1946,29 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
          |       )
          |hsp0
          |JOIN (
-         |SELECT tutor_id AS t3_id, name AS mang_researcher_name, status AS mang_researcher_status, id r1_id
-         |FROM hive_researcher
-         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ))
-         |)
-         |r1
-         |ON
-         |hsp0.researcher_id = r1.r1_id
-         |       JOIN (
-         |SELECT researcher_id AS researcher_id, name AS mang_student_name, id s2_id
-         |FROM hive_student_v1
-         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' )) AND (id = 213)
-         |)
-         |s2
-         |ON
-         |hsp0.student_id = s2.s2_id
-         |       JOIN (
-         |SELECT id t3_id
+         |SELECT id t1_id
          |FROM hive_tutor
          |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' )) AND (status = 'admitted')
          |)
-         |t3
+         |t1
          |ON
-         |hsp0.tutor_id = t3.t3_id
+         |hsp0.tutor_id = t1.t1_id
+         |       JOIN (
+         |SELECT tutor_id AS tutor_id, name AS mang_researcher_name, status AS mang_researcher_status, id r2_id
+         |FROM hive_researcher
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ))
+         |)
+         |r2
+         |ON
+         |hsp0.researcher_id = r2.r2_id
+         |       JOIN (
+         |SELECT researcher_id AS researcher_id, name AS mang_student_name, id s3_id
+         |FROM hive_student_v1
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' )) AND (id = 213)
+         |)
+         |s3
+         |ON
+         |hsp0.student_id = s3.s3_id
          |
          |)
          |        queryAlias LIMIT 200
@@ -1412,12 +2026,13 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
 
     val expected =
       s"""
          |SELECT CAST(mang_student_name as VARCHAR) AS mang_student_name, CAST(mang_researcher_name as VARCHAR) AS mang_researcher_name, CAST(mang_researcher_status as VARCHAR) AS mang_researcher_status, CAST(mang_marks_obtained as VARCHAR) AS mang_marks_obtained
          |FROM(
-         |SELECT COALESCE(CAST(s2.mang_student_name as VARCHAR), 'NA') mang_student_name, COALESCE(CAST(r1.mang_researcher_name as VARCHAR), 'NA') mang_researcher_name, COALESCE(CAST(r1.mang_researcher_status as VARCHAR), 'NA') mang_researcher_status, COALESCE(CAST(obtained_marks as bigint), 0) mang_marks_obtained
+         |SELECT COALESCE(CAST(s3.mang_student_name as VARCHAR), 'NA') mang_student_name, COALESCE(CAST(r2.mang_researcher_name as VARCHAR), 'NA') mang_researcher_name, COALESCE(CAST(r2.mang_researcher_status as VARCHAR), 'NA') mang_researcher_status, COALESCE(CAST(obtained_marks as bigint), 0) mang_marks_obtained
          |FROM(SELECT tutor_id, student_id, researcher_id, SUM(obtained_marks) obtained_marks
          |FROM presto_student_performance
          |WHERE (student_id = 213) AND (date >= '$fromDateHive' AND date <= '$toDateHive')
@@ -1426,29 +2041,29 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
          |       )
          |psp0
          |JOIN (
-         |SELECT tutor_id AS t3_id, name AS mang_researcher_name, status AS mang_researcher_status, id r1_id
-         |FROM presto_researcher
-         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ))
-         |)
-         |r1
-         |ON
-         |psp0.researcher_id = r1.r1_id
-         |       JOIN (
-         |SELECT researcher_id AS researcher_id, name AS mang_student_name, id s2_id
-         |FROM presto_student_v1
-         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' )) AND (id = 213)
-         |)
-         |s2
-         |ON
-         |psp0.student_id = s2.s2_id
-         |       JOIN (
-         |SELECT id t3_id
+         |SELECT id t1_id
          |FROM presto_tutor
          |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' )) AND (status = 'admitted')
          |)
-         |t3
+         |t1
          |ON
-         |psp0.tutor_id = t3.t3_id
+         |psp0.tutor_id = t1.t1_id
+         |       JOIN (
+         |SELECT tutor_id AS tutor_id, name AS mang_researcher_name, status AS mang_researcher_status, id r2_id
+         |FROM presto_researcher
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ))
+         |)
+         |r2
+         |ON
+         |psp0.researcher_id = r2.r2_id
+         |       JOIN (
+         |SELECT researcher_id AS researcher_id, name AS mang_student_name, id s3_id
+         |FROM presto_student_v1
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' )) AND (id = 213)
+         |)
+         |s3
+         |ON
+         |psp0.student_id = s3.s3_id
          |
          |
          |          )
@@ -1507,10 +2122,70 @@ class RequestModelSameDimLevelJoinTest extends BaseOracleQueryGeneratorTest {
 
     val queryPipeline = queryPipelineTry.toOption.get
     val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
 
     val expected = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"dr_student_performance"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\}\]\},\{"type":"selector","dimension":"student_id","value":"213"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"name","outputName":"Researcher Name","outputType":"STRING"\},\{"type":"default","dimension":"status","outputName":"Researcher Status","outputType":"STRING"\},\{"type":"default","dimension":"name","outputName":"Student Name","outputType":"STRING"\},\{"type":"default","dimension":"status","outputName":"Tutor Status","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Marks Obtained","fieldName":"obtained_marks"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":400\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}""".r
     result should fullyMatch regex expected
   }
 
-}
+  test("Test") {
+    val jsonString =
+      s"""
+         |{
+         |    "cube": "student_performance",
+         |    "isDimDriven": true,
+         |    "selectFields": [
+         |        {
+         |            "field": "Student Name"
+         |        },
+         |        {
+         |            "field": "Researcher Name"
+         |        },
+         |        {
+         |            "field": "Class Volunteer Name"
+         |        },
+         |        {
+         |            "field": "Science Lab Volunteer Name"
+         |        },
+         |        {
+         |            "field": "Tutor Name"
+         |        },
+         |        {
+         |            "field": "Section Name"
+         |        },
+         |        {
+         |            "field": "Class Name"
+         |        }
+         |    ],
+         |    "filterExpressions": [
+         |        {
+         |            "field": "Day",
+         |            "operator": "between",
+         |            "from": "$fromDate",
+         |            "to": "$toDate"
+         |        },
+         |        {
+         |            "field": "Student ID",
+         |            "operator": "=",
+         |            "value": "213"
+         |        }
+         |    ]
+         |}
+         |""".stripMargin
+    val request: ReportingRequest = ReportingRequest.forceDruid(getReportingRequestSync(jsonString, StudentSchema))
+    val registry = exampleRegistry
+    val res = getRequestModel(request, registry, revision = Some(3))
+    assert(res.isSuccess, s"Building request model failed.")
 
+    val queryPipelineTry = generatePipeline(res.toOption.get)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val queryPipeline = queryPipelineTry.toOption.get
+    val result = queryPipeline.queryChain.drivingQuery.asString
+    println(result)
+
+    //val expected = """\{"queryType":"groupBy","dataSource":\{"type":"table","name":"dr_student_performance"\},"intervals":\{"type":"intervals","intervals":\[".*"\]\},"virtualColumns":\[\],"filter":\{"type":"and","fields":\[\{"type":"or","fields":\[\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\},\{"type":"selector","dimension":"date","value":".*"\}\]\},\{"type":"selector","dimension":"student_id","value":"213"\}\]\},"granularity":\{"type":"all"\},"dimensions":\[\{"type":"default","dimension":"name","outputName":"Researcher Name","outputType":"STRING"\},\{"type":"default","dimension":"status","outputName":"Researcher Status","outputType":"STRING"\},\{"type":"default","dimension":"name","outputName":"Student Name","outputType":"STRING"\},\{"type":"default","dimension":"status","outputName":"Tutor Status","outputType":"STRING"\}\],"aggregations":\[\{"type":"longSum","name":"Marks Obtained","fieldName":"obtained_marks"\}\],"postAggregations":\[\],"limitSpec":\{"type":"default","columns":\[\],"limit":400\},"context":\{"applyLimitPushDown":"false","uncoveredIntervalsLimit":1,"groupByIsSingleThreaded":true,"timeout":5000,"queryId":".*"\},"descending":false\}""".r
+    //result should fullyMatch regex expected
+  }
+
+}


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

**Motivation**: Currently maha does not support joins between dimensions on same dimLevel. This PR includes code that will allow such joins.

**Change**: Dimensions on same dimLevel will be assigned secondaryDimLevel(default = 0) based on the foreign keys they have.

**Dimension Ordering before change**:
`Ordering.by(d => s"${d.dim.dimLevel.level}-${dc.dim.name}")`

**Dimension Ordering after change**:
`Ordering.by(d => s"${d.dim.dimLevel.level}-${d.dim.secondaryDimLevel}-${dc.dim.name}")`

```

For eg., 

Foreign Keys:   
researcher -> science_lab_volunteer             
student -> class_volunteer, researcher
section -> class, remarks, student

**Order before this change**:

dimLevel:                                 1,              2,         2,                 2,            2,        2,      3 
                                        (class, class_volunteer, researcher, science_lab_volunteer, student, tutor, section)

**Order after this change**:              

dimLevel:                                  1,            2,                   2,         2,      2,          2,        3 
                                        (class, class_volunteer, science_lab_volunteer, tutor, researcher, student, section )
secondaryDimLevel:                         0,            0,                   0,         0,      1,          2,        0

```


