### PR TITLE
SQL fix for translating maha lookup expression

### DIFF
--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
@@ -53,8 +53,10 @@ public class MahaLookupExprMacro implements ExprMacroTable.ExprMacro
         String columnStr = (String) columnExpr.getLiteralValue();
         final Expr missingValueExpr = args.get(3);
         String missingValueStr = (String) missingValueExpr.getLiteralValue();
-        final String secondaryColOverrideMapStr = args.size() >= 5? (String) args.get(4).getLiteralValue(): "";
-        final String dimensionOverrideMapStr = args.size() >= 6? (String) args.get(5).getLiteralValue(): "";
+        final Expr secondaryColOverrideMapExpr = args.size() >= 5? args.get(4): null;
+        final String secondaryColOverrideMapStr = secondaryColOverrideMapExpr != null ? (String) secondaryColOverrideMapExpr.getLiteralValue(): null;
+        final Expr dimensionOverrideMapStrExpr = args.size() >= 6? args.get(5): null;
+        final String dimensionOverrideMapStr = dimensionOverrideMapStrExpr != null ? (String) dimensionOverrideMapStrExpr.getLiteralValue(): null;
 
         //valueMap
         Map<String, String> secondaryColOverrideMap = secondaryColOverrideMapStr!= null && !secondaryColOverrideMapStr.isEmpty() ?
@@ -117,7 +119,19 @@ public class MahaLookupExprMacro implements ExprMacroTable.ExprMacro
             @Override
             public String stringify()
             {
-                return StringUtils.format("%s(%s, %s, %s, %s, %s, %s)", FN_NAME, arg.stringify(), lookupExpr.stringify(), columnStr, secondaryColOverrideMapStr, dimensionOverrideMapStr);
+                StringBuilder sb = new StringBuilder();
+                sb.append(FN_NAME + "(");
+                sb.append(StringUtils.format("%s, %s, %s, %s", arg.stringify(), lookupExpr.stringify(), columnExpr.stringify(), missingValueExpr.stringify()));
+                if(args.size() >= 5) {
+                    sb.append(", " + secondaryColOverrideMapExpr.stringify());
+                }
+
+                if(args.size() >= 6) {
+                    sb.append(", " + dimensionOverrideMapStrExpr.stringify());
+                }
+
+                sb.append(")");
+                return sb.toString();
             }
         }
 

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
@@ -3,7 +3,6 @@ package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace;
 import com.google.common.base.Splitter;
 import com.google.inject.Inject;
 import com.yahoo.maha.maha_druid_lookups.query.lookup.MahaRegisteredLookupExtractionFn;
-import com.yahoo.maha.maha_druid_lookups.query.lookup.util.LookupUtil;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -14,12 +13,9 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExprType;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.LookupReferencesManager;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,8 +25,6 @@ public class MahaLookupExprMacro implements ExprMacroTable.ExprMacro
     private static final Logger LOG = new Logger(MahaLookupExprMacro.class);
     private static final String FN_NAME = "maha_lookup";
     private final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider;
-    private static final LookupUtil util = new LookupUtil();
-    private static final List<String> REPL_LIST = Arrays.asList("", null);
     private static final String SEPARATOR = ",";
     private static final String KV_DEFAULT = "->";
 
