### PR TITLE
Reduce log level for cache check failures to info

### DIFF
--- a/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
+++ b/druid-lookups/src/main/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactory.java
@@ -182,7 +182,7 @@ public class URIExtractionNamespaceCacheFactory
 
     private byte[] checkCacheAndReturn(URIExtractionNamespace extractionNamespace, Map<String, List<String>> cache, String key, String valueColumn) {
         if(!cache.containsKey(key) || !extractionNamespace.getNamespaceParseSpec().getColumns().contains(valueColumn)){
-            log.error("Found no value for " + key + " with Namespace Cols: " + extractionNamespace.getNamespaceParseSpec().getColumns().toString() + " and val: " + valueColumn);
+            log.info("Found no value for " + key + " with Namespace Cols: " + extractionNamespace.getNamespaceParseSpec().getColumns().toString() + " and val: " + valueColumn);
             return new byte[0];
         } else {
             return cache.get(key).get(extractionNamespace.getNamespaceParseSpec().getColumns().indexOf(valueColumn)).getBytes();


### PR DESCRIPTION
In case requests are coking in for lookups with many invalid keys, but doesn't remove these logs entirely as these misses are important.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
