### PR TITLE
Demonstrate global URI is persisting in Executor.

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/test/scala/com/yahoo/maha/core/query/BaseQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/BaseQueryGeneratorTest.scala
@@ -62,8 +62,9 @@ trait BaseQueryGeneratorTest {
                       , registry: Registry
                       , userTimeZoneProvider: UserTimeZoneProvider = NoopUserTimeZoneProvider
                       , utcTimeProvider: UTCTimeProvider = PassThroughUTCTimeProvider
-                      , revision: Option[Int] = None): Try[RequestModel] = {
-    RequestModel.from(request, registry, userTimeZoneProvider, utcTimeProvider, revision)
+                      , revision: Option[Int] = None
+                      , uri: String = null): Try[RequestModel] = {
+    RequestModel.from(request, registry, userTimeZoneProvider, utcTimeProvider, revision, uri)
   }
 
   protected[this] def getReportingRequestAsync(jsonString: String, schema: Schema = AdvertiserSchema) = {

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/druid/src/main/scala/com/yahoo/maha/executor/druid/DruidQueryExecutor.scala
+++ b/druid/src/main/scala/com/yahoo/maha/executor/druid/DruidQueryExecutor.scala
@@ -432,8 +432,11 @@ class DruidQueryExecutor(config: DruidQueryExecutorConfig, lifecycleListener: Ex
       throw new UnsupportedOperationException(s"DruidQueryExecutor does not support query with engine=${query.engine}")
     } else {
       val isFactDriven = query.queryContext.requestModel.isFactDriven
-      if (isFactDriven && query.queryContext.requestModel.uri != null)
-        url = query.queryContext.requestModel.uri
+      val local_url: String = if (isFactDriven && query.queryContext.requestModel.uri != null) {
+        query.queryContext.requestModel.uri
+      } else {
+        url
+      }
 
       val headersWithAuthHeader = if (config.headers.isDefined) {
         Some(config.headers.get ++ authHeaderProvider.getAuthHeaders)
@@ -450,7 +453,7 @@ class DruidQueryExecutor(config: DruidQueryExecutorConfig, lifecycleListener: Ex
           val performJoin = irl.size > 0
           var pagination: Option[JValue] = null
           val result = Try {
-            val response: Response = httpUtils.post(url, httpUtils.POST, headersWithAuthHeader, Some(query.asString))
+            val response: Response = httpUtils.post(local_url, httpUtils.POST, headersWithAuthHeader, Some(query.asString))
 
             checkUncoveredIntervals(query, response, config)
 
@@ -499,7 +502,7 @@ class DruidQueryExecutor(config: DruidQueryExecutorConfig, lifecycleListener: Ex
           val qrl = rl.asInstanceOf[QueryRowList]
           var pagination: Option[JValue] = None
           val result = Try {
-            val response = httpUtils.post(url, httpUtils.POST, headersWithAuthHeader, Some(query.asString))
+            val response = httpUtils.post(local_url, httpUtils.POST, headersWithAuthHeader, Some(query.asString))
 
             checkUncoveredIntervals(query, response, config)
 

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
@@ -3307,7 +3307,7 @@ class DruidQueryExecutorTest extends AnyFunSuite with Matchers with BeforeAndAft
       }
 
       assert(count2 == 3)
-      val expected2 = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 15))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 16))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 17))"
+      val expected2 = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 15))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 16))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-03, 17))"
 
       str2 should equal(expected2)(after being whiteSpaceNormalised)
       result2.rowList.foreach { row =>

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
@@ -3232,4 +3232,92 @@ class DruidQueryExecutorTest extends AnyFunSuite with Matchers with BeforeAndAft
         assert(expectedSet.size == count)
     }
   }
