### PR TITLE
Support filter for HiveDerFactCol

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorCommon.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorCommon.scala
@@ -119,6 +119,8 @@ abstract class HiveQueryGeneratorCommon(partitionColumnRenderer:PartitionColumnR
           x match {
             case FactCol(_, dt, cc, rollup, _, annotations, _) =>
               s"""${renderRollupExpression(x.name, rollup, None)}"""
+            case HiveDerFactCol(_, _, dt, cc, de, annotations, rollup, _) =>
+              s"""${renderRollupExpression(de.render(x.name, Map.empty), rollup, None)}"""
             case OracleDerFactCol(_, _, dt, cc, de, annotations, rollup, _) => //This never gets used, otherwise errors would be thrown before the Generator.
               s"""${renderRollupExpression(de.render(x.name, Map.empty), rollup, None)}"""
             case any =>

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/BaseHiveQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/BaseHiveQueryGeneratorTest.scala
@@ -81,6 +81,7 @@ trait BaseHiveQueryGeneratorTest
           , HiveDerFactCol("max_price_type", IntType(), "{price_type}", rollupExpression = MaxRollup)
           , HiveDerFactCol("Average CPC", DecType(), "{spend}" /- "{clicks}", rollupExpression = NoopRollup)
           , HiveDerFactCol("Average CPC Cents", DecType(), "{Average CPC}" * "100", rollupExpression = NoopRollup)
+          , HiveDerFactCol("CTR", DecType(), "{clicks}" /- "{impressions}", rollupExpression = HiveCustomRollup(SUM("{clicks}") /- SUM("{impressions}")))
           , FactCol("avg_pos", DecType(3, "0.0", "0.1", "500"), HiveCustomRollup(SUM("{weighted_position}" * "{impressions}") /- SUM("{impressions}")))
         ), underlyingTableName = Some("s_stats_fact_underlying")
       )
@@ -121,6 +122,7 @@ trait BaseHiveQueryGeneratorTest
           PublicFactCol("max_bid", "Max Bid", FieldEquality),
           PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
           PublicFactCol("Average CPC Cents", "Average CPC Cents", InBetweenEquality),
+          PublicFactCol("CTR", "CTR", InNotInBetweenEqualityNotEqualsGreaterLesser),
           PublicFactCol("max_price_type", "Max Price Type", Equality)
         ),
         Set(),

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
@@ -1836,7 +1836,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
          |""".stripMargin
     result should equal(expected)(after being whiteSpaceNormalised)
   }
-  
+
   test("generating Hive query with COL Function") {
     val jsonString =
       s"""{
@@ -1912,13 +1912,13 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
                          }
           }"""
     val request: ReportingRequest = ReportingRequest.deserializeWithAdditionalParameters(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
-    
+
     val registry = getDefaultRegistry()
     val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v0)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-    
+
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
     assert(result.contains("""ROUND(COALESCE((CASE WHEN SUM(spend) > 0 THEN SUM(clicks) / 10 ELSE SUM(impressions) END), 0L), 10) mang_test_metric_col""")) //DON'T change existing functions
     assert(result.contains("""ROUND(COALESCE((CASE WHEN SUM(123) > 0 THEN SUM(clicks) / 10 ELSE SUM(potatoes) END), 0L), 10) mang_test_mod_metric_col""")) //DO change new function

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
@@ -1836,7 +1836,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
          |""".stripMargin
     result should equal(expected)(after being whiteSpaceNormalised)
   }
-
+  
   test("generating Hive query with COL Function") {
     val jsonString =
       s"""{
@@ -1912,18 +1912,62 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
                          }
           }"""
     val request: ReportingRequest = ReportingRequest.deserializeWithAdditionalParameters(jsonString.getBytes(StandardCharsets.UTF_8), AdvertiserSchema).toOption.get
-
+    
     val registry = getDefaultRegistry()
     val requestModel = getRequestModel(request, registry)
-
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
     val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v0)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
