### PR TITLE
preventing closing override file system during runtime

### DIFF
--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBExtractionNamespaceCacheFactory.java
@@ -70,7 +70,7 @@ public class RocksDBExtractionNamespaceCacheFactory
                     emitter.emit(ServiceMetricEvent.builder().build(MonitoringConstants.MAHA_LOOKUP_ROCKSDB_OPEN_SUCCESS, 1));
                     return loadTime;
                 } catch(Exception e) {
-                    LOG.error(e, "Caught exception while RocksDB creation, error: %s, lastVersion: [%s]", e.getMessage(), lastVersion);
+                    LOG.error(e, "Caught exception while RocksDB creation, error: %s, namespace: %s, lastVersion: [%s]", e.getMessage(), extractionNamespace.getLookupName(),lastVersion);
                     emitter.emit(ServiceMetricEvent.builder().build(MonitoringConstants.MAHA_LOOKUP_ROCKSDB_OPEN_FAILURE, 1));
                     return lastVersion;
                 }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Bug fixing for the following error:
```
2022-05-12T17:19:42,668 ERROR [MahaNamespaceExtractionCacheManager-50] com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.RocksDBExtractionNamespaceCach
eFactory - Caught exception while RocksDB creation, error: Filesystem closed, lastVersion: [null]
java.io.IOException: Filesystem closed
```
Specifically, the creating RocksDB process is not thread-safe hence sometimes the FS gets closed while others still downloading RocksDB.  Hence moved the closing FS only when:
1. close at the LifecycleStop function
2. There is a Third fs destination show ups, that case we should drop the previous one and get the fs object for the latest one.  Some contention can still happen for this case. fe. one rocksdb creation thread can still be using previous fs but get closed by another for a different cluster.