### PR TITLE
hadoop file system fix

### DIFF
--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBManager.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBManager.java
@@ -134,16 +134,13 @@ public class RocksDBManager {
             LOG.debug("config fs.defaultFS:" + config.get("fs.defaultFS"));
             if(!config.get("fs.defaultFS").equals(nameNodePath)) {
                 LOG.debug("default config defaulFS is not equal to intended one, overriding..");
-                //check if previous overrideConfig is pointing to different hdfs cluster
-                //if (overrideConfig.get("fs.defaultFS") != nameNodePath) {
-                    //closing previous file system before getting a new one
-                //    closeFileSystem(overrideFileSystem);
-                //}
-                overrideConfig.set("fs.defaultFS", nameNodePath);
-                if (overrideFileSystem == null) {
-                    overrideFileSystem = FileSystem.newInstance(overrideConfig);
+                //make sure only one new instance will be created for the targeted cluster
+                synchronized (overrideConfig) {
+                    overrideConfig.set("fs.defaultFS", nameNodePath);
+                    if (overrideFileSystem == null) {
+                        overrideFileSystem = FileSystem.newInstance(overrideConfig);
+                    }
                 }
-                //overrideFileSystem = FileSystem.get(overrideConfig);
             }
         }
 

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBManager.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBManager.java
@@ -135,12 +135,15 @@ public class RocksDBManager {
             if(!config.get("fs.defaultFS").equals(nameNodePath)) {
                 LOG.debug("default config defaulFS is not equal to intended one, overriding..");
                 //check if previous overrideConfig is pointing to different hdfs cluster
-                if (overrideConfig.get("fs.defaultFS") != nameNodePath) {
+                //if (overrideConfig.get("fs.defaultFS") != nameNodePath) {
                     //closing previous file system before getting a new one
-                    closeFileSystem(overrideFileSystem);
-                }
+                //    closeFileSystem(overrideFileSystem);
+                //}
                 overrideConfig.set("fs.defaultFS", nameNodePath);
-                overrideFileSystem = FileSystem.get(overrideConfig);
+                if (overrideFileSystem == null) {
+                    overrideFileSystem = FileSystem.newInstance(overrideConfig);
+                }
+                //overrideFileSystem = FileSystem.get(overrideConfig);
             }
         }
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

- use **newInstance** instead of **get** to prevent using cached object
- add synchronized block to assure only one file system object will be created for RocksDBManager