### PR TITLE
Make deploy properly fail, currently print which step failed first.

### DIFF
--- a/screwdriver/publish_to_maven.sh
+++ b/screwdriver/publish_to_maven.sh
@@ -16,7 +16,7 @@ ls -l screwdriver/deploy
 error_exit()
 {
 	echo "Error, step failed to deploy: $1"
-	exit 1
+	exit 0
 }
 
 

--- a/screwdriver/publish_to_maven.sh
+++ b/screwdriver/publish_to_maven.sh
@@ -12,7 +12,7 @@ gpg --batch --import screwdriver/deploy/sec.key
 
 ls -l screwdriver/deploy
 
-# Print deploy failure step, exit with failure.
+# Print deploy failure step, exit without thrown failure.
 error_exit()
 {
 	echo "Error, step failed to deploy: $1"

--- a/screwdriver/publish_to_maven.sh
+++ b/screwdriver/publish_to_maven.sh
@@ -12,20 +12,28 @@ gpg --batch --import screwdriver/deploy/sec.key
 
 ls -l screwdriver/deploy
 
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-parent --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-db --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-druid-lookups --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-par-request-2 --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dscoverage.skip=true -Darguments="-Dscoverage.skip=true" --projects com.yahoo.maha:maha-core --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-bigquery-executor --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-request-log --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-job-service --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-druid-executor --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-oracle-executor --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-presto-executor --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-postgres-executor --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-service --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-worker --settings screwdriver/maven-settings.xml
-mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-api-jersey --settings screwdriver/maven-settings.xml
+# Print deploy failure step, exit with failure.
+error_exit()
+{
+	echo "Error, step failed to deploy: $1"
+	exit 1
+}
+
+
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-parent --settings screwdriver/maven-settings.xml || error_exit "maha-parent"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-db --settings screwdriver/maven-settings.xml || error_exit "maha-db"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-druid-lookups --settings screwdriver/maven-settings.xml || error_exit "maha-druid-lookups"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-par-request-2 --settings screwdriver/maven-settings.xml || error_exit "maha-par-request-2"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dscoverage.skip=true -Darguments="-Dscoverage.skip=true" --projects com.yahoo.maha:maha-core --settings screwdriver/maven-settings.xml || error_exit "maha-core"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-bigquery-executor --settings screwdriver/maven-settings.xml || error_exit "maha-bigquery-executor"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-request-log --settings screwdriver/maven-settings.xml || error_exit "maha-request-log"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-job-service --settings screwdriver/maven-settings.xml || error_exit "maha-maha-job-service"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-druid-executor --settings screwdriver/maven-settings.xml || error_exit "maha-druid-executor"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-oracle-executor --settings screwdriver/maven-settings.xml || error_exit "maha-oracle-executor"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-presto-executor --settings screwdriver/maven-settings.xml || error_exit "maha-presto-executor"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-postgres-executor --settings screwdriver/maven-settings.xml || error_exit "maha-postgres-executor"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-service --settings screwdriver/maven-settings.xml || error_exit "maha-service"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-worker --settings screwdriver/maven-settings.xml || error_exit "maha-worker"
+mvn deploy -Dgpg.passphrase=${PASS_PHRASE} -Dgpg.skip=false -Dmaven.test.skip=true -Dscoverage.skip=true -DskipTests -Darguments="-DskipTests -Dscoverage.skip=true" --projects com.yahoo.maha:maha-api-jersey --settings screwdriver/maven-settings.xml || error_exit "maha-api-jersey"
 
 rm -rf screwdriver/deploy


### PR DESCRIPTION
Currently, publish fails when versions haven't been upgraded.

Two options:
- Keep the failure, update the output message on this deploy.
- Print the failure, exit immediately without publishing any further.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
