### PR TITLE
Table Aliasing

### DIFF
--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -140,7 +140,16 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
   }
 
   def getFromTableAndTableSchema(sqlNode: SqlNode): (String, Option[String]) = {
-    sqlNode match {
+    var sqlFromNode = sqlNode
+    sqlFromNode match {
+      case sqlBasicCall: SqlBasicCall =>
+        sqlBasicCall.getOperator.kind match {
+          case SqlKind.AS =>
+            sqlFromNode = sqlBasicCall.getOperands() (0)
+      }
+      case _ => logger.debug("From sqlNode is not an sqlBasicCall type")
+    }
+    sqlFromNode match {
       case sqlIdentifier: SqlIdentifier =>
         val fromTableAndTableSchema = sqlIdentifier.names
         if (fromTableAndTableSchema.size == 1)

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -140,14 +140,13 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
   }
 
   def getFromTableAndTableSchema(sqlNode: SqlNode): (String, Option[String]) = {
-    var sqlFromNode = sqlNode
-    sqlFromNode match {
+    val sqlFromNode = sqlNode match {
       case sqlBasicCall: SqlBasicCall =>
         sqlBasicCall.getOperator.kind match {
-          case SqlKind.AS =>
-            sqlFromNode = sqlBasicCall.getOperands() (0)
-      }
-      case _ => logger.debug("From sqlNode is not an sqlBasicCall type")
+          case SqlKind.AS => sqlBasicCall.getOperands()(0)
+          case _ => sqlNode
+        }
+      case _ => sqlNode
     }
     sqlFromNode match {
       case sqlIdentifier: SqlIdentifier =>

--- a/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
@@ -558,4 +558,17 @@ class DefaultMahaCalciteSqlParserTest extends BaseMahaServiceTest with Matchers 
 
     assert(request.filterExpressions.toString contains "NotInFilter(Student ID,List(123, 1234),false,false)")
   }
+
+  test("test table aliasing") {
+    val sql = s"""
+              select * from "maha"."student_performance" as sp where 'Student ID' = 123
+              """
+    val mahaSqlNode: MahaSqlNode = defaultMahaCalciteSqlParser.parse(sql, StudentSchema, "er")
+    assert(mahaSqlNode.isInstanceOf[SelectSqlNode])
+    val request = mahaSqlNode.asInstanceOf[SelectSqlNode].reportingRequest
+    assert(request.cube == "student_performance")
+    assert(request.filterExpressions.toString contains "EqualityFilter(Student ID,123,false,false)")
+    assert(request.cube contains "student_performance")
+    request.toString shouldNot contain ("sp")
+    }
 }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Adding functionality to ignore table alias in calcite parser instead of throwing an error.