### PR TITLE
Fix flaky CSVRowList and JsonRowList tests

### DIFF
--- a/core/src/test/scala/com/yahoo/maha/core/query/CSVRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/CSVRowListTest.scala
@@ -249,16 +249,14 @@ class CSVRowListTest extends BaseOracleQueryGeneratorTest with BaseRowListTest {
   }
 
   test("fail to construct file csv row list with no write perm") {
-    val tmpFile= new File("/blah")
-    if (!tmpFile.exists()) {
-      val rowListWithHeaders : CSVRowList = new CSVRowList(query, FileRowCSVWriterProvider(tmpFile), true)
-      val thrown = intercept[FileNotFoundException] {
-        rowListWithHeaders.withLifeCycle {
+    val tmpFile= new File("/dummy/dir")
+    val rowListWithHeaders : CSVRowList = new CSVRowList(query, FileRowCSVWriterProvider(tmpFile), true)
+    val thrown = intercept[FileNotFoundException] {
+      rowListWithHeaders.withLifeCycle {
 
-        }
       }
-      assert(thrown.getMessage === "/blah (Permission denied)" || thrown.getMessage === "/blah (Read-only file system)")
     }
+    assert(thrown.getMessage === "/dummy/dir (No such file or directory)")
   }
 
   test("Error case, no alias") {

--- a/core/src/test/scala/com/yahoo/maha/report/JsonRowListTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/report/JsonRowListTest.scala
@@ -390,16 +390,14 @@ class JsonRowListTest extends AnyFunSuite with BaseQueryGeneratorTest with Share
     assert(jsonString === """{"header":{"cube":"k_stats","fields":[{"fieldName":"campaign_id","fieldType":"DIM"},{"fieldName":"Impressions","fieldType":"FACT"},{"fieldName":"Campaign Name","fieldType":"DIM"},{"fieldName":"Campaign Status","fieldType":"DIM"},{"fieldName":"CTR","fieldType":"FACT"},{"fieldName":"TotalRows","fieldType":"CONSTANT"}],"maxRows":100},"rows":[[1,2,"\"name\"","o,n",1.11,1]],"debug":{"fields":[{"fieldName":"Campaign ID","dataType":"Number"},{"fieldName":"Campaign Status","dataType":"String"},{"fieldName":"Impressions","dataType":"Number"},{"fieldName":"Campaign Name","dataType":"String"},{"fieldName":"CTR","dataType":"Number"},{"fieldName":"TOTALROWS","dataType":"Number"},{"fieldName":"TotalRows","dataType":"integer"}],"drivingQuery":{"tableName":"campaign_oracle","engine":"Oracle"}}}""")
   }
   test("fail to construct file json row list with no write perm") {
-    val tmpFile= new File("/blah")
-    if (!tmpFile.exists()) {
-      val jsonRowList : RowList = FileJsonRowList.fileJsonRowList(tmpFile, None, false)(query)
-      val thrown = intercept[FileNotFoundException]{
-        jsonRowList.withLifeCycle {
+    val tmpFile= new File("/dummy/dir")
+    val jsonRowList : RowList = FileJsonRowList.fileJsonRowList(tmpFile, None, false)(query)
+    val thrown = intercept[FileNotFoundException]{
+      jsonRowList.withLifeCycle {
 
-        }
       }
-      assert(thrown.getMessage === "/blah (Permission denied)" || thrown.getMessage === "/blah (Read-only file system)")
     }
+    assert(thrown.getMessage === "/dummy/dir (No such file or directory)")
   }
 
   override protected[this] def registerFacts(forcedFilters: Set[ForcedFilter], registryBuilder: RegistryBuilder): Unit = {


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Since build is running as root, `/blah` is being created without any permission issues. To bypass file creation, if we specify a parent directory that does not exist then the file is not created.