### PR TITLE
fix for lookupService SSL connection

### DIFF
--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -191,14 +191,19 @@ public class URIExtractionNamespaceCacheFactory
 
     @Override
     public byte[] getCacheValue(final URIExtractionNamespace extractionNamespace, final Map<String, List<String>> cache, final String key, String valueColumn, final Optional<DecodeConfig> decodeConfigOptional) {
-        if(!extractionNamespace.isCacheEnabled()){
-            byte[] value = lookupService.lookup(new LookupService.LookupData(extractionNamespace, key, valueColumn, decodeConfigOptional));
-            value = (value == null) ? new byte[0] : value;
-            log.info("From URI Namespace: [%s] got Cache value [%s]", extractionNamespace.getLookupName(), new String(value));
-            return value;
-        } else {
-            return checkCacheAndReturn(extractionNamespace, cache, key, valueColumn);
-        }
+//        if(!extractionNamespace.isCacheEnabled()){
+//            byte[] value = lookupService.lookup(new LookupService.LookupData(extractionNamespace, key, valueColumn, decodeConfigOptional));
+//            value = (value == null) ? new byte[0] : value;
+//            log.info("From URI Namespace: [%s] got Cache value [%s]", extractionNamespace.getLookupName(), new String(value));
+//            return value;
+//        } else {
+//            return checkCacheAndReturn(extractionNamespace, cache, key, valueColumn);
+//        }
+        // for testing purpose always check the lookupService
+        byte[] value = lookupService.lookup(new LookupService.LookupData(extractionNamespace, key, valueColumn, decodeConfigOptional));
+        value = (value == null) ? new byte[0] : value;
+        log.info("From URI Namespace: [%s] got Cache value [%s]", extractionNamespace.getLookupName(), new String(value));
+        return value;
     }
 
 

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -191,19 +191,14 @@ public class URIExtractionNamespaceCacheFactory
 
     @Override
     public byte[] getCacheValue(final URIExtractionNamespace extractionNamespace, final Map<String, List<String>> cache, final String key, String valueColumn, final Optional<DecodeConfig> decodeConfigOptional) {
-//        if(!extractionNamespace.isCacheEnabled()){
-//            byte[] value = lookupService.lookup(new LookupService.LookupData(extractionNamespace, key, valueColumn, decodeConfigOptional));
-//            value = (value == null) ? new byte[0] : value;
-//            log.info("From URI Namespace: [%s] got Cache value [%s]", extractionNamespace.getLookupName(), new String(value));
-//            return value;
-//        } else {
-//            return checkCacheAndReturn(extractionNamespace, cache, key, valueColumn);
-//        }
-        // for testing purpose always check the lookupService
-        byte[] value = lookupService.lookup(new LookupService.LookupData(extractionNamespace, key, valueColumn, decodeConfigOptional));
-        value = (value == null) ? new byte[0] : value;
-        log.info("From URI Namespace: [%s] got Cache value [%s]", extractionNamespace.getLookupName(), new String(value));
-        return value;
+        if(!extractionNamespace.isCacheEnabled()){
+            byte[] value = lookupService.lookup(new LookupService.LookupData(extractionNamespace, key, valueColumn, decodeConfigOptional));
+            value = (value == null) ? new byte[0] : value;
+            log.info("From URI Namespace: [%s] got Cache value [%s]", extractionNamespace.getLookupName(), new String(value));
+            return value;
+        } else {
+            return checkCacheAndReturn(extractionNamespace, cache, key, valueColumn);
+        }
     }
 
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

fix the following exception:
```
javax.net.ssl.SSLException: Unsupported or unrecognized SSL message
        at sun.security.ssl.SSLSocketInputRecord.handleUnknownRecord(SSLSocketInputRecord.java:455) ~[?:1.8.0_332]
        at sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:184) ~[?:1.8.0_332]
        at sun.security.ssl.SSLTransport.decode(SSLTransport.java:109) ~[?:1.8.0_332]
        at sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1397) ~[?:1.8.0_332]
        at sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1305) ~[?:1.8.0_332]
        at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:440) ~[?:1.8.0_332]
        at org.apache.http.conn.ssl.SSLConnectionSocketFactory.createLayeredSocket(SSLConnectionSocketFactory.java:396) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.conn.ssl.SSLConnectionSocketFactory.connectSocket(SSLConnectionSocketFactory.java:355) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:142) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:359) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:381) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:237) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:185) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:111) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83) ~[httpclient-4.5.3.jar:4.5.3]
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108) ~[httpclient-4.5.3.jar:4.5.3]
        at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.LookupService.callService(LookupService.java:180) ~[?:?]
        at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.LookupService.access$200(LookupService.java:46) ~[?:?]
        at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.LookupService$1.load(LookupService.java:126) ~[?:?]
        at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.LookupService$1.load(LookupService.java:117) ~[?:?]
        at com.github.benmanes.caffeine.cache.LocalLoadingCache.lambda$newMappingFunction$2(LocalLoadingCache.java:140) ~[caffeine-2.8.0.jar:?]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$14(BoundedLocalCache.java:2404) ~[caffeine-2.8.0.jar:?]
        at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1877) ~[?:1.8.0_332]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2377) ~[caffeine-2.8.0.jar:?]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2360) ~[caffeine-2.8.0.jar:?]
        at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:108) ~[caffeine-2.8.0.jar:?]
        at com.github.benmanes.caffeine.cache.LocalLoadingCache.get(LocalLoadingCache.java:54) ~[caffeine-2.8.0.jar:?]
        at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.LookupService.lookup(LookupService.java:226) ~[?:?]
        at com.yahoo.maha.maha_druid_lookups.server.lookup.namespace.URIExtractionNamespaceCacheFactory.getCacheValue
```
Specifically, fix the code to build the connection based on the given scheme.