### PR TITLE
Support for sum('xyz') and aliases(AS) in select and orderby

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.115-SNAPSHOT</version>
+    <version>6.116-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.26.0</version>
+            <version>1.32.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -274,11 +274,7 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
       case SqlKind.AND =>
         constructFilters(operands.get(0)) ++ constructFilters(operands.get(1))
       case SqlKind.NOT_IN =>
-//        val notInList: List[String] = operands.get(1).asInstanceOf[SqlNodeList].getList.stream().map(Node => toLiteral(sqlNode)).collect(Coll)
-//        var notInList: List[String]
-//        operands.get(1).asInstanceOf[SqlNodeList].forEach(sqlNode: SqlNode =>{
-//          notInList.add
-//        })
+        val notInList: List[String] = operands.get(1).asInstanceOf[SqlNodeList].getList.asScala.map(sqlNode=> toLiteral(sqlNode)).toList
         ArrayBuffer.empty += NotInFilter(toLiteral(operands.get(0)), notInList).asInstanceOf[Filter]
       case SqlKind.OR =>
         val mergeBuffer: ArrayBuffer[Filter] = constructFilters(operands.get(0)) ++ constructFilters(operands.get(1))
@@ -290,7 +286,7 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
       case SqlKind.GREATER_THAN =>
         ArrayBuffer.empty += GreaterThanFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1))).asInstanceOf[Filter]
       case SqlKind.IN =>
-        val inList: List[String] = operands.get(1).asInstanceOf[SqlNodeList].toArray.toList.map(sqlNode => toLiteral(sqlNode))
+        val inList: List[String] = operands.get(1).asInstanceOf[SqlNodeList].getList.asScala.map(sqlNode => toLiteral(sqlNode)).toList
         ArrayBuffer.empty += InFilter(toLiteral(operands.get(0)), inList).asInstanceOf[Filter]
       case SqlKind.BETWEEN =>
         ArrayBuffer.empty += BetweenFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1)), toLiteral(operands.get(2))).asInstanceOf[Filter]

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -38,7 +38,6 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
     val parser: SqlParser = SqlParser.create(sql, config)
     try {
       val topSqlNode: SqlNode = parser.parseQuery
-
       val sqlNode:SqlNode = topSqlNode match {
          case sqlSelect: SqlSelect=> sqlSelect
          case sqlOrderBy: SqlOrderBy=> sqlOrderBy.query

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -190,8 +190,14 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
                 val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(sqlCharStringLiteral), columnAliasToColumnMap)
                 arrayBuffer += Field(publicCol.alias, None, None)
               case sqlBasicCall: SqlBasicCall =>
-                val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(sqlBasicCall.operands(0)), columnAliasToColumnMap)
-                arrayBuffer += Field(publicCol.alias, None, None)
+                sqlBasicCall.operands(0) match {
+                  case innerSqlBasicCall: SqlBasicCall =>
+                    val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(innerSqlBasicCall.operands(0)), columnAliasToColumnMap)
+                    arrayBuffer += Field(publicCol.alias, None, None)
+                  case sqlIdentifier: SqlIdentifier =>
+                    val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(sqlIdentifier), columnAliasToColumnMap)
+                    arrayBuffer += Field(publicCol.alias, None, None)
+                }
               case other: AnyRef =>
                 val errMsg = s"sqlNode type${other.getClass.toString} in getSelectList is not yet supported"
                 logger.error(errMsg);

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -197,6 +197,9 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
                   case sqlIdentifier: SqlIdentifier =>
                     val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(sqlIdentifier), columnAliasToColumnMap)
                     arrayBuffer += Field(publicCol.alias, None, None)