+
+  test("Use executor with alternative URI, show the URI is global.") {
+    val jsonString =
+      s"""{
+                          "cube": "k_stats",
+                          "selectFields": [
+                            {"field": "Day"},
+                            {"field": "Impressions"}
+                          ],
+                          "filterExpressions": [
+                            {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                            {"field": "Advertiser ID", "operator": "=", "value": "213"}
+                          ],
+                          "paginationStartIndex":20,
+                          "rowsPerPage":100
+                        }"""
+    val request: ReportingRequest = ReportingRequest.enableDebug(getReportingRequestSync(jsonString))
+    val registry = defaultRegistry
+    val requestModel = getRequestModel(request, registry, uri = "http://localhost:6667/mock/timeseries_override")
+    val requestModel2 = getRequestModel(request, registry, uri = null)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+    assert(requestModel2.isSuccess, requestModel2.errorMessage("Building request model failed"))
+
+    val altQueryGeneratorRegistry = new QueryGeneratorRegistry
+    altQueryGeneratorRegistry.register(DruidEngine, getDruidQueryGenerator()) //do not include local time filter
+    val queryPipelineFactoryLocal = new DefaultQueryPipelineFactory(druidMultiQueryEngineList = List(defaultFactEngine))(altQueryGeneratorRegistry)
+    val queryPipelineTry = queryPipelineFactoryLocal.from(requestModel.toOption.get, QueryAttributes.empty)
+    val queryPipelineTry2 = queryPipelineFactoryLocal.from(requestModel2.toOption.get, QueryAttributes.empty)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    assert(queryPipelineTry2.isSuccess, queryPipelineTry2.errorMessage("Fail to get the query pipeline"))
+    val query = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    val query2 = queryPipelineTry2.toOption.get.queryChain.drivingQuery.asInstanceOf[DruidQuery[_]]
+    val executor = new DruidQueryExecutor(new DruidQueryExecutorConfig(50, 500, 5000, 5000, 5000,
+      "config", "http://localhost:6667/mock/timeseries", None, 3000, 3000, 3000, 3000,
+      true, 500, 3, false, allowPartialIfResultExceedsMaxRowLimit = false),
+      new NoopExecutionLifecycleListener, ResultSetTransformer.DEFAULT_TRANSFORMS)
+    try {
+      val rowList = new CompleteRowList(query)
+      val result = executor.execute(query, rowList, QueryAttributes.empty)
+      assert(!result.rowList.isEmpty)
+      var str: String = ""
+      var count: Int = 0
+      result.rowList.foreach {
+        row => {
+          count += 1
+
+          str = str + s"$row"
+        }
+      }
+
+      assert(count == 2)
+      val expected = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 21))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 22))"
+
+      str should equal(expected)(after being whiteSpaceNormalised)
+      result.rowList.foreach { row =>
+        val map = row.aliasMap
+        for ((key, value) <- map) {
+          assert(row.getValue(key) != null)
+        }
+      }
+
+      val rowList2 = new CompleteRowList(query2)
+      val result2 = executor.execute(query2, rowList2, QueryAttributes.empty)
+      assert(!result2.rowList.isEmpty)
+      var str2: String = ""
+      var count2: Int = 0
+      result2.rowList.foreach {
+        row => {
+          count2 += 1
+
+          str2 = str2 + s"$row"
+        }
+      }
+
+      assert(count2 == 3)
+      val expected2 = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 21))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 22))"
+
+      str2 should equal(expected2)(after being whiteSpaceNormalised)
+      result2.rowList.foreach { row =>
+        val map = row.aliasMap
+        for ((key, value) <- map) {
+          assert(row.getValue(key) != null)
+        }
+      }
+    } finally {
+      executor.close()
+    }
+  }
 }

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/DruidQueryExecutorTest.scala
@@ -3307,7 +3307,7 @@ class DruidQueryExecutorTest extends AnyFunSuite with Matchers with BeforeAndAft
       }
 
       assert(count2 == 3)
-      val expected2 = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 21))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 22))"
+      val expected2 = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 15))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 16))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 17))"
 
       str2 should equal(expected2)(after being whiteSpaceNormalised)
       result2.rowList.foreach { row =>

--- a/druid/src/test/scala/com/yahoo/maha/executor/druid/TestWebService.scala
+++ b/druid/src/test/scala/com/yahoo/maha/executor/druid/TestWebService.scala
@@ -1355,6 +1355,22 @@ trait TestWebService {
           |  }
           |  ]""".stripMargin
       Ok(groupby)
+
+
+    case POST -> Root / ("timeseries_override") =>
+
+      val timeSeries =
+        """[
+          |  {
+          |    "timestamp": "2012-01-01T00:00:00.000Z",
+          |    "result": { "Impressions": 21 }
+          |  },
+          |  {
+          |   "timestamp": "2012-01-02T00:00:00.000Z",
+          |   "result": { "Impressions": 22 }
+          |  }
+          |]""".stripMargin
+      Ok(timeSeries)
   }
 
 }

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.126-SNAPSHOT</version>
+    <version>6.127-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.126-SNAPSHOT</version>
+        <version>6.127-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
If a URI is overridden on a single request, the following request will retain it.

This PR is to demo that fact, then fix the issue.

Original PR:
```
      assert(count == 2)
      val expected = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 21))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 22))"
            assert(count2 == 2)
      val expected = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 21))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 22))"
```

Fixed:
```
      assert(count == 2)
      val expected = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 21))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 22))"
     assert(count2 == 3)
      val expected2 = "Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-01, 15))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-02, 16))Row(Map(Day -> 0, Impressions -> 1),ArrayBuffer(2012-01-03, 17))"
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
