### PR TITLE
startIndex/maxRow support for mahaCalcite

### DIFF
--- a/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
@@ -244,15 +244,13 @@ class DefaultMahaAvaticaService(executeFunction: (MahaRequestContext, MahaServic
     }
 
     def getRegistryForFact(cube: String): Registry = {
-        mahaService.getMahaServiceConfig.registry.values.foreach {
-            registryConfig =>
-                val factOption: Option[PublicFact] = registryConfig.registry.getFact(cube)
-                if(factOption.isDefined) {
-                    return registryConfig.registry
-                }
-        }
-        //should not reach here
-        return null
+        val registryOption = mahaService.getMahaServiceConfig.registry
+          .map(rc => rc._2.registry -> rc._2.registry.getFact(cube))
+          .filter(entry => entry._2.isDefined)
+          .map(entry => entry._1)
+          .headOption
+        require(registryOption.isDefined, s"Failed to find the registry for ${cube}")
+        registryOption.get
     }
 
     def execute(avaticaContext: AvaticaContext) : ExecuteResponse = {


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Change SQLConformance setting from Default to LENIENT to allow the SQL syntax "LIMIT start, count".
```
val config = SqlParser.config().withConformance(SqlConformanceEnum.LENIENT)
val parser: SqlParser = SqlParser.create(sql, config)
```

Without this conformance change it will throw the following exception:
```
'LIMIT start, count' is not allowed under the current SQL conformance level
```
References:
https://calcite.apache.org/javadocAggregate/org/apache/calcite/sql/validate/SqlConformance.html#isLimitStartCountAllowed()
https://calcite.apache.org/javadocAggregate/org/apache/calcite/sql/validate/SqlConformanceEnum.html#LENIENT