### PR TITLE
Fixed CVE-2021-42392 @ RCE in H2 Console

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -310,7 +310,7 @@
                     <dependency>
                         <groupId>com.h2database</groupId>
                         <artifactId>h2</artifactId>
-                        <version>1.4.191</version>
+                        <version>2.1.210</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
## Descriptions
H2 Console in versions since 1.1.100 (2008-10-14) to 2.0.204 (2021-12-21) inclusive allows loading of custom classes from remote servers through JNDI. H2 Console doesn't accept remote connections by default. If remote access was enabled explicitly and some protection method (such as security constraint) wasn't set, an intruder can load own custom class and execute its code in a process with H2 Console (H2 Server process or a web server with H2 Console servlet). It is also possible to load them by creation a linked table in these versions, but it requires `ADMIN` privileges and user with `ADMIN` privileges has full access to the Java process by design. These privileges should never be granted to untrusted users.

**CVE-2021-42392**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
GHSA-h376-j262-vhq6
