### PR TITLE
Convert incoming day filters to Between filter

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.116-SNAPSHOT</version>
+    <version>6.117-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -301,18 +301,27 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
       case SqlKind.IS_NULL =>
         ArrayBuffer.empty += IsNullFilter(toLiteral(operands.get(0))).asInstanceOf[Filter]
       case SqlKind.LESS_THAN=>
-        if(toLiteral(operands(0)).equals(DailyGrain.DAY_FILTER_FIELD)) {
-          toDate = DailyGrain.toFormattedString(DateTime.parse(toLiteral(operands(1)), DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")))
+        if(toLiteral(operands.get(0)).equals(DailyGrain.DAY_FILTER_FIELD)) {
+          toDate = DailyGrain.toFormattedString(DateTime.parse(toLiteral(operands.get(1)), DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")))
           ArrayBuffer.empty
         }
         else
-          ArrayBuffer.empty += LessThanFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
+          ArrayBuffer.empty += LessThanFilter(toLiteral(operands.get(0)), toLiteral(operands.get(1))).asInstanceOf[Filter]
       case SqlKind.GREATER_THAN_OR_EQUAL =>
-        if(toLiteral(operands(0)).equals(DailyGrain.DAY_FILTER_FIELD)) {
-          fromDate = DailyGrain.toFormattedString(DateTime.parse(toLiteral(operands(1)),DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")))
+        if(toLiteral(operands.get(0)).equals(DailyGrain.DAY_FILTER_FIELD)) {
+          fromDate = DailyGrain.toFormattedString(DateTime.parse(toLiteral(operands.get(1)),DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")))
         }
         else {
           val errMsg = s"SqlKind.GREATER_THAN_OR_EQUAL filter is supported only for Day column"
+          logger.error(errMsg);
+        }
+        ArrayBuffer.empty
+      case SqlKind.LESS_THAN_OR_EQUAL=>
+        if(toLiteral(operands.get(0)).equals(DailyGrain.DAY_FILTER_FIELD)) {
+          toDate = DailyGrain.toFormattedString(DateTime.parse(toLiteral(operands.get(1)), DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")))
+        }
+        else {
+          val errMsg = s"SqlKind.LESSER_THAN_OR_EQUAL filter is supported only for Day column"
           logger.error(errMsg);
         }
         ArrayBuffer.empty

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/MahaCalciteSqlParser.scala
@@ -306,7 +306,7 @@ case class DefaultMahaCalciteSqlParser(mahaServiceConfig: MahaServiceConfig) ext
           ArrayBuffer.empty
         }
         else
-        ArrayBuffer.empty += LessThanFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
+          ArrayBuffer.empty += LessThanFilter(toLiteral(operands(0)), toLiteral(operands(1))).asInstanceOf[Filter]
       case SqlKind.GREATER_THAN_OR_EQUAL =>
         if(toLiteral(operands(0)).equals(DailyGrain.DAY_FILTER_FIELD)) {
           fromDate = DailyGrain.toFormattedString(DateTime.parse(toLiteral(operands(1)),DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")))

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaService.scala
@@ -496,7 +496,7 @@ object MahaAvaticaServiceHelper extends Logging {
     val dataTypeMap: Map[String, String] = Map(
         "IntType" -> "bigint",
         "StrType" -> "varchar",
-        "DecType" -> "float",
+        "DecType" -> "double",
         "DateType" -> "date",
         "TimestampType" -> "timestamp",
         "PassthroughType" -> "varchar"

--- a/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
@@ -666,7 +666,7 @@ class DefaultMahaCalciteSqlParserTest extends BaseMahaServiceTest with Matchers 
           select SUM('Total Marks') AS "SUM(Total Marks)", "Student ID" as "ABC" from student_performance
           where "Student ID" = 123
               AND "Class ID" = 234
-              AND "Total Marks" > 0
+              AND "Total Marks" >= 0
               AND "Day" >= '2022-10-26 00:00:00.000000'
               AND "Day" < '2022-10-27 00:00:00.000000'
           GROUP BY "ABC"
@@ -678,6 +678,7 @@ class DefaultMahaCalciteSqlParserTest extends BaseMahaServiceTest with Matchers 
     val request = mahaSqlNode.asInstanceOf[SelectSqlNode].reportingRequest
     //print(request)
     assert(request.dayFilter.toString contains "BetweenFilter(Day,2022-10-26,2022-10-27)")
+    assert((request.dayFilter.toString contains "GreaterFilter(Total Marks,0)")==false)
 
     val ser = ReportingRequest.serialize(request)
     assert(ser != null)

--- a/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/calcite/DefaultMahaCalciteSqlParserTest.scala
@@ -655,6 +655,30 @@ class DefaultMahaCalciteSqlParserTest extends BaseMahaServiceTest with Matchers 
     request.sortBy.head.field shouldBe "Total Marks"
     request.sortBy.head.order.toString shouldBe "DESC"
 
+    assert(request.dayFilter.toString contains "BetweenFilter(Day")
+
+    val ser = ReportingRequest.serialize(request)
+    assert(ser != null)
+  }
+
+  test("test superset table query - testing Day filters") {
+    val sql = s"""
+          select SUM('Total Marks') AS "SUM(Total Marks)", "Student ID" as "ABC" from student_performance
+          where "Student ID" = 123
+              AND "Class ID" = 234
+              AND "Total Marks" > 0
+              AND "Day" >= '2022-10-26 00:00:00.000000'
+              AND "Day" < '2022-10-27 00:00:00.000000'
+          GROUP BY "ABC"
+          ORDER BY "SUM(Total Marks)" DESC
+          """
+
+    val mahaSqlNode: MahaSqlNode = defaultMahaCalciteSqlParser.parse(sql, StudentSchema, "er")
+    assert(mahaSqlNode.isInstanceOf[SelectSqlNode])
+    val request = mahaSqlNode.asInstanceOf[SelectSqlNode].reportingRequest
+    //print(request)
+    assert(request.dayFilter.toString contains "BetweenFilter(Day,2022-10-26,2022-10-27)")
+
     val ser = ReportingRequest.serialize(request)
     assert(ser != null)
   }

--- a/service/src/test/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaServiceTest.scala
+++ b/service/src/test/scala/com/yahoo/maha/service/calcite/avatica/MahaAvaticaServiceTest.scala
@@ -171,7 +171,7 @@ class MahaAvaticaServiceTest extends BaseMahaServiceTest {
     rowsIt.forEachRemaining(s=> {
       //Section ID,Date are DimCol from FactTable, Performance Factor is a FactCol from FactTable, Student Name is a DimCol from DimTable
       if(s.asInstanceOf[Array[String]](0).equals("Section ID")) assert(s.asInstanceOf[Array[String]](2).equals("bigint"))
-      else if(s.asInstanceOf[Array[String]](0).equals("Performance Factor")) assert(s.asInstanceOf[Array[String]](2).equals("float"))
+      else if(s.asInstanceOf[Array[String]](0).equals("Performance Factor")) assert(s.asInstanceOf[Array[String]](2).equals("double"))
       else if(s.asInstanceOf[Array[String]](0).equals("Student Name")) assert(s.asInstanceOf[Array[String]](2).equals("varchar"))
       else if(s.asInstanceOf[Array[String]](0).equals("Date")) assert(s.asInstanceOf[Array[String]](2).equals("date"))
       //println(s.asInstanceOf[Array[String]](0)+" +++ "+s.asInstanceOf[Array[String]](1)+" +++ "+ s.asInstanceOf[Array[String]](2) + " +++ " + s.asInstanceOf[Array[String]](3) + " ")

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.116-SNAPSHOT</version>
+        <version>6.117-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

* Superset passes 2 Day filters such as :
```
WHERE "Day" >= '2022-10-25 00:00:00.000000'
  AND "Day" < '2022-11-01 00:00:00.000000'
```
* So new code gathers the `from` and `to` dates from the above 2 filters, and then creates a `Between filter` for Day that maha expects, after the filters are parsed.

* Test for the above

Other changes:
* Change mapping from float to double that mahajdbc expects for DecType
* Change default from and to variable names.