@@ -49,9 +43,8 @@ public class MahaLookupExprMacro implements ExprMacroTable.ExprMacro
     @Override
     public Expr apply(final List<Expr> args)
     {
-
-        if (args.size() != 4) {
-            throw new IAE("Function[%s] must have 4 arguments", name());
+        if (args.size() < 4) {
+            throw new IAE("Function[%s] must have at least 4 arguments", name());
         }
 
         final Expr arg = args.get(0);
@@ -60,15 +53,16 @@ public class MahaLookupExprMacro implements ExprMacroTable.ExprMacro
         String columnStr = (String) columnExpr.getLiteralValue();
         final Expr missingValueExpr = args.get(3);
         String missingValueStr = (String) missingValueExpr.getLiteralValue();
-
         final String secondaryColOverrideMapStr = args.size() >= 5? (String) args.get(4).getLiteralValue(): "";
         final String dimensionOverrideMapStr = args.size() >= 6? (String) args.get(5).getLiteralValue(): "";
 
-        Map<String, String> secondaryColOverrideMap = !secondaryColOverrideMapStr.isEmpty() ?
+        //valueMap
+        Map<String, String> secondaryColOverrideMap = secondaryColOverrideMapStr!= null && !secondaryColOverrideMapStr.isEmpty() ?
                 new HashMap<>(Splitter.on(SEPARATOR).withKeyValueSeparator(KV_DEFAULT).split(secondaryColOverrideMapStr)) :
                 null;
 
-        Map<String, String> dimensionOverrideMap = !dimensionOverrideMapStr.isEmpty() ?
+        //keyMap
+        Map<String, String> dimensionOverrideMap = dimensionOverrideMapStr != null && !dimensionOverrideMapStr.isEmpty() ?
                 new HashMap<>(Splitter.on(SEPARATOR).withKeyValueSeparator(KV_DEFAULT).split(dimensionOverrideMapStr)) :
                 null;
 
@@ -90,7 +84,7 @@ public class MahaLookupExprMacro implements ExprMacroTable.ExprMacro
                 dimensionOverrideMap,
                 secondaryColOverrideMap,
                 false);
-        LOG.error("Macro: valid call to Maha_lookup: lookupName = " + lookupName + ", columnName = " + columnStr + ", arg = " + arg);
+        LOG.debug("MahaMacro: valid call: lookupName = " + lookupName + ", columnName = " + columnStr + ", arg = " + arg);
 
         class MahaLookupExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
         {

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
@@ -123,49 +123,10 @@ public class MahaLookupExprMacro implements ExprMacroTable.ExprMacro
             @Override
             public String stringify()
             {
-                return StringUtils.format("%s(%s, %s, %s, %s)", FN_NAME, arg.stringify(), lookupExpr.stringify(), columnStr);
+                return StringUtils.format("%s(%s, %s, %s, %s, %s, %s)", FN_NAME, arg.stringify(), lookupExpr.stringify(), columnStr, secondaryColOverrideMapStr, dimensionOverrideMapStr);
             }
         }
 
         return new MahaLookupExpr(arg);
-    }
-
-    private Map<String, String> getMapOrDefault(List<DruidExpression> inputExpressions, int index) {
-        String map = getMissingValue(inputExpressions, index, "");
-        HashMap<String, String> reqMap = map == null || map.isEmpty() ? null : new HashMap<>(Splitter.on(SEPARATOR).withKeyValueSeparator(KV_DEFAULT).split(map));
-        reqMap = mapCase(reqMap);
-
-        return reqMap;
-    }
-
-    private HashMap<String, String> fixKeys(HashMap<String, String> input, String keyToFix) {
-        String mod = input.remove(keyToFix);
-        input.put(util.NULL_VAL, mod);
-        return input;
-    }
-
-    private HashMap<String, String> mapCase(HashMap<String, String> input) {
-        if(input == null)
-            return input;
-        for(String item: REPL_LIST){
-            if(input.containsKey(item)) {
-                input = fixKeys(input, item);
-            }
-        }
-
-        return input;
-    }
-
-    private String getMissingValue(List<DruidExpression> list, int index, String valueIfMissing) {
-        if (list==null) {
-            return valueIfMissing;
-        }
-        if (list.size() >= index+1) {
-            DruidExpression expression = list.get(index);
-            if (expression != null) {
-                return (String) expression.parse(plannerContext.getExprMacroTable()).getLiteralValue();
-            }
-        }
-        return valueIfMissing;
     }
 }

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
@@ -1,0 +1,122 @@
+package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace;
+
+import com.google.inject.Inject;
+import com.yahoo.maha.maha_druid_lookups.query.lookup.MahaRegisteredLookupExtractionFn;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.ExprType;
+import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
+import org.apache.druid.query.lookup.LookupReferencesManager;
+import org.apache.druid.query.lookup.RegisteredLookupExtractionFn;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class MahaLookupExprMacro implements ExprMacroTable.ExprMacro
+{
+    private static final Logger LOG = new Logger(MahaLookupExprMacro.class);
+    private static final String FN_NAME = "maha_lookup";
+    private final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider;
+
+
+    @Inject
+    public MahaLookupExprMacro(final LookupExtractorFactoryContainerProvider lookupExtractorFactoryContainerProvider)
+    {
+        this.lookupExtractorFactoryContainerProvider = lookupExtractorFactoryContainerProvider;
+    }
+
+    @Override
+    public String name()
+    {
+        return FN_NAME;
+    }
+
+    @Override
+    public Expr apply(final List<Expr> args)
+    {
+
+
+        if (args.size() != 4) {
+            throw new IAE("Function[%s] must have 2 arguments", name());
+        }
+
+        final Expr arg = args.get(0);
+        final Expr lookupExpr = args.get(1);
+        final Expr columnExpr = args.get(2);
+        String columnStr = (String) columnExpr.getLiteralValue();
+        final Expr missingValueExpr = args.get(3);
+        String missingValueStr = (String) missingValueExpr.getLiteralValue();
+
+        if (!lookupExpr.isLiteral() || lookupExpr.getLiteralValue() == null) {
+            throw new IAE("Function[%s] second argument must be a registered lookup name", name());
+        }
+
+        final String lookupName = lookupExpr.getLiteralValue().toString();
+//        final RegisteredLookupExtractionFn extractionFn = new RegisteredLookupExtractionFn(
+//                lookupExtractorFactoryContainerProvider,
+//                lookupName,
+//                false,
+//                null,
+//                false,
+//                null
+//        );
+
+
+        LookupReferencesManager lrm = (LookupReferencesManager) lookupExtractorFactoryContainerProvider;
+        MahaRegisteredLookupExtractionFn mahaRegisteredLookupExtractionFn = new MahaRegisteredLookupExtractionFn(lrm,
+                lookupName,
+                false,
+                missingValueStr,
+                false,
+                false,
+                columnStr,
+                null,
+                null,
+                null,
+                false);
+        LOG.error("Macro: valid call to Maha_lookup: lookupName = " + lookupName + ", columnName = " + columnStr + ", arg = " + arg);
+
+        class MahaLookupExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+        {
+            private MahaLookupExpr(Expr arg)
+            {
+                super(FN_NAME, arg);
+            }
+
+            @Nonnull
+            @Override
+            public ExprEval eval(final ObjectBinding bindings)
+            {
+                return ExprEval.of(mahaRegisteredLookupExtractionFn.apply(NullHandling.emptyToNullIfNeeded(arg.eval(bindings).asString())));
+            }
+
+            @Override
+            public Expr visit(Shuttle shuttle)
+            {
+                Expr newArg = arg.visit(shuttle);
+                return shuttle.visit(new MahaLookupExpr(newArg));
+            }
+
+            @Nullable
+            @Override
+            public ExprType getOutputType(InputBindingInspector inspector)
+            {
+                return ExprType.STRING;
+            }
+
+            @Override
+            public String stringify()
+            {
+                return StringUtils.format("%s(%s, %s, %s, %s)", FN_NAME, arg.stringify(), lookupExpr.stringify(), columnStr);
+            }
+        }
+
+        return new MahaLookupExpr(arg);
+    }
+}

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright 2022, Yahoo Holdings Inc.
+// Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
+
 package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace;
 
 import com.google.common.base.Splitter;

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacro.java
@@ -13,8 +13,6 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExprType;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.LookupReferencesManager;
-import org.apache.druid.sql.calcite.expression.DruidExpression;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversion.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversion.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright 2022, Yahoo Holdings Inc.
+// Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
+
 package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace;
 
 import com.google.common.base.Splitter;

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversion.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversion.java
@@ -98,7 +98,7 @@ public class MahaLookupOperatorConversion implements SqlOperatorConversion {
         );
         if(simpleExtraction == null) return null;
         LOG.debug(String.format("Maha Lookup SimpleExtraction: %s", simpleExtraction.toString()));
