### PR TITLE
AdditionalInfo: Add User-Modifiable Derived Expression

### DIFF
--- a/core/src/main/scala/com/yahoo/maha/core/DerivedExpression.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/DerivedExpression.scala
@@ -8,7 +8,6 @@ package com.yahoo.maha.core
 
 import java.util
 import java.util.concurrent.atomic.AtomicLong
-
 import com.google.common.collect.Lists
 import com.yahoo.maha.core.ThetaSketchSetOp.ThetaSketchSetOp
 import com.yahoo.maha.core.fact.FactCol
@@ -374,6 +373,10 @@ object PrestoExpression {
     def asString : String = s
   }
 
+  case class COL_W_REPLACEMENTS(s: String, hasRollupExpression: Boolean = false, hasNumericOperation: Boolean = false) extends BasePrestoExpression {
+    def asString: String = s
+  }
+
   case class SUM(s: PrestoExp) extends BasePrestoExpression {
     val hasRollupExpression = true
     val hasNumericOperation = true
@@ -510,7 +513,11 @@ object HiveExpression {
   }
 
   case class COL(s: String, hasRollupExpression: Boolean = false, hasNumericOperation: Boolean = false) extends BaseHiveExpression {
-    def asString : String = s
+    def asString: String = s
+  }
+
+  case class COL_W_REPLACEMENTS(s: String, hasRollupExpression: Boolean = false, hasNumericOperation: Boolean = false) extends BaseHiveExpression {
+    def asString: String = s
   }
 
   case class SUM(s: HiveExp) extends BaseHiveExpression {
@@ -1399,6 +1406,10 @@ object BigqueryExpression {
   }
 
   case class COL(s: String, hasRollupExpression: Boolean = false, hasNumericOperation: Boolean = false) extends BaseBigqueryExpression {
+    def asString: String = s
+  }
+
+  case class COL_W_REPLACEMENTS(s: String, hasRollupExpression: Boolean = false, hasNumericOperation: Boolean = false) extends BaseBigqueryExpression {
     def asString: String = s
   }
 

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
@@ -3,6 +3,7 @@ package com.yahoo.maha.core.query.presto
 import com.yahoo.maha.core._
 import com.yahoo.maha.core.dimension._
 import com.yahoo.maha.core.fact._
+import com.yahoo.maha.core.query.QueryGeneratorHelper.getAdditionalColData
 import com.yahoo.maha.core.query._
 import grizzled.slf4j.Logging
 

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGenerator.scala
@@ -5,6 +5,7 @@ package com.yahoo.maha.core.query.presto
 import com.yahoo.maha.core._
 import com.yahoo.maha.core.dimension._
 import com.yahoo.maha.core.fact._
+import com.yahoo.maha.core.query.QueryGeneratorHelper.{getAdditionalColData, overrideRenderedCol}
 import com.yahoo.maha.core.query._
 
 import grizzled.slf4j.Logging
@@ -237,8 +238,9 @@ class PrestoQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, udfS
             name
           case PrestoDerDimCol(_, dt, _, de, _, _, _) =>
             val renderedAlias = renderColumnAlias(alias)
+            val overriddenCol = overrideRenderedCol(false, getAdditionalColData(queryContext), column.asInstanceOf[PrestoDerDimCol], name)
             queryBuilderContext.setFactColAlias(alias, renderedAlias, column)
-            s"""${de.render(name, Map.empty)} $renderedAlias"""
+            s"""${overriddenCol} $renderedAlias"""
           case FactCol(_, dt, _, rollup, _, _, _) =>
             dt match {
               case DecType(_, _, Some(default), Some(min), Some(max), _) =>
@@ -438,7 +440,8 @@ class PrestoQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, udfS
           case DimCol(_, dt, _, _, _, _) =>
             name
           case PrestoDerDimCol(_, dt, _, de, _, _, _) =>
-            s"""${de.render(name, Map.empty)}"""
+            val overriddenCol = overrideRenderedCol(false, getAdditionalColData(queryContext), column.asInstanceOf[PrestoDerDimCol], name)
+            s"""${overriddenCol}"""
           case other => throw new IllegalArgumentException(s"Unhandled column type for dimension cols : $other")
         }
       }

--- a/core/src/test/scala/com/yahoo/maha/core/query/presto/BasePrestoQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/presto/BasePrestoQueryGeneratorTest.scala
@@ -573,6 +573,8 @@ trait BasePrestoQueryGeneratorTest
           , DimCol("column_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned")))
           , DimCol("column2_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned_with_singleton")))
           , PrestoDerDimCol("Ad Group Start Date Full", StrType(), TIMESTAMP_TO_FORMATTED_DATE("{start_time}", "YYYY-MM-dd HH:mm:ss"))
+          , PrestoDerDimCol("col_test", StrType(), COL("CASE WHEN ({keyword_id}) is not null then ({keyword}) ELSE ({search_term}) END"))
+          , PrestoDerDimCol("col_modifiable_test", StrType(), COL_W_REPLACEMENTS("CASE WHEN ({keyword_id}) is not null then ({keyword}) ELSE ({search_term}) END"))
 
         ),
         Set(
@@ -607,7 +609,9 @@ trait BasePrestoQueryGeneratorTest
           PubCol("column2_id", "Column2 ID", Equality),
           PubCol("Ad Group Start Date Full", "Ad Group Start Date Full", InEquality),
           PubCol("network_type", "Network ID", InEquality),
-          PubCol("device_id", "Device ID", InEquality)
+          PubCol("device_id", "Device ID", InEquality),
+          PubCol("col_test", "Test COL Function", InEquality),
+          PubCol("col_modifiable_test", "Test Modifiable COL Function", InEquality)
         ),
         Set(
           PublicFactCol("impressions", "Impressions", InNotInBetweenEqualityNotEqualsGreaterLesser),


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


Add a COL_W_REPLACEMENTS DerivedExpression, this will:
- By default, act the same as COL.
- When user specifies, any substring in this may be replaced in the reportingRequest within additionalParameters (if we are allowing these parameters to get parsed, API restricts this parsing heavily)

This PR demos the POC on PrestoQueryGenerator, further PRs will add Hive, Druid, Oracle, etc one at a time (for easy reverts)