+                  case sqlCharStringLiteral: SqlCharStringLiteral =>
+                    val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(sqlCharStringLiteral), columnAliasToColumnMap)
+                    arrayBuffer += Field(publicCol.alias, None, None)
                 }
               case other: AnyRef =>
                 val errMsg = s"sqlNode type${other.getClass.toString} in getSelectList is not yet supported"

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -81,13 +81,13 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
               val orderBySql = topSqlNode.asInstanceOf[SqlOrderBy]
               orderBySql.orderList.asScala.map {
                 case sqlOrderByBasic:SqlBasicCall=>
-                  require(sqlOrderByBasic.operands.size>0, s"Missing field and Order by Clause ${sqlOrderByBasic}")
+                  require(sqlOrderByBasic.getOperandList.size()>0, s"Missing field and Order by Clause ${sqlOrderByBasic}")
                   val order:Order = {
                     if (sqlOrderByBasic.getOperator!=null && sqlOrderByBasic.getKind == SqlKind.DESCENDING) {
                       DESC
                     } else ASC
                   }
-                  SortBy(queryAliasToColumnNameMap.getOrElse(toLiteral(sqlOrderByBasic.operands(0)),toLiteral(sqlOrderByBasic.operands(0))), order)
+                  SortBy(queryAliasToColumnNameMap.getOrElse(toLiteral(sqlOrderByBasic.getOperandList.get(0)),toLiteral(sqlOrderByBasic.getOperandList.get(0))), order)
                 case sqlString:SqlCharStringLiteral=>
                   SortBy(queryAliasToColumnNameMap.getOrElse(toLiteral(sqlString),toLiteral(sqlString)), ASC)
                 case sqlString:SqlIdentifier=>
@@ -146,7 +146,7 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
     val sqlFromNode = sqlNode match {
       case sqlBasicCall: SqlBasicCall =>
         sqlBasicCall.getOperator.kind match {
-          case SqlKind.AS => sqlBasicCall.getOperands()(0)
+          case SqlKind.AS => sqlBasicCall.getOperandList().get(0)
           case _ => sqlNode
         }
       case _ => sqlNode
@@ -193,27 +193,27 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
                 val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(sqlCharStringLiteral), columnAliasToColumnMap)
                 arrayBuffer += Field(publicCol.alias, None, None)
               case sqlBasicCall: SqlBasicCall =>
-                sqlBasicCall.operands(0) match {
+                sqlBasicCall.getOperandList.get(0) match {
                   case innerSqlBasicCall: SqlBasicCall =>
-                    val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(innerSqlBasicCall.operands(0)), columnAliasToColumnMap)
-                    if(sqlBasicCall.operands.length>1) {
-                      val alias = toLiteral(sqlBasicCall.operands(1))
+                    val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(innerSqlBasicCall.getOperandList.get(0)), columnAliasToColumnMap)
+                    if(sqlBasicCall.getOperandList.size()>1) {
+                      val alias = toLiteral(sqlBasicCall.getOperandList.get(1))
                       queryAliasToColumnNameMap += (alias -> publicCol.alias)
                       arrayBuffer += Field(publicCol.alias, Option(alias), None)
                     }
                     else arrayBuffer += Field(publicCol.alias, None, None)
                   case sqlIdentifier: SqlIdentifier =>
                     val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(sqlIdentifier), columnAliasToColumnMap)
-                    if(sqlBasicCall.operands.length>1) {
-                      val alias = toLiteral(sqlBasicCall.operands(1))
+                    if(sqlBasicCall.getOperandList.size>1) {
+                      val alias = toLiteral(sqlBasicCall.getOperandList.get(1))
                       queryAliasToColumnNameMap += (alias -> publicCol.alias)
                       arrayBuffer += Field(publicCol.alias, Option(alias), None)
                     }
                     else arrayBuffer += Field(publicCol.alias, None, None)
                   case sqlCharStringLiteral: SqlCharStringLiteral =>
                     val publicCol: PublicColumn = getColumnFromPublicFact(publicFact, toLiteral(sqlCharStringLiteral), columnAliasToColumnMap)
-                    if(sqlBasicCall.operands.length>1) {
-                      val alias = toLiteral(sqlBasicCall.operands(1))
+                    if(sqlBasicCall.getOperandList.size>1) {
+                      val alias = toLiteral(sqlBasicCall.getOperandList.get(1))
                       queryAliasToColumnNameMap += (alias -> publicCol.alias)
                       arrayBuffer += Field(publicCol.alias, Option(alias), None)
                     }
@@ -269,36 +269,40 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
   def constructFilters(sqlNode: SqlNode): ArrayBuffer[Filter] = {
     require(sqlNode.isInstanceOf[SqlBasicCall], s"type ${sqlNode.getKind} not supported in construct current filter")
     val sqlBasicCall: SqlBasicCall = sqlNode.asInstanceOf[SqlBasicCall]
-    val operands = sqlBasicCall.getOperands
+    val operands = sqlBasicCall.getOperandList
     sqlBasicCall.getOperator.kind match {
       case SqlKind.AND =>
-        constructFilters(operands(0)) ++ constructFilters(operands(1))
+        constructFilters(operands.get(0)) ++ constructFilters(operands.get(1))
       case SqlKind.NOT_IN =>
-        val notInList: List[String] = operands(1).asInstanceOf[SqlNodeList].toArray.toList.map(sqlNode => toLiteral(sqlNode))
-        ArrayBuffer.empty += NotInFilter(toLiteral(operands(0)), notInList).asInstanceOf[Filter]
+//        val notInList: List[String] = operands.get(1).asInstanceOf[SqlNodeList].getList.stream().map(Node => toLiteral(sqlNode)).collect(Coll)
+//        var notInList: List[String]
+//        operands.get(1).asInstanceOf[SqlNodeList].forEach(sqlNode: SqlNode =>{
+//          notInList.add
+//        })
+        ArrayBuffer.empty += NotInFilter(toLiteral(operands.get(0)), notInList).asInstanceOf[Filter]
       case SqlKind.OR =>
-        val mergeBuffer: ArrayBuffer[Filter] = constructFilters(operands(0)) ++ constructFilters(operands(1))
+        val mergeBuffer: ArrayBuffer[Filter] = constructFilters(operands.get(0)) ++ constructFilters(operands.get(1))
         ArrayBuffer.empty += OrFilter(mergeBuffer.toList).asInstanceOf[Filter]
       case SqlKind.EQUALS =>
-        ArrayBuffer.empty += EqualityFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
+        ArrayBuffer.empty += EqualityFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1))).asInstanceOf[Filter]
       case SqlKind.NOT_EQUALS =>
-        ArrayBuffer.empty += NotEqualToFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
+        ArrayBuffer.empty += NotEqualToFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1))).asInstanceOf[Filter]
       case SqlKind.GREATER_THAN =>
