### PR TITLE
Fix URI cache updated condition and logs

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -164,7 +164,7 @@ public class URIExtractionNamespaceCacheFactory
 
                 if (populator.getLines() > 0) {
                     if (newCache.size() != populator.getEntries()) {
-                        log.warn("Namespace [%s]: the input file may have duplicated key causing num of loaded data [%d] != num of entries parsed [%d]", id, newCache.size(), populator.getEntries());
+                        log.warn("Namespace [%s]: the input file may have duplicated key causing map size [%d] != num of entries parsed [%d]", id, newCache.size(), populator.getEntries());
                     }
                     cache.keySet().retainAll(newCache.keySet());
                     cache.putAll(newCache);

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -131,7 +131,7 @@ public class URIExtractionNamespaceCacheFactory
                     if (lastModified <= lastCheck) {
                         final DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
                         log.debug(
-                                "URI [%s] for namespace [%s] was las modified [%s] but was last cached [%s]. Skipping ",
+                                "URI [%s] for namespace [%s] was last modified [%s] but was last cached [%s]. Skipping ",
                                 uri.toString(), id, fmt.print(lastModified), fmt.print(lastCheck));
                         return version;
                     }
@@ -162,14 +162,16 @@ public class URIExtractionNamespaceCacheFactory
                         extractionNamespace.getNamespaceParseSpec().getParser()).populate(source,
                         newCache);
 
-                if (newCache.size() == populator.getEntries()) {
-                    log.info("Loaded data to a new map successfully. Cleaning previous cache and adding data in the new map to cache ...");
+                if (populator.getLines() > 0) {
+                    if (newCache.size() != populator.getEntries()) {
+                        log.warn("Namespace [%s]: the input file may have duplicated key causing num of loaded data [%d] != num of entries parsed [%d]", id, newCache.size(), populator.getEntries());
+                    }
                     cache.keySet().retainAll(newCache.keySet());
                     cache.putAll(newCache);
-                    log.info("Finished loading %d lines for namespace [%s]", populator.getLines(), id);
+                    log.info("Namespace [%s]: finished loading %d lines and updated cache", id, populator.getLines());
                     return version;
                 } else {
-                    log.error("Num of loaded data is not matching with num of entries parsed. Continue to use previous cache");
+                    log.error("Namespace [%s]: processed %d lines. Do nothing to cache", id, populator.getLines());
                     return String.valueOf(lastCheck);
                 }
             }, puller.shouldRetryPredicate(), DEFAULT_NUM_RETRIES);

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.101-SNAPSHOT</version>
+    <version>6.102-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.101-SNAPSHOT</version>
+        <version>6.102-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

### Motivation
The URI lookup shows `Num of loaded data is not matching with num of entries parsed. Continue to use previous cache` and cache not getting updated when the input .csv file having same keys showing in different rows. 

### Changes Summary
Modify URI cache updated condition to allow cache updated in this case but showing warning log at the same time.

### Reproduced Issue
1. Used the following input state.csv as input: cache loaded successfully 
```
state_id,state_name
,Unknown
-1,Unknown
1,s1
2,s2
3,s3
4,s4
5,s5
```
2. Modified state.csv with duplicated rows: error showing 
```
state_id,state_name
,Unknown
-1,Unknown
1,s1
2,s2
3,s3
4,s4
5,s5
3,s3
```
3. Reverted the change: cache loaded successfully again
4. Modified state.csv with duplicated key using: error showing 
```
state_id,state_name
,Unknown
-1,Unknown
1,s1
2,s2
3,s3
4,s4
5,s5
3,s3333
```
5. Reverted the change: cache loaded successfully again

<img width="1649" alt="Screen Shot 2022-05-23 at 4 42 54 PM" src="https://user-images.githubusercontent.com/42597424/169921378-d9a4cc84-230e-463b-8b57-227af70afe36.png">

### Tested with Fix
1. Following the above steps, and cached can be updated even when duplicated key used with correct log showing:
<img width="1737" alt="Screen Shot 2022-05-23 at 5 08 45 PM" src="https://user-images.githubusercontent.com/42597424/169923405-fbd07c9b-2f6b-4398-875c-b0ba89d24fa3.png">

2. Tested cache working well with updating value, updating key, deleting row, and adding rows in input .csv file
     a. old input vs new input
<img width="1668" alt="Screen Shot 2022-05-23 at 5 15 57 PM" src="https://user-images.githubusercontent.com/42597424/169923957-d629a60b-cc64-43fd-b6d7-6329ad5d61d3.png">

     b. result with new input
<img width="1641" alt="Screen Shot 2022-05-23 at 5 14 23 PM" src="https://user-images.githubusercontent.com/42597424/169923831-a3671e01-42e2-4d79-8036-e2dac929b874.png">
<img width="1250" alt="Screen Shot 2022-05-23 at 5 18 04 PM" src="https://user-images.githubusercontent.com/42597424/169924141-6d1dfce1-af9b-4ace-8848-d6d0ef5a60d1.png">


