### PR TITLE
Alternative engine doesn't need fkeys when fromTable doesn't have fkeys

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/fact/Fact.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/fact/Fact.scala
@@ -1054,7 +1054,7 @@ case class FactBuilder private[fact](private val baseFact: Fact, private var tab
         dimColMap += (d.name -> d)
     }
 
-    require(dimColMap.values.exists(_.isForeignKey), s"Fact has no foreign keys after discarding $discarding")
+    require(!fromTable.dimCols.exists(_.isForeignKey) || dimColMap.values.exists(_.isForeignKey), s"Fact has no foreign keys after discarding $discarding")
 
     overrideFactCols foreach {
       f =>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