-        ArrayBuffer.empty += GreaterThanFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
+        ArrayBuffer.empty += GreaterThanFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1))).asInstanceOf[Filter]
       case SqlKind.IN =>
-        val inList: List[String] = operands(1).asInstanceOf[SqlNodeList].toArray.toList.map(sqlNode => toLiteral(sqlNode))
-        ArrayBuffer.empty += InFilter(toLiteral(operands(0)), inList).asInstanceOf[Filter]
+        val inList: List[String] = operands.get(1).asInstanceOf[SqlNodeList].toArray.toList.map(sqlNode => toLiteral(sqlNode))
+        ArrayBuffer.empty += InFilter(toLiteral(operands.get(0)), inList).asInstanceOf[Filter]
       case SqlKind.BETWEEN =>
-        ArrayBuffer.empty += BetweenFilter(toLiteral(operands(0)), toLiteral(operands(1)), toLiteral(operands(2))).asInstanceOf[Filter]
+        ArrayBuffer.empty += BetweenFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1)), toLiteral(operands.get(2))).asInstanceOf[Filter]
       case SqlKind.LIKE =>
         if (sqlBasicCall.getOperator.asInstanceOf[SqlLikeOperator].isNegated)
-          ArrayBuffer.empty += NotLikeFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
+          ArrayBuffer.empty += NotLikeFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1))).asInstanceOf[Filter]
         else
-          ArrayBuffer.empty += LikeFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
+          ArrayBuffer.empty += LikeFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1))).asInstanceOf[Filter]
       case SqlKind.IS_NULL =>
-        ArrayBuffer.empty += IsNullFilter(toLiteral(operands(0))).asInstanceOf[Filter]
+        ArrayBuffer.empty += IsNullFilter(toLiteral(operands.get(0))).asInstanceOf[Filter]
       case SqlKind.LESS_THAN=>
-        ArrayBuffer.empty += LessThanFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
+        ArrayBuffer.empty += LessThanFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1))).asInstanceOf[Filter]
     }
   }
 

--- a/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
@@ -599,6 +599,7 @@ class DefaultMahaCalciteSqlParserTest extends BaseMahaServiceTest with Matchers 
     val ser = ReportingRequest.serialize(request)
     assert(ser != null)
   }
+
   test("test superset table query - testing sum(colName), aliases, aliases in order by Desc") {
     val sql = s"""
           select "Student ID" as "ABC", SUM('Total Marks') AS "XYZ" from student_performance
@@ -628,6 +629,7 @@ class DefaultMahaCalciteSqlParserTest extends BaseMahaServiceTest with Matchers 
     val ser = ReportingRequest.serialize(request)
     assert(ser != null)
   }
+
   test("test superset table query - testing sum(colName), complex aliases, aliases in order by Desc") {
     val sql = s"""
           select SUM('Total Marks') AS "SUM(Total Marks)", "Student ID" as "ABC" from student_performance

--- a/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
@@ -571,24 +571,87 @@ class DefaultMahaCalciteSqlParserTest extends BaseMahaServiceTest with Matchers 
     request.toString shouldNot contain ("sp")
     }
 
