### PR TITLE
Add Druid capabilities for Union DataSource

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -299,7 +299,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
 
   def createDataSource(dataSource: String): DataSource = {
     if(dataSource.split(",").length <= 1)
-      new TableDataSource(dataSource)
+      new TableDataSource(dataSource.split(",").head)
     else {
       val unionSources = dataSource.split(",").toSet
       val unionSourcesObject: List[TableDataSource] = unionSources.map(source => new TableDataSource(source)).toList

--- a/core/src/main/scala/com/yahoo/maha/core/request/Request.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/request/Request.scala
@@ -144,6 +144,7 @@ case class JobNameValue(value: String) extends ParameterValue[String]
 case class RegistryNameValue(value: String) extends ParameterValue[String]
 case class HostNameValue(value: String) extends ParameterValue[String]
 case class AllowPushDownNameValue(value: String) extends ParameterValue[String]
+//case class AdditionalColumnInfo(values: IndexedSeq[String]) extends ParameterValue[IndexedSeq[String]]
 
 sealed abstract class Parameter(override val entryName: String) extends EnumEntry with Snakecase with Uppercase
 
@@ -166,6 +167,7 @@ object Parameter extends Enum[Parameter] with Logging {
   case object RegistryName extends Parameter("RegistryName")
   case object HostName extends Parameter("HostName")
   case object AllowPushDownName extends Parameter("AllowPushDown")
+  case object AdditionalColumnInfo extends Parameter("AdditionalColumnInfo")
 
   import syntax.validation._
   def deserializeParameters(json: JValue) : JsonScalaz.Result[Map[Parameter, ParameterValue[_]]] = {

--- a/core/src/main/scala/com/yahoo/maha/core/request/Request.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/request/Request.scala
@@ -144,7 +144,6 @@ case class JobNameValue(value: String) extends ParameterValue[String]
 case class RegistryNameValue(value: String) extends ParameterValue[String]
 case class HostNameValue(value: String) extends ParameterValue[String]
 case class AllowPushDownNameValue(value: String) extends ParameterValue[String]
-//case class AdditionalColumnInfo(values: IndexedSeq[String]) extends ParameterValue[IndexedSeq[String]]
 
 sealed abstract class Parameter(override val entryName: String) extends EnumEntry with Snakecase with Uppercase
 
@@ -167,7 +166,6 @@ object Parameter extends Enum[Parameter] with Logging {
   case object RegistryName extends Parameter("RegistryName")
   case object HostName extends Parameter("HostName")
   case object AllowPushDownName extends Parameter("AllowPushDown")
-  case object AdditionalColumnInfo extends Parameter("AdditionalColumnInfo")
 
   import syntax.validation._
   def deserializeParameters(json: JValue) : JsonScalaz.Result[Map[Parameter, ParameterValue[_]]] = {

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
@@ -47,6 +47,7 @@ class BaseDruidQueryGeneratorTest extends AnyFunSuite with Matchers with BeforeA
     registryBuilder.register(pubfact16(forcedFilters))
     registryBuilder.register(pubfact17(forcedFilters))
     registryBuilder.register(pubfact18(forcedFilters))
+    registryBuilder.register(pubfact19(forcedFilters))
   }
 
   private[this] def factBuilder(annotations: Set[FactAnnotation]): FactBuilder = {
@@ -1019,6 +1020,56 @@ class BaseDruidQueryGeneratorTest extends AnyFunSuite with Matchers with BeforeA
       )
     }
   }
+
+  private[this] def factBuilder10(): FactBuilder = {
+    import DruidExpression._
+    ColumnContext.withColumnContext { implicit dc: ColumnContext =>
+      Fact.newFact(
+        "fact1,", DailyGrain, DruidEngine, Set(AdvertiserSchema, InternalSchema),
+        Set(
+          DimCol("id", IntType(), annotations = Set(ForeignKey("keyword")))
+          , DimCol("ad_id", IntType(), annotations = Set(ForeignKey("ad")))
+          , DimCol("ad_group_id", IntType(), annotations = Set(ForeignKey("ad_group")))
+          , DimCol("campaign_id", IntType(), alias = Option("campaign_id_alias"), annotations = Set(ForeignKey("campaign")))
+          , DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+          , DimCol("external_id", IntType(), annotations = Set(ForeignKey("site_externals")))
+          , DimCol("stats_source", IntType(3))
+          , DimCol("price_type", IntType(3, (Map(1 -> "CPC", 2 -> "CPA", 3 -> "CPM", 6 -> "CPV", 7 -> "CPCV", -10 -> "CPE", -20 -> "CPF"), "NONE")))
+          , DruidFuncDimCol("Derived Pricing Type", IntType(3), DECODE_DIM("{price_type}", "7", "6"))
+          , DimCol("start_time", TimestampType("yyyyMMdd"))
+          , DimCol("landing_page_url", StrType(), annotations = Set(EscapingRequired))
+          , DimCol("stats_date", DateType("yyyyMMdd"), Some("statsDate"))
+          , DimCol("engagement_type", StrType(3))
+          , DruidFuncDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "w"))
+          , DruidFuncDimCol("Day of Week", DateType(), DAY_OF_WEEK("{stats_date}"))
+          , DruidFuncDimCol("My Date", DateType(), DRUID_TIME_FORMAT("YYYY-MM-dd"))
+          , DimCol("show_sov_flag", IntType())
+          , DruidFuncDimCol("Day Timestamp", TimestampType("yyyy-MM-dd"), DRUID_TIME_FORMAT("yyyy-MM-dd"))
+          , DruidFuncDimCol("week_start", TimestampType("yyyy-MM-dd"), DRUID_TIME_FORMAT_WITH_PERIOD_GRANULARITY("yyyy-MM-dd", "P1W"))
+          , DruidFuncDimCol("Date From Req Context", TimestampType("YYYY-MM-dd"), TIME_FORMAT_WITH_REQUEST_CONTEXT("YYYY-MM-dd"))
+          , DruidFuncDimCol("Start DateTime", TimestampType("yyyyMMdd"), DATETIME_FORMATTER("{start_time}", 0, 12))
+        ),
+        Set(
+          FactCol("impressions", IntType(3, 1))
+          , FactCol("sov_impressions", IntType())
+          , FactCol("clicks", IntType(3, 0, 1, 800))
+          , FactCol("spend", DecType(0, "0.0"))
+          , FactCol("max_bid", DecType(0, "0.0"), MaxRollup)
+          , FactCol("min_bid", DecType(0, "0.0"), MinRollup)
+          , FactCol("avg_bid", DecType(0, "0.0"), AverageRollup)
+          , FactCol("avg_pos_times_impressions", DecType(0, "0.0"), MaxRollup)
+          , FactCol("engagement_count", IntType(0, 0))
+          , DruidDerFactCol("Average CPC", DecType(), "{spend}" / "{clicks}")
+          , DruidDerFactCol("CTR", DecType(), "{clicks}" /- "{impressions}")
+          , DruidDerFactCol("derived_avg_pos", DecType(3, "0.0", "0.1", "500"), "{avg_pos_times_impressions}" /- "{impressions}")
+          , FactCol("Reblogs", IntType(), DruidFilteredRollup(EqualityFilter("engagement_type", "1"), "engagement_count", SumRollup))
+          , DruidDerFactCol("Reblog Rate", DecType(), "{Reblogs}" /- "{impressions}" * "100")
+          , DruidPostResultDerivedFactCol("impression_share", StrType(), "{impressions}" /- "{sov_impressions}", postResultFunction = POST_RESULT_DECODE("{show_sov_flag}", "0", "N/A"))
+        ),
+        annotations = Set(DruidGroupByStrategyV2)
+      )
+    }
+  }
   private[this] def pubfact11(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
     import DruidExpression._
     factBuilder6().toPublicFact("k_stats_minute_grain_ts_dtf",
@@ -1293,6 +1344,46 @@ class BaseDruidQueryGeneratorTest extends AnyFunSuite with Matchers with BeforeA
   private[this] def pubfact18(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
     import DruidExpression._
     factBuilder9().toPublicFact("k_stats_daily_grain_ts_dtf2",
+      Set(
+        PubCol("Day Timestamp", "Day", InBetweenDateTimeBetweenEquality),
+        PubCol("engagement_type", "engagement_type", Equality),
+        PubCol("id", "Keyword ID", InEquality),
+        PubCol("ad_id", "Ad ID", InEquality),
+        PubCol("ad_group_id", "Ad Group ID", InEquality),
+        PubCol("campaign_id", "Campaign ID", InEquality),
+        PubCol("advertiser_id", "Advertiser ID", InEquality),
+        PubCol("stats_source", "Source", Equality),
+        PubCol("price_type", "Pricing Type", In),
+        PubCol("Derived Pricing Type", "Derived Pricing Type", InEquality),
+        PubCol("landing_page_url", "Destination URL", Set.empty),
+        PubCol("Week", "Week", InEquality),
+        PubCol("My Date", "My Date", InEquality),
+        PubCol("Day of Week", "Day of Week", InEquality),
+        PubCol("week_start", "Week Start", InEquality),
+        PubCol("Date From Req Context", "Date From Req Context", InEquality),
+        PubCol("Start DateTime", "Start DateTime", InEquality)
+      ),
+      Set(
+        PublicFactCol("impressions", "Impressions", InBetweenEquality),
+        PublicFactCol("clicks", "Clicks", InBetweenEquality),
+        PublicFactCol("spend", "Spend", Set.empty),
+        PublicFactCol("derived_avg_pos", "Average Position", Set.empty),
+        PublicFactCol("max_bid", "Max Bid", Set.empty),
+        PublicFactCol("min_bid", "Min Bid", Set.empty),
+        PublicFactCol("avg_bid", "Average Bid", Set.empty),
+        PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
+        PublicFactCol("Reblogs", "Reblogs", InBetweenEquality),
+        PublicFactCol("Reblog Rate", "Reblog Rate", InBetweenEquality),
+        PublicFactCol("CTR", "CTR", InBetweenEquality)
+      ),
+      Set(),
+      getMaxDaysWindow, getMaxDaysLookBack, renderLocalTimeFilter = true
+    )
+  }
+
+  private[this] def pubfact19(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+    import DruidExpression._
+    factBuilder10().toPublicFact("k_stats_daily_grain_ts_dtf3",
       Set(
         PubCol("Day Timestamp", "Day", InBetweenDateTimeBetweenEquality),
         PubCol("engagement_type", "engagement_type", Equality),

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/BaseDruidQueryGeneratorTest.scala
@@ -46,6 +46,7 @@ class BaseDruidQueryGeneratorTest extends AnyFunSuite with Matchers with BeforeA
     registryBuilder.register(pubfact15(forcedFilters))
     registryBuilder.register(pubfact16(forcedFilters))
     registryBuilder.register(pubfact17(forcedFilters))
+    registryBuilder.register(pubfact18(forcedFilters))
   }
 
   private[this] def factBuilder(annotations: Set[FactAnnotation]): FactBuilder = {
@@ -968,6 +969,56 @@ class BaseDruidQueryGeneratorTest extends AnyFunSuite with Matchers with BeforeA
       )
     }
   }
+
+  private[this] def factBuilder9(): FactBuilder = {
+    import DruidExpression._
+    ColumnContext.withColumnContext { implicit dc: ColumnContext =>
+      Fact.newFact(
+        "fact1,fact2", DailyGrain, DruidEngine, Set(AdvertiserSchema, InternalSchema),
+        Set(
+          DimCol("id", IntType(), annotations = Set(ForeignKey("keyword")))
+          , DimCol("ad_id", IntType(), annotations = Set(ForeignKey("ad")))
+          , DimCol("ad_group_id", IntType(), annotations = Set(ForeignKey("ad_group")))
+          , DimCol("campaign_id", IntType(), alias = Option("campaign_id_alias"), annotations = Set(ForeignKey("campaign")))
+          , DimCol("advertiser_id", IntType(), annotations = Set(ForeignKey("advertiser")))
+          , DimCol("external_id", IntType(), annotations = Set(ForeignKey("site_externals")))
+          , DimCol("stats_source", IntType(3))
+          , DimCol("price_type", IntType(3, (Map(1 -> "CPC", 2 -> "CPA", 3 -> "CPM", 6 -> "CPV", 7 -> "CPCV", -10 -> "CPE", -20 -> "CPF"), "NONE")))
+          , DruidFuncDimCol("Derived Pricing Type", IntType(3), DECODE_DIM("{price_type}", "7", "6"))
+          , DimCol("start_time", TimestampType("yyyyMMdd"))
+          , DimCol("landing_page_url", StrType(), annotations = Set(EscapingRequired))
+          , DimCol("stats_date", DateType("yyyyMMdd"), Some("statsDate"))
+          , DimCol("engagement_type", StrType(3))
+          , DruidFuncDimCol("Week", DateType(), GET_INTERVAL_DATE("{stats_date}", "w"))
+          , DruidFuncDimCol("Day of Week", DateType(), DAY_OF_WEEK("{stats_date}"))
+          , DruidFuncDimCol("My Date", DateType(), DRUID_TIME_FORMAT("YYYY-MM-dd"))
+          , DimCol("show_sov_flag", IntType())
+          , DruidFuncDimCol("Day Timestamp", TimestampType("yyyy-MM-dd"), DRUID_TIME_FORMAT("yyyy-MM-dd"))
+          , DruidFuncDimCol("week_start", TimestampType("yyyy-MM-dd"), DRUID_TIME_FORMAT_WITH_PERIOD_GRANULARITY("yyyy-MM-dd", "P1W"))
+          , DruidFuncDimCol("Date From Req Context", TimestampType("YYYY-MM-dd"), TIME_FORMAT_WITH_REQUEST_CONTEXT("YYYY-MM-dd"))
+          , DruidFuncDimCol("Start DateTime", TimestampType("yyyyMMdd"), DATETIME_FORMATTER("{start_time}", 0, 12))
+        ),
+        Set(
+          FactCol("impressions", IntType(3, 1))
+          , FactCol("sov_impressions", IntType())
+          , FactCol("clicks", IntType(3, 0, 1, 800))
+          , FactCol("spend", DecType(0, "0.0"))
+          , FactCol("max_bid", DecType(0, "0.0"), MaxRollup)
+          , FactCol("min_bid", DecType(0, "0.0"), MinRollup)
+          , FactCol("avg_bid", DecType(0, "0.0"), AverageRollup)
+          , FactCol("avg_pos_times_impressions", DecType(0, "0.0"), MaxRollup)
+          , FactCol("engagement_count", IntType(0, 0))
+          , DruidDerFactCol("Average CPC", DecType(), "{spend}" / "{clicks}")
+          , DruidDerFactCol("CTR", DecType(), "{clicks}" /- "{impressions}")
+          , DruidDerFactCol("derived_avg_pos", DecType(3, "0.0", "0.1", "500"), "{avg_pos_times_impressions}" /- "{impressions}")
+          , FactCol("Reblogs", IntType(), DruidFilteredRollup(EqualityFilter("engagement_type", "1"), "engagement_count", SumRollup))
+          , DruidDerFactCol("Reblog Rate", DecType(), "{Reblogs}" /- "{impressions}" * "100")
+          , DruidPostResultDerivedFactCol("impression_share", StrType(), "{impressions}" /- "{sov_impressions}", postResultFunction = POST_RESULT_DECODE("{show_sov_flag}", "0", "N/A"))
+        ),
+        annotations = Set(DruidGroupByStrategyV2)
+      )
+    }
+  }
   private[this] def pubfact11(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
     import DruidExpression._
     factBuilder6().toPublicFact("k_stats_minute_grain_ts_dtf",
@@ -1202,6 +1253,46 @@ class BaseDruidQueryGeneratorTest extends AnyFunSuite with Matchers with BeforeA
   private[this] def pubfact17(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
     import DruidExpression._
     factBuilder8().toPublicFact("k_stats_daily_grain_ts_dtf",
+      Set(
+        PubCol("Day Timestamp", "Day", InBetweenDateTimeBetweenEquality),
+        PubCol("engagement_type", "engagement_type", Equality),
+        PubCol("id", "Keyword ID", InEquality),
+        PubCol("ad_id", "Ad ID", InEquality),
+        PubCol("ad_group_id", "Ad Group ID", InEquality),
+        PubCol("campaign_id", "Campaign ID", InEquality),
+        PubCol("advertiser_id", "Advertiser ID", InEquality),
+        PubCol("stats_source", "Source", Equality),
+        PubCol("price_type", "Pricing Type", In),
+        PubCol("Derived Pricing Type", "Derived Pricing Type", InEquality),
+        PubCol("landing_page_url", "Destination URL", Set.empty),
+        PubCol("Week", "Week", InEquality),
+        PubCol("My Date", "My Date", InEquality),
+        PubCol("Day of Week", "Day of Week", InEquality),
+        PubCol("week_start", "Week Start", InEquality),
+        PubCol("Date From Req Context", "Date From Req Context", InEquality),
+        PubCol("Start DateTime", "Start DateTime", InEquality)
+      ),
+      Set(
+        PublicFactCol("impressions", "Impressions", InBetweenEquality),
+        PublicFactCol("clicks", "Clicks", InBetweenEquality),
+        PublicFactCol("spend", "Spend", Set.empty),
+        PublicFactCol("derived_avg_pos", "Average Position", Set.empty),
+        PublicFactCol("max_bid", "Max Bid", Set.empty),
+        PublicFactCol("min_bid", "Min Bid", Set.empty),
+        PublicFactCol("avg_bid", "Average Bid", Set.empty),
+        PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
+        PublicFactCol("Reblogs", "Reblogs", InBetweenEquality),
+        PublicFactCol("Reblog Rate", "Reblog Rate", InBetweenEquality),
+        PublicFactCol("CTR", "CTR", InBetweenEquality)
+      ),
+      Set(),
+      getMaxDaysWindow, getMaxDaysLookBack, renderLocalTimeFilter = true
+    )
+  }
+
+  private[this] def pubfact18(forcedFilters: Set[ForcedFilter] = Set.empty): PublicFact = {
+    import DruidExpression._
+    factBuilder9().toPublicFact("k_stats_daily_grain_ts_dtf2",
       Set(
         PubCol("Day Timestamp", "Day", InBetweenDateTimeBetweenEquality),
         PubCol("engagement_type", "engagement_type", Equality),

--- a/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/druid/DruidQueryGeneratorTest.scala
@@ -3958,5 +3958,47 @@ class DruidQueryGeneratorTest extends BaseDruidQueryGeneratorTest {
     assert (result.contains(json2), "Missing dimension JSON in result: " + result)
   }
 
+  test("Generate a valid query at daily grain with datetime between filter with timestamp type for Day, use Union table def") {
+    val cubes = List("k_stats_daily_grain_ts_dtf2")
+    cubes.foreach {
+      cube =>
+        val jsonString =
+          s"""{
+                          "cube": "$cube",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Week"},
+                            {"field": "Keyword ID"},
+                            {"field": "Keyword Value"},
+                            {"field": "Source"},
+                            {"field": "Clicks"},
+                            {"field": "CTR"},
+                            {"field": "Reblogs"},
+                            {"field": "Reblog Rate"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "datetimebetween", "from": "${fromDateTime}", "to": "$toDateTime", "format": "$iso8601Format"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "12345"}
+                          ],
+                          "sortBy": [
+                            {"field": "Impressions", "order": "Desc"}
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                        }"""
+        val request: ReportingRequest = getReportingRequestSync(jsonString)
+        val requestModel = getRequestModel(request, defaultRegistry)
+        assert(requestModel.isSuccess, requestModel.errorMessage("Failed to get request model"))
+        val queryPipelineTry = generatePipeline(requestModel.toOption.get)
+        assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+        val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]].asString
+        assert(result.contains("Day") && result.contains("selector") && result.contains(DailyGrain.toFullFormattedString(baseDate)), result)
+        println(result)
+    }
+  }
+
+
 }
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.120-SNAPSHOT</version>
+    <version>6.121-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.120-SNAPSHOT</version>
+        <version>6.121-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


Issue: Druid is only querying on a single data source.  

Without making massive changes to the code base, this allows Druid definitions anywhere in the Fact hierarchy to generate Union datasource queries.  ex:
```
{"queryType":"groupBy","dataSource":{"type":"union","dataSources":[{"type":"table","name":"fact1"},{"type":"table","name":"fact2"}]},"intervals":
...
```

Note that this change is relatively simple for Druid since Druid Native queries support this sort of logic, but SQL-based queries will need a fact-fact union generator or augmentation to serve this distinct use case.