### PR TITLE
fixed CVE-2022-39135 @ potential XML External Entity (XXE) attack

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.26.0</version>
+            <version>1.32.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>


### PR DESCRIPTION
## Descriptions Overview
In Apache Calcite prior to version 1.32.0 the SQL operators EXISTS_NODE, EXTRACT_XML, XML_TRANSFORM and EXTRACT_VALUE do not restrict XML External Entity references in their configuration, which makes them vulnerable to a potential XML External Entity (XXE) attack. Therefore any client exposing these operators, typically by using Oracle dialect (the first three) or MySQL dialect (the last one), is affected by this vulnerability (the extent of it will depend on the user under which the application is running). From Apache Calcite 1.32.0 onwards, Document Type Declarations and XML External Entity resolution are disabled on the impacted operators.


**CVE-2022-39135**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
GHSA-fj2m-w3wv-x9pr
