### PR TITLE
Add dependency: hadoop-aws

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/README.md
+++ b/druid-lookups/README.md
@@ -131,6 +131,43 @@ exec "$JAVA_BIN"/java `cat "$CONFDIR"/"$WHATAMI"/jvm.config | xargs` \
   `cat "$CONFDIR"/$WHATAMI/main.config | xargs`
 ```
 
+* S3A Configuration  
+  * If encounter the following error:
+  ```
+  Caused by: java.lang.ClassNotFoundException: Class org.apache.hadoop.fs.s3a.S3AFileSystem not found
+          at org.apache.hadoop.conf.Configuration.getClassByName(Configuration.java:2273) ~[hadoop-common-2.8.5.jar:?]
+          at org.apache.hadoop.conf.Configuration.getClass(Configuration.java:2367) ~[hadoop-common-2.8.5.jar:?]
+          ... 19 more
+  ```
+  This is caused by lack of Hadoop dependency: [hadoop-aws](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html).
+  <br>  
+  **Solution:**
+  
+  Include the hadoop-aws-2.8.5.jar in class path `<druid_root>/hadoop-dependencies/hadoop-client/2.8.5/*`, and then follow the above `HDFS Configuration` solution.  
+
+  <br>
+
+  * If encounter the following error:
+  ```
+  com.amazonaws.AmazonClientException: No AWS Credentials provided by BasicAWSCredentialsProvider EnvironmentVariableCredentialsProvider SharedInstanceProfileCredentialsProvider : com.amazonaws.SdkClientException: Failed to connect to service endpoint: 
+          at org.apache.hadoop.fs.s3a.S3AUtils.translateException(S3AUtils.java:125) ~[hadoop-aws-2.8.5.jar:?]
+          at org.apache.hadoop.fs.s3a.S3AFileSystem.verifyBucketExists(S3AFileSystem.java:288) ~[hadoop-aws-2.8.5.jar:?]
+          at org.apache.hadoop.fs.s3a.S3AFileSystem.initialize(S3AFileSystem.java:236) ~[hadoop-aws-2.8.5.jar:?]
+          at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2812) ~[hadoop-common-2.8.5.jar:?]
+  ```
+  This is caused by missing correct AWS credentials.
+  <br>  
+  **Solution:**
+  
+  Here are a few ways to authenticate with s3: ([link](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Authenticating_with_S3)). Besides, for local development, it also supports to use credentials from the `~/.aws/credentials` file, which is not by default to pick up credential from it, but adding the following property in `<druid_root>/conf/druid/single-server/micro-quickstart/_common/core-site.xml` will make it work:  
+  ```
+  <property>
+    <name>fs.s3a.aws.credentials.provider</name>
+    <value>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</value>
+  </property>
+  ```
+
+
 ### Set up Dynamic Schema Lookups:
 
 Steps:

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -161,6 +161,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-aws</artifactId>
+            <version>2.8.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
             <version>${druid.version}</version>
@@ -205,6 +211,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBManager.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBManager.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.FsUrlStreamHandlerFactory;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.joda.time.Period;
 import org.rocksdb.*;
@@ -31,6 +32,8 @@ import org.zeroturnaround.zip.ZipUtil;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -89,6 +92,10 @@ public class RocksDBManager {
         config.set("fs.file.impl",
                 LocalFileSystem.class.getName()
         );
+        config.set("fs.s3a.impl",
+                S3AFileSystem.class.getName()
+        );
+
         this.localStorageDirectory = mahaNamespaceExtractionConfig.getRocksDBProperties().getProperty(ROCKSDB_LOCATION_PROP_NAME, TEMPORARY_PATH);
         this.blockCacheSizeInMb = Long.parseLong(mahaNamespaceExtractionConfig.getRocksDBProperties().getProperty(ROCKSDB_BLOCK_CACHE_SIZE_PROP_NAME, String.valueOf(DEFAULT_BLOCK_CACHE_SIZE_IN_MB)));
         Preconditions.checkArgument(blockCacheSizeInMb > 0);
@@ -99,7 +106,7 @@ public class RocksDBManager {
     }
 
     public String createDB(final RocksDBExtractionNamespace extractionNamespace,
-                           final String lastVersion) throws RocksDBException, IOException {
+                           final String lastVersion) throws RocksDBException, IOException, URISyntaxException {
 
 
         String loadTime = null;
@@ -130,6 +137,23 @@ public class RocksDBManager {
         if (extractionNamespace.getRocksDbInstanceHDFSPath().contains("hdfs")) {
             URL hdfsUrl = new URL(extractionNamespace.getRocksDbInstanceHDFSPath());
             String nameNodePath = hdfsUrl.getProtocol() + "://" + hdfsUrl.getHost() + ":" + hdfsUrl.getPort();
+            LOG.debug("intended namenode path for lookup: " + nameNodePath);
+            LOG.debug("config fs.defaultFS:" + config.get("fs.defaultFS"));
+            if(!config.get("fs.defaultFS").equals(nameNodePath)) {
+                LOG.debug("default config defaulFS is not equal to intended one, overriding..");
+                //make sure only one new instance will be created for the targeted cluster
+                synchronized (overrideConfig) {
+                    overrideConfig.set("fs.defaultFS", nameNodePath);
+                    if (overrideFileSystem == null) {
+                        overrideFileSystem = FileSystem.newInstance(overrideConfig);
+                    }
+                }
+            }
+        }
+
+        if (extractionNamespace.getRocksDbInstanceHDFSPath().contains("s3a")) {
+            URI s3aUri = new URI(extractionNamespace.getRocksDbInstanceHDFSPath());
+            String nameNodePath = s3aUri.toString();
             LOG.debug("intended namenode path for lookup: " + nameNodePath);
             LOG.debug("config fs.defaultFS:" + config.get("fs.defaultFS"));
             if(!config.get("fs.defaultFS").equals(nameNodePath)) {

--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBManager.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/RocksDBManager.java
@@ -154,10 +154,11 @@ public class RocksDBManager {
         if (extractionNamespace.getRocksDbInstanceHDFSPath().contains("s3a")) {
             URI s3aUri = new URI(extractionNamespace.getRocksDbInstanceHDFSPath());
             String nameNodePath = s3aUri.toString();
-            LOG.debug("intended namenode path for lookup: " + nameNodePath);
-            LOG.debug("config fs.defaultFS:" + config.get("fs.defaultFS"));
+            LOG.info("[s3a] intended namenode path for lookup: " + nameNodePath);
+            LOG.info("[s3a] config fs.defaultFS:" + config.get("fs.defaultFS"));
+            
             if(!config.get("fs.defaultFS").equals(nameNodePath)) {
-                LOG.debug("default config defaulFS is not equal to intended one, overriding..");
+                LOG.info("[s3a] default config defaulFS is not equal to intended one, overriding..");
                 //make sure only one new instance will be created for the targeted cluster
                 synchronized (overrideConfig) {
                     overrideConfig.set("fs.defaultFS", nameNodePath);

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.107-SNAPSHOT</version>
+    <version>6.108-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.107-SNAPSHOT</version>
+        <version>6.108-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

### Changes Summary
Introduce `hadoop-aws` dependency which support to read and write on AWS S3 through s3a client. Adding s3a impl in config and s3a path check in `RocksdbManager`, which will get s3a URI and use `S3AFileSystem` to get the input from s3.

References: 
https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html
https://druid.apache.org/docs/latest/development/extensions-core/hdfs.html#configuration-for-aws-s3