### PR TITLE
Clear non-existent uri records from cache

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -27,8 +27,6 @@ import com.google.inject.Inject;
 import com.yahoo.maha.maha_druid_lookups.query.lookup.DecodeConfig;
 import com.yahoo.maha.maha_druid_lookups.query.lookup.namespace.ExtractionNamespaceCacheFactory;
 import com.yahoo.maha.maha_druid_lookups.query.lookup.namespace.URIExtractionNamespace;
-import com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.cache.MahaNamespaceExtractionCacheManager;
-import com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.cache.OnHeapMahaNamespaceExtractionCacheManager;
 import org.apache.druid.data.SearchableVersionedDataFinder;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.RetryUtils;

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactoryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactoryTest.java
@@ -136,27 +136,6 @@ public class URIExtractionNamespaceCacheFactoryTest {
         assert(!cache.containsKey("123"));
     }
 
-//    @Test
-//    public void testGetCacheValueDeleteRecords() throws Exception{
-//        namespace = new URIExtractionNamespace(tmpFileParent.toURI(), null, null,
-//                new CSVFlatDataParser(Arrays.asList("id", "gpa", "date"), "id", false, 0, null),
-//                null, null, 10L, "student_lookup", "date", true, null, null);
-//
-//        tmpFileParent.setWritable(true);
-//        FileUtils.writeStringToFile(tmpFileParent, "543,0.2,20220102\n", true);
-//        FileUtils.writeStringToFile(tmpFileParent, "111,0.3,22220103\n", true);
-//        FileUtils.writeStringToFile(tmpFileParent, "222,3.9,20220104\n", true);
-//        tmpFileParent.setLastModified(8675309123L);
-//        Map<String, List<String>> cache = new HashMap<String, List<String>>(){{put("123", Arrays.asList("123", "4.5", "20220101"));}};
-//        Callable<String> versionedCache = obj.getCachePopulator("blah",
-//                namespace, "500", cache);
-//
-//        assert(versionedCache.call().equals("8675309123"));
-//        assert(cache.containsKey("222"));
-//        assert(cache.containsValue(Arrays.asList("111", "0.3", "22220103")));
-//        assert(!cache.containsValue(Arrays.asList("123", "4.5", "20220101")));
-//    }
-
     @Test
     public void testGetRegexCacheOnFileRegex() throws Exception{
         namespace = new URIExtractionNamespace(null, tmpFileParent.getParentFile().toURI(), ".*tmp.*txt", //want the regex to match all tmp*txt files

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactoryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactoryTest.java
@@ -130,9 +130,32 @@ public class URIExtractionNamespaceCacheFactoryTest {
                 namespace, "500", cache);
 
         assert(versionedCache.call().equals("8675309000"));
+        assert (cache.size() == 3);
         assert(cache.containsKey("222"));
         assert(cache.containsValue(Arrays.asList("111", "0.3", "22220103")));
+        assert(!cache.containsKey("123"));
     }
+
+//    @Test
+//    public void testGetCacheValueDeleteRecords() throws Exception{
+//        namespace = new URIExtractionNamespace(tmpFileParent.toURI(), null, null,
+//                new CSVFlatDataParser(Arrays.asList("id", "gpa", "date"), "id", false, 0, null),
+//                null, null, 10L, "student_lookup", "date", true, null, null);
+//
+//        tmpFileParent.setWritable(true);
+//        FileUtils.writeStringToFile(tmpFileParent, "543,0.2,20220102\n", true);
+//        FileUtils.writeStringToFile(tmpFileParent, "111,0.3,22220103\n", true);
+//        FileUtils.writeStringToFile(tmpFileParent, "222,3.9,20220104\n", true);
+//        tmpFileParent.setLastModified(8675309123L);
+//        Map<String, List<String>> cache = new HashMap<String, List<String>>(){{put("123", Arrays.asList("123", "4.5", "20220101"));}};
+//        Callable<String> versionedCache = obj.getCachePopulator("blah",
+//                namespace, "500", cache);
+//
+//        assert(versionedCache.call().equals("8675309123"));
+//        assert(cache.containsKey("222"));
+//        assert(cache.containsValue(Arrays.asList("111", "0.3", "22220103")));
+//        assert(!cache.containsValue(Arrays.asList("123", "4.5", "20220101")));
+//    }
 
     @Test
     public void testGetRegexCacheOnFileRegex() throws Exception{

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.99-SNAPSHOT</version>
+    <version>6.100-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.99-SNAPSHOT</version>
+        <version>6.100-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

### Motivation
A URI lookup is reading an input data file to update the cache. If the input data file is updated by adding new records or updating an existing records, the cache can be updated as expectation. 

However, if remove a record from the input file, then the record cannot be removed from cache, causing the record can still be queried. Thus, having this PR to resolve the issue.

### Changes Summary
In `URIExtractionNamespaceCacheFactory`, add all the records into a new map from the input file. Compare the new map with cache, removing non-existing records from the cache and update/add the rest of records into the cache.

### Tests
- [x] Unit test: check the cache should be able to remove the non-existent records
- [x] Test in Druid 21 sandbox: [link](https://docs.google.com/document/d/1R5aVMUXIC10OQK3yKbcDkT3DqDkddtp_Y1zOKy53iHo/edit?usp=sharing)