-
-
+    
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
     assert(result.contains("""ROUND(COALESCE((CASE WHEN SUM(spend) > 0 THEN SUM(clicks) / 10 ELSE SUM(impressions) END), 0L), 10) mang_test_metric_col""")) //DON'T change existing functions
     assert(result.contains("""ROUND(COALESCE((CASE WHEN SUM(123) > 0 THEN SUM(clicks) / 10 ELSE SUM(potatoes) END), 0L), 10) mang_test_mod_metric_col""")) //DO change new function
+  }
+  
+  test("generating hive query with filter on derived fact col") {
+    val jsonString =
+      s"""{
+                          "cube": "s_stats",
+                          "selectFields": [
+                              {"field": "Advertiser ID"},
+                              {"field": "CTR"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                              {"field": "CTR", "operator": ">", "value": "100"}
+                          ]
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v0)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
+    println(result)
+
+    val expected =
+      s"""
+         |SELECT CONCAT_WS(",",NVL(CAST(advertiser_id AS STRING), ''), NVL(CAST(mang_ctr AS STRING), ''))
+         |FROM(
+         |SELECT COALESCE(account_id, 0L) advertiser_id, ROUND(COALESCE(mang_ctr, 0L), 10) mang_ctr
+         |FROM(SELECT account_id, (CASE WHEN SUM(impressions) = 0 THEN 0.0 ELSE SUM(clicks) / (SUM(impressions)) END) mang_ctr
+         |FROM s_stats_fact_underlying
+         |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
+         |GROUP BY account_id
+         |HAVING ((CASE WHEN SUM(impressions) = 0 THEN 0.0 ELSE SUM(clicks) / (SUM(impressions)) END) > 100)
+         |       )
+         |ssfu0
+         |
+         |)
+         |        queryAlias LIMIT 200
+         |""".stripMargin
+
+    result should equal (expected) (after being whiteSpaceNormalised)
   }
 
 }

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
@@ -1935,7 +1935,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
                           "filterExpressions": [
                               {"field": "Advertiser ID", "operator": "=", "value": "12345"},
                               {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
-                              {"field": "CTR", "operator": ">", "value": "100"}
+                              {"field": "CTR", "operator": ">", "value": "0.1"}
                           ]
                           }"""
 
@@ -1948,8 +1948,6 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
     
     val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
-    println(result)
-
     val expected =
       s"""
          |SELECT CONCAT_WS(",",NVL(CAST(advertiser_id AS STRING), ''), NVL(CAST(mang_ctr AS STRING), ''))
@@ -1959,7 +1957,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
          |FROM s_stats_fact_underlying
          |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
          |GROUP BY account_id
-         |HAVING ((CASE WHEN SUM(impressions) = 0 THEN 0.0 ELSE SUM(clicks) / (SUM(impressions)) END) > 100)
+         |HAVING ((CASE WHEN SUM(impressions) = 0 THEN 0.0 ELSE SUM(clicks) / (SUM(impressions)) END) > 0.1)
          |       )
          |ssfu0
          |

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.129-SNAPSHOT</version>
+    <version>6.130-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.129-SNAPSHOT</version>
+        <version>6.130-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

### Motivation
Observed the query generator failed if a hive derived fact column is shown as a filter in request json:
```
queryPipelineTry.isSuccess was false Fail to get the query pipeline - Found non fact column : HiveDerFactCol(CTR,None,DecType(0,0,None,None,None,0),455668354,HiveDerivedExpression(455668354,COL(CASE WHEN {impressions} = 0 THEN 0.0 ELSE {clicks} / {impressions} END,false,true)),Set(),SumRollup,Set()) 
 com.yahoo.maha.core.query.hive.HiveQueryGeneratorCommon.$anonfun$generateFactQueryFragment$11(HiveQueryGeneratorCommon.scala:127)
```