### PR TITLE
[URI Integration] Use LookupService when URI is non-cacheEnabled

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -190,9 +190,10 @@ public class URIExtractionNamespaceCacheFactory
     @Override
     public byte[] getCacheValue(final URIExtractionNamespace extractionNamespace, final Map<String, List<String>> cache, final String key, String valueColumn, final Optional<DecodeConfig> decodeConfigOptional) {
         if(!extractionNamespace.isCacheEnabled()){
-            Map<String, List<String>> tempCache = new HashMap<>();
-            getValuesFromURI(extractionNamespace, 0L, tempCache, extractionNamespace.getLookupName());
-            return checkCacheAndReturn(extractionNamespace, tempCache, key, valueColumn);
+            byte[] value = lookupService.lookup(new LookupService.LookupData(extractionNamespace, key, valueColumn, decodeConfigOptional));
+            value = (value == null) ? new byte[0] : value;
+            log.info("From URI Namespace: [%s] got Cache value [%s]", extractionNamespace.getLookupName(), new String(value));
+            return value;
         } else {
             return checkCacheAndReturn(extractionNamespace, cache, key, valueColumn);
         }

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.100-SNAPSHOT</version>
+    <version>6.101-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.100-SNAPSHOT</version>
+        <version>6.101-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
- Currently, non-cacheEnabled calls will force the lookup to rerun its populator when used.
- This will use lookupService so that the cacheEnabled hosts will instead be called.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