-        return DruidExpression.of(simpleExtraction.getSimpleExtraction(), simpleExtraction.getExpression());
+        return DruidExpression.of(simpleExtraction.isSimpleExtraction()? simpleExtraction.getSimpleExtraction(): null, simpleExtraction.getExpression());
     }
 
     private Map<String, String> getMapOrDefault(List<DruidExpression> inputExpressions, int index, PlannerContext plannerContext) {

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversion.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversion.java
@@ -114,8 +114,6 @@ public class MahaLookupOperatorConversion implements SqlOperatorConversion {
                 }
         );
         if(simpleExtraction == null) return null;
-        //MAHA_LOOKUP(cityName, 'druid_data_lookup', 'val', 'NA')
-        //String mahaLookupExprStr = String.format("MAHA_LOOKUP(%s, '%s', '%s', '%s')", arg);
         LOG.error("end of operatorConversion, simpleExtraction: " + simpleExtraction.toString());
         return DruidExpression.of(simpleExtraction.getSimpleExtraction(), simpleExtraction.getExpression());
     }

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaNamespaceExtractionModule.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaNamespaceExtractionModule.java
@@ -21,13 +21,10 @@ import com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.schema.flatbuff
 import com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.schema.flatbuffer.FlatBufferSchemaFactoryProvider;
 import com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.schema.protobuf.ProtobufSchemaFactory;
 import com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.schema.protobuf.ProtobufSchemaFactoryProvider;
