### PR TITLE
Describe to return only distinct columns

### DIFF
--- a/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
@@ -372,15 +372,23 @@ class DefaultMahaAvaticaService(executeFunction: (MahaRequestContext, MahaServic
                 val publicFact = pubFactOption.get
                 val signature: Signature = getSignature(sql)
                 val rows = new util.ArrayList[Object]()
+                val distinctCols = scala.collection.mutable.Set[Array[String]]()
+
                 publicFact.dimCols.foreach {
                     dimCol=>
                         val row = Array(dimCol.alias, DIMENSION_COLUMN, getDataType(dimCol, publicFact) , toComment(dimCol))
-                        rows.add(row)
+                        if(!distinctCols.contains(row)) {
+                            distinctCols.add(row)
+                            rows.add(row)
+                        }
                 }
                 publicFact.factCols.foreach {
                     factCol=>
                         val row = Array(factCol.alias, METRIC_COLUMN, getDataType(factCol, publicFact) , toComment(factCol))
-                        rows.add(row)
+                        if(!distinctCols.contains(row)) {
+                            distinctCols.add(row)
+                            rows.add(row)
+                        }
                 }
                 publicFact.foreignKeySources.foreach {
                     dimensionCube =>
@@ -391,7 +399,10 @@ class DefaultMahaAvaticaService(executeFunction: (MahaRequestContext, MahaServic
                             dim.columnsByAliasMap.foreach {
                                 case (alias, dimCol)=>
                                     val row = Array(dimCol.alias, DIMENSION_JOIN_COLUMN, getDataTypeFromDim(dimCol, dim) , toComment(dimCol))
-                                    rows.add(row)
+                                    if(!distinctCols.contains(row)) {
+                                        distinctCols.add(row)
+                                        rows.add(row)
+                                    }
                             }
                         }
                 }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

For cases where a column is present in both fact, and joined dimension tables, they are returned multiple times in the output of the cube's describe table command. This makes sure the column is returned just once.