### PR TITLE
[maha SQL] fix column metadata type

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.71-SNAPSHOT</version>
+    <version>6.72-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
@@ -220,7 +220,11 @@ class DefaultMahaAvaticaService(executeFunction: (MahaRequestContext, MahaServic
         val cursorFactory = CursorFactory.create(Style.LIST, classOf[String], util.Arrays.asList())
         columnMetaArray.zipWithIndex.foreach {
             case (columnName, index) => {
-                columns.add(MetaImpl.columnMetaData(columnName, index, classOf[String], true))
+                columnMetaTypeMap.getOrElse(columnName, None) match {
+                    case "Int" => columns.add(MetaImpl.columnMetaData(columnName, index, classOf[Int], true))
+                    case "String" => columns.add(MetaImpl.columnMetaData(columnName, index, classOf[String], true))
+                    case _ => columns.add(MetaImpl.columnMetaData(columnName, index, classOf[String], true))
+                }
             }
         }
         val signature: Signature = Signature.create(columns, "", params, cursorFactory, StatementType.SELECT)
@@ -458,6 +462,32 @@ object MahaAvaticaServiceHelper extends Logging {
     val REF_GENERATION = StringUtils.EMPTY
 
     val columnMetaArray: Array[String] = Array("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE", "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS", "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE", "SCOPE_CATALOG", "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE", "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN")
+    val columnMetaTypeMap: Map[String, String] = Map(
+        "TABLE_CAT" -> "String",
+        "TABLE_SCHEM" -> "String",
+        "TABLE_NAME" -> "String",
+        "COLUMN_NAME" -> "String",
+        "DATA_TYPE" -> "Int",
+        "TYPE_NAME" -> "String",
+        "COLUMN_SIZE" -> "Int",
+        "BUFFER_LENGTH" -> "String",
+        "DECIMAL_DIGITS" -> "Int",
+        "NUM_PREC_RADIX" -> "String",
+        "NULLABLE" -> "Int",
+        "REMARKS" -> "String",
+        "COLUMN_DEF" -> "String",
+        "SQL_DATA_TYPE" -> "String",
+        "SQL_DATETIME_SUB" -> "String",
+        "CHAR_OCTET_LENGTH" -> "String",
+        "ORDINAL_POSITION" -> "String",
+        "IS_NULLABLE" -> "String",
+        "SCOPE_CATALOG" -> "String",
+        "SCOPE_SCHEMA" -> "String",
+        "SCOPE_TABLE" -> "String",
+        "SOURCE_DATA_TYPE" -> "String",
+        "IS_AUTOINCREMENT" -> "String",
+        "IS_GENERATEDCOLUMN" -> "String"
+    )
     val COLUMN_SIZE = 20
     val BUFFER_LENGTH = 10 //unused
     val NUM_PREC_RADIX = 10

--- a/service/src/test/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaServiceTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaServiceTest.scala
@@ -2,6 +2,7 @@ package com.yahoo.maha.service.calcite.avatica
 
 import com.google.common.collect.Maps
 import com.yahoo.maha.core.bucketing.{BucketParams, UserInfo}
+import com.yahoo.maha.core.helper.jdbc.ColumnMetadata
 import com.yahoo.maha.core.query.{CompleteRowList, QueryAttributes, QueryRowList}
 import com.yahoo.maha.core.request.ReportingRequest
 import com.yahoo.maha.service.calcite.DefaultMahaCalciteSqlParser
@@ -9,6 +10,7 @@ import com.yahoo.maha.service.example.ExampleSchema
 import com.yahoo.maha.service.example.ExampleSchema.StudentSchema
 import com.yahoo.maha.service.utils.MahaRequestLogHelper
 import com.yahoo.maha.service.{BaseMahaServiceTest, MahaRequestContext, MahaService, RegistryConfig}
+import org.apache.calcite.avatica.ColumnMetaData
 import org.apache.calcite.avatica.proto.Requests.TablesRequest
 import org.apache.calcite.avatica.remote.Service
 import org.apache.calcite.avatica.remote.Service.{FetchRequest, OpenConnectionRequest, PrepareAndExecuteRequest}
@@ -177,6 +179,13 @@ class MahaAvaticaServiceTest extends BaseMahaServiceTest {
     val result =  mahaAvaticaService(new Service.ColumnsRequest(connectionID, "", "", "student_performance", null))
     //println(result)
     assert(result != null && result.signature != null && result.firstFrame != null)
+    val columnsMetaDataList = result.signature.columns
+
+    assert(columnsMetaDataList.get(4).`type`.name.equals("INTEGER")) //DATA_TYPE
+    assert(columnsMetaDataList.get(6).`type`.name.equals("INTEGER")) //COLUMN_SIZE
+    assert(columnsMetaDataList.get(8).`type`.name.equals("INTEGER")) //DECIMAL_DIGITS
+    assert(columnsMetaDataList.get(10).`type`.name.equals("INTEGER")) //NULLABLE
+
     val rows = result.firstFrame.rows
     var count = 0
     rows.iterator().forEachRemaining(s=> {

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.71-SNAPSHOT</version>
+        <version>6.72-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
fix for the casting error
```
Caused by: java.sql.SQLDataException: cannot convert to long (org.apache.calcite.avatica.util.AbstractCursor$StringAccessor@72ac5466)
	at org.apache.calcite.avatica.util.AbstractCursor$AccessorImpl.cannotConvert(AbstractCursor.java:363)
	at org.apache.calcite.avatica.util.AbstractCursor$AccessorImpl.getLong(AbstractCursor.java:319)
	at org.apache.calcite.avatica.util.AbstractCursor$AccessorImpl.getInt(AbstractCursor.java:315)
	at org.apache.calcite.avatica.AvaticaResultSet.getInt(AvaticaResultSet.java:255)
	at org.apache.calcite.adapter.jdbc.JdbcSchema.getRelDataType(JdbcSchema.java:315)
	at org.apache.calcite.adapter.jdbc.JdbcSchema.getRelDataType(JdbcSchema.java:296)
	at org.apache.calcite.adapter.jdbc.JdbcTable.getRowType(JdbcTable.java:108)
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.