-import org.apache.druid.guice.Jerseys;
-import org.apache.druid.guice.JsonConfigProvider;
-import org.apache.druid.guice.LazySingleton;
-import org.apache.druid.guice.LifecycleModule;
-import org.apache.druid.guice.PolyBind;
+import org.apache.druid.guice.*;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.query.expression.LookupExprMacro;
 import org.apache.druid.sql.calcite.schema.*;
 import org.apache.druid.sql.guice.*;
 
@@ -186,6 +183,7 @@ public class MahaNamespaceExtractionModule implements DruidModule
         LifecycleModule.register(binder, LookupService.class);
 
         SqlBindings.addOperatorConversion(binder, MahaLookupOperatorConversion.class);
+        ExpressionModule.addExprMacro(binder, MahaLookupExprMacro.class);
         binder.bind(LookupSchema.class).in(Scopes.SINGLETON);
 
         Jerseys.addResource(binder, MahaNamespacesCacheResource.class);

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaNamespaceExtractionModule.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaNamespaceExtractionModule.java
@@ -24,7 +24,6 @@ import com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.schema.protobuf
 import org.apache.druid.guice.*;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.initialization.DruidModule;
-import org.apache.druid.query.expression.LookupExprMacro;
 import org.apache.druid.sql.calcite.schema.*;
 import org.apache.druid.sql.guice.*;
 

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacroTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacroTest.java
@@ -109,6 +109,7 @@ public class MahaLookupExprMacroTest {
     @Test
     public void testLookup()
     {
+        assertExpr("maha_lookup(id1, 'test_maha_lookup', 'dim_val_column')", "dim_val1");
         assertExpr("maha_lookup(id1, 'test_maha_lookup', 'dim_val_column', 'NA')", "dim_val1");
         assertExpr("maha_lookup(id1, 'test_maha_lookup', 'dim_val_column', 'NA', 'dim_val1->UNKNOWN')", "UNKNOWN");
         assertExpr("maha_lookup(id1, 'test_maha_lookup', 'dim_val_column', 'NA', null, 'dim_key1->UNKNOWN')", "UNKNOWN");

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacroTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacroTest.java
@@ -1,0 +1,132 @@
+package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.yahoo.maha.maha_druid_lookups.query.lookup.JDBCLookupExtractor;
+import com.yahoo.maha.maha_druid_lookups.query.lookup.namespace.JDBCExtractionNamespace;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.Parser;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
+import org.apache.druid.query.lookup.*;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.annotation.Nullable;
+import org.joda.time.Period;
+import java.util.*;
+
+public class MahaLookupExprMacroTest {
+
+
+    private static final Expr.ObjectBinding BINDINGS = Parser.withMap(
+            ImmutableMap.<String, Object>builder()
+                    .put("id1", "dim_key1")
+                    .build()
+    );
+
+    private static Map<String, List> lookupCache = ImmutableMap.of(
+            "dim_key1", Arrays.asList("dim_key1", "dim_val1")
+    );
+
+    private static final String TEST_LOOKUP = "test_maha_lookup";
+
+    static LookupExtractorFactoryContainerProvider manager;
+    static ExprMacroTable macroTable;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        NullHandling.initializeForTests();
+
+        //Construct LookupExtractor
+        MetadataStorageConnectorConfig metadataStorageConnectorConfig = new MetadataStorageConnectorConfig();
+        JDBCExtractionNamespace extractionNamespace =
+                new JDBCExtractionNamespace(
+                        metadataStorageConnectorConfig, "test", new ArrayList<>(Arrays.asList("dim_key_column", "dim_val_column")),
+                        "dim_key_column", "", new Period(), true, TEST_LOOKUP);
+        LookupService lookupService = EasyMock.createStrictMock(LookupService.class);
+        JDBCLookupExtractor LOOKUP_EXTRACTOR = new JDBCLookupExtractor(extractionNamespace, lookupCache, lookupService);
+
+        //Construct conatiner
+        LookupExtractorFactoryContainer container = new LookupExtractorFactoryContainer("v0", new LookupExtractorFactory()
+        {
+            @Override
+            public boolean start()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean replaces(@Nullable LookupExtractorFactory other)
+            {
+                return false;
+            }
+
+            @Override
+            public boolean close()
+            {
+                return false;
+            }
+
+            @Nullable
+            @Override
+            public LookupIntrospectHandler getIntrospectHandler()
+            {
+                return null;
+            }
+
+            @Override
+            public LookupExtractor get()
+            {
+                return LOOKUP_EXTRACTOR;
+            }
+        }
+        );
+
+        //Construct LookupReferencesManager
+        manager = EasyMock.createStrictMock(LookupReferencesManager.class);
+        EasyMock.expect(manager.get(EasyMock.eq(TEST_LOOKUP))).andReturn(Optional.of(container)).anyTimes();
+        EasyMock.replay(manager);
+
+        macroTable = new ExprMacroTable(
+                Lists.newArrayList(
+                        Collections.singletonList(
+                                new MahaLookupExprMacro(manager)
+                        )
+                )
+        );
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testLookup()
+    {
+        assertExpr("maha_lookup(id1, 'test_maha_lookup', 'dim_val_column', 'NA')", "dim_val1");
+        assertExpr("maha_lookup(id1, 'test_maha_lookup', 'dim_val_column', 'NA', 'dim_val1->UNKNOWN')", "UNKNOWN");
+        assertExpr("maha_lookup(id1, 'test_maha_lookup', 'dim_val_column', 'NA', null, 'dim_key1->UNKNOWN')", "UNKNOWN");
+    }
+
+    private void assertExpr(final String expression, final Object expectedResult)
+    {
+        final Expr expr = Parser.parse(expression, macroTable);
+        expr.eval(BINDINGS);
+        Assert.assertEquals(expression, expectedResult, expr.eval(BINDINGS).value());
+
+        final Expr exprNotFlattened = Parser.parse(expression, macroTable, false);
+        String str = exprNotFlattened.stringify();
+        final Expr roundTripNotFlattened =
+                Parser.parse(exprNotFlattened.stringify(), macroTable);
+        Assert.assertEquals(exprNotFlattened.stringify(), expectedResult, roundTripNotFlattened.eval(BINDINGS).value());
+
+        final Expr roundTrip = Parser.parse(expr.stringify(), macroTable);
+        Assert.assertEquals(exprNotFlattened.stringify(), expectedResult, roundTrip.eval(BINDINGS).value());
+    }
+}

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacroTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupExprMacroTest.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright 2022, Yahoo Holdings Inc.
+// Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
+
 package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace;
 
 import com.google.common.collect.ImmutableMap;

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversionTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversionTest.java
@@ -64,7 +64,7 @@ public class MahaLookupOperatorConversionTest {
         DruidExpression druidExp = opConversion.toDruidExpression(plannerContext, ROW_SIGNATURE, rn2);
         assert druidExp != null;
 
-        String expectedDruidExpr = "DruidExpression{simpleExtraction=MahaRegisteredLookupExtractionFn{delegate=null, lookup='student_lookup', retainMissingValue=false, replaceMissingValueWith='123', injective=false, optimize=false, valueColumn=student_id, decodeConfig=null, useQueryLevelCache=false}(student_id), expression='maha'}";
+        String expectedDruidExpr = "DruidExpression{simpleExtraction=MahaRegisteredLookupExtractionFn{delegate=null, lookup='student_lookup', retainMissingValue=false, replaceMissingValueWith='123', injective=false, optimize=false, valueColumn=student_id, decodeConfig=null, useQueryLevelCache=false}(student_id), expression='maha_lookup(\"student_id\",'student_lookup','student_id','123')'}";
         String json = util.convertToJson(druidExp, "testing_stats", "Student ID");
         assert druidExp.toString().equals(expectedDruidExpr);
         assert json.contains("\"dimensions\":[{\"type\":\"extraction\",\"dimension\":\"student_id\",\"outputName\":\"Student ID\",\"outputType\":\"STRING\",\"extractionFn\":{\"type\":\"mahaRegisteredLookup\",\"lookup\":\"student_lookup\",\"retainMissingValue\":false,\"replaceMissingValueWith\":\"123\",\"injective\":false,\"optimize\":false,\"valueColumn\":\"student_id\",\"decode\":null,\"dimensionOverrideMap\":null,\"secondaryColOverrideMap\":null,\"useQueryLevelCache\":false}}]");

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversionTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/MahaLookupOperatorConversionTest.java
@@ -1,5 +1,26 @@
-package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
+// Copyright 2022, Yahoo Holdings Inc.
+// Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
+
+package com.yahoo.maha.maha_druid_lookups.server.lookup.namespace;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.lang3.tuple.Pair;

--- a/druid-lookups/src/test/resources/maha_lookup_extraction_factory.json
+++ b/druid-lookups/src/test/resources/maha_lookup_extraction_factory.json
@@ -1,3 +1,4 @@
+
 {
   "version": "v1",
   "lookupExtractorFactory": {

--- a/druid-lookups/src/test/resources/maha_lookup_extraction_factory.json
+++ b/druid-lookups/src/test/resources/maha_lookup_extraction_factory.json
@@ -1,4 +1,3 @@
-
 {
   "version": "v1",
   "lookupExtractorFactory": {


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

**Summary of changes**
- fix minor issues for existing dimension extraction classes.
- add maha lookup macro to translate Druid SQL expression correctly, ex: 
```
"postAggregations": [
  {
    "type": "expression",
    "name": "p0",
    "expression": "maha_lookup(\"d0\",'druid_data_lookup','val','NA',null,'-3->UNKNOWN')",
    "ordering": null
  }
]
```
Reference:
LookupExprMacro - https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/query/expression/LookupExprMacro.java
LookupExprMacroTest - https://github.com/apache/druid/blob/master/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java