-  test("test superset table query") {
+  test("test superset table query - testing sum(colName), aliases, aliases in order by Asc") {
     val sql = s"""
-          select "Student ID" as "Student ID", SUM('Total Marks') from student_performance
+          select "Student ID" as "ABC", SUM('Total Marks') AS "XYZ" from student_performance
           where "Student ID" = 123
               AND "Class ID" = 234
               AND "Total Marks" > 0
-          GROUP BY "Student ID"
+          GROUP BY "ABC"
+          ORDER BY "XYZ" ASC
           """
 
     val mahaSqlNode: MahaSqlNode = defaultMahaCalciteSqlParser.parse(sql, StudentSchema, "er")
     assert(mahaSqlNode.isInstanceOf[SelectSqlNode])
     val request = mahaSqlNode.asInstanceOf[SelectSqlNode].reportingRequest
+    //print(request)
     assert(request.requestType === SyncRequest)
     assert(request.selectFields.size > 1)
     assert(request.selectFields.map(_.field).contains("Student ID"))
     assert(request.selectFields.map(_.field).contains("Total Marks"))
     assert(request.filterExpressions.size == 3)
     assert(request.queryType == GroupByQuery)
+
+    request.sortBy.size shouldBe 1
+    request.sortBy.head.field shouldBe "Total Marks"
+    request.sortBy.head.order.toString shouldBe "ASC"
+
+    val ser = ReportingRequest.serialize(request)
+    assert(ser != null)
+  }
+  test("test superset table query - testing sum(colName), aliases, aliases in order by Desc") {
+    val sql = s"""
+          select "Student ID" as "ABC", SUM('Total Marks') AS "XYZ" from student_performance
+          where "Student ID" = 123
+              AND "Class ID" = 234
+              AND "Total Marks" > 0
+          GROUP BY "ABC"
+          ORDER BY "XYZ" DESC
+          """
+
+    val mahaSqlNode: MahaSqlNode = defaultMahaCalciteSqlParser.parse(sql, StudentSchema, "er")
+    assert(mahaSqlNode.isInstanceOf[SelectSqlNode])
+    val request = mahaSqlNode.asInstanceOf[SelectSqlNode].reportingRequest
+    //print(request)
+    assert(request.requestType === SyncRequest)
+    assert(request.selectFields.size > 1)
+    assert(request.selectFields.map(_.field).contains("Student ID"))
+    assert(request.selectFields.head.alias.get.equals("ABC"))
+    assert(request.selectFields.map(_.field).contains("Total Marks"))
+    assert(request.filterExpressions.size == 3)
+    assert(request.queryType == GroupByQuery)
+
+    request.sortBy.size shouldBe 1
+    request.sortBy.head.field shouldBe "Total Marks"
+    request.sortBy.head.order.toString shouldBe "DESC"
+
+    val ser = ReportingRequest.serialize(request)
+    assert(ser != null)
+  }
+  test("test superset table query - testing sum(colName), complex aliases, aliases in order by Desc") {
+    val sql = s"""
+          select SUM('Total Marks') AS "SUM(Total Marks)", "Student ID" as "ABC" from student_performance
+          where "Student ID" = 123
+              AND "Class ID" = 234
+              AND "Total Marks" > 0
+          GROUP BY "ABC"
+          ORDER BY "SUM(Total Marks)" DESC
+          """
+
+    val mahaSqlNode: MahaSqlNode = defaultMahaCalciteSqlParser.parse(sql, StudentSchema, "er")
+    assert(mahaSqlNode.isInstanceOf[SelectSqlNode])
+    val request = mahaSqlNode.asInstanceOf[SelectSqlNode].reportingRequest
+    //print(request)
+    assert(request.requestType === SyncRequest)
+    assert(request.selectFields.size > 1)
+    assert(request.selectFields.map(_.field).contains("Student ID"))
+    assert(request.selectFields.head.alias.get.equals("SUM(Total Marks)"))
+    assert(request.selectFields.map(_.field).contains("Total Marks"))
+    assert(request.queryType == GroupByQuery)
+
+    request.sortBy.size shouldBe 1
+    request.sortBy.head.field shouldBe "Total Marks"
+    request.sortBy.head.order.toString shouldBe "DESC"
 
     val ser = ReportingRequest.serialize(request)
     assert(ser != null)

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.115-SNAPSHOT</version>
+        <version>6.116-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

* Added conditions for when sqlBasicCall.operands(0) is also of type SqlBasicCall (eg - for `sqlBasicCall=SUM("Impressions") AS "ABC"`, `sqlBasicCall.operands(0) = SUM("Impressions")` which needs to be parsed further)
* Created map `queryAliasToColumnNameMap` for column aliases, populated it while parsing select columns, and used it in identifying columns for order by where the aliases are used. (Had to reorder code as well for this so that select parsing happens before orderby parsing)
* Passing the aliases into reporting request
