### PR TITLE
Fix data type returned for DimTable's columns

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.113-SNAPSHOT</version>
+    <version>6.114-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
@@ -320,16 +320,16 @@ class DefaultMahaAvaticaService(executeFunction: (MahaRequestContext, MahaServic
                                     TABLE_SCHEM,
                                     publicFact.name,
                                     dimCol.alias,
-                                    getSqlDataType(dimCol, publicFact),
-                                    getDataType(dimCol, publicFact),
+                                    getSqlDataTypeFromDim(dimCol, dimCubeOption.get),
+                                    getDataTypeFromDim(dimCol, dimCubeOption.get),
                                     COLUMN_SIZE,
                                     BUFFER_LENGTH,
-                                    if(getDataType(dimCol, publicFact).equals("DecType")) 38 else null, //DECIMAL_DIGITS
+                                    if(getDataTypeFromDim(dimCol, dimCubeOption.get).equals("DecType")) 38 else null, //DECIMAL_DIGITS
                                     NUM_PREC_RADIX,
                                     NULLABLE,
                                     toComment(dimCol),
                                     toComment(dimCol),
-                                    getSqlDataType(dimCol, publicFact),
+                                    getSqlDataTypeFromDim(dimCol, dimCubeOption.get),
                                     SQL_DATETIME_SUB,
                                     CHAR_OCTET_LENGTH,
                                     ordinalPos, //ORDINAL_POSITION

--- a/service/src/test/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaServiceTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaServiceTest.scala
@@ -126,6 +126,58 @@ class MahaAvaticaServiceTest extends BaseMahaServiceTest {
 
   }
 
+  test("Test that Describe table request returns distinct rows") {
+    val mahaAvaticaService = new DefaultMahaAvaticaService(executeFunction,
+      DefaultMahaCalciteSqlParser(mahaServiceConfig),
+      mahaService,
+      new DefaultAvaticaRowListTransformer(),
+      (schma)=> ExampleSchema.namesToValuesMap(schma),
+      REGISTRY,
+      StudentSchema,
+      ReportingRequest,
+      new DefaultConnectionUserInfoProvider
+    )
+
+    mahaAvaticaService(new OpenConnectionRequest(connectionID, Maps.newHashMap()))
+    val result =  mahaAvaticaService(new PrepareAndExecuteRequest(connectionID, 1, "describe student_performance", 10))
+    assert(result.results.size() == 1)
+    val frame = result.results.get(0).firstFrame
+    assert(frame!=null)
+    val rowsIt = frame.rows.iterator();
+    val distinctCols = scala.collection.mutable.Set[String]()
+    rowsIt.forEachRemaining(s=> {
+      assert(distinctCols.add(s.asInstanceOf[Array[String]](0))==true)
+    })
+  }
+
+  test("Test that datatypes are returned correctly") {
+    val mahaAvaticaService = new DefaultMahaAvaticaService(executeFunction,
+      DefaultMahaCalciteSqlParser(mahaServiceConfig),
+      mahaService,
+      new DefaultAvaticaRowListTransformer(),
+      (schma)=> ExampleSchema.namesToValuesMap(schma),
+      REGISTRY,
+      StudentSchema,
+      ReportingRequest,
+      new DefaultConnectionUserInfoProvider
+    )
+
+    mahaAvaticaService(new OpenConnectionRequest(connectionID, Maps.newHashMap()))
+    val result =  mahaAvaticaService(new PrepareAndExecuteRequest(connectionID, 1, "describe student_performance", 10))
+    assert(result.results.size() == 1)
+    val frame = result.results.get(0).firstFrame
+    assert(frame!=null)
+    val rowsIt = frame.rows.iterator();
+    val distinctCols = scala.collection.mutable.Set[String]()
+    rowsIt.forEachRemaining(s=> {
+      //Section ID is a DimCol from FactTable, Performance Factor is a FactCol from FactTable, Student Name is a DimCol from DimTable
+      if(s.asInstanceOf[Array[String]](0).equals("Section ID")) assert(s.asInstanceOf[Array[String]](2).equals("IntType"))
+      else if(s.asInstanceOf[Array[String]](0).equals("Performance Factor")) assert(s.asInstanceOf[Array[String]](2).equals("DecType"))
+      else if(s.asInstanceOf[Array[String]](0).equals("Student Name")) assert(s.asInstanceOf[Array[String]](2).equals("StrType"))
+      //println(s.asInstanceOf[Array[String]](0)+" +++ "+s.asInstanceOf[Array[String]](1)+" +++ "+ s.asInstanceOf[Array[String]](2) + " +++ " + s.asInstanceOf[Array[String]](3) + " ")
+    })
+  }
+
   test("Noop avatica service") {
     val noopMahaAvaticaService = new NoopMahaAvaticaService()
     noopMahaAvaticaService.apply(new PrepareAndExecuteRequest("", 1, "", 10))

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.113-SNAPSHOT</version>
+        <version>6.114-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

* Currently "" is returned as dataType for DimTable's columns

* This is because , for dimTable's columns, FactTable's `getDataType` and `getSqlDataType` were called instead of
`getDataTypeFromDim` and `getSqlDataTypeFromDim`

* Added unit test
