### PR TITLE
Add Druid Lookup with user-modifiable missing value override

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/DerivedFunction.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/DerivedFunction.scala
@@ -196,6 +196,28 @@ object DruidDerivedFunction {
       )
   }
 
+  case class LOOKUP_WITH_DECODE_ON_OTHER_COLUMN_REPLACE_MISSING(lookupNamespace: String,
+                                                columnToCheck: String,
+                                                valueToCheck: String,
+                                                columnIfValueMatched: String,
+                                                columnIfValueNotMatched: String,
+                                                dimensionOverrideMap: Map[String, String] = Map.empty,
+                                                replaceMissingValueWith: String) extends DruidDerivedFunction {
+    override def asJSON(): JObject =
+      makeObj(
+        List(
+          ("function_type" -> toJSON(this.getClass.getSimpleName))
+          , ("lookupNamespace" -> toJSON(lookupNamespace))
+          , ("columnToCheck" -> toJSON(columnToCheck))
+          , ("valueToCheck" -> toJSON(valueToCheck))
+          , ("columnIfValueMatched" -> toJSON(columnIfValueMatched))
+          , ("columnIfValueNotMatched" -> toJSON(columnIfValueNotMatched))
+          , ("dimensionOverrideMap" -> toJSON(dimensionOverrideMap))
+          , ("replaceMissingValueWith" -> toJSON(replaceMissingValueWith))
+        )
+      )
+  }
+
   case class LOOKUP_WITH_TIMEFORMATTER(lookupNameSpace: String, valueColumn: String, inputFormat: String, resultFormat: String, dimensionOverrideMap: Map[String, String] = Map.empty, overrideValue: Option[String] = None) extends DruidDerivedFunction {
     override def asJSON(): JObject =
       makeObj(

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -642,6 +642,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
                     case LOOKUP_WITH_DECODE(_, _, _, args@_*) => true
                     case LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE(_, _, _, _, _, args@_*) => true
                     case LOOKUP_WITH_DECODE_ON_OTHER_COLUMN(_, _, _, _, _, _) => true
+                    case LOOKUP_WITH_DECODE_ON_OTHER_COLUMN_REPLACE_MISSING(_, _, _, _, _, _, _) => true
                     case LOOKUP_WITH_TIMEFORMATTER(_, _, _, _, _, _) => true
                     case LOOKUP_WITH_TIMESTAMP(_, _, _, _, _, _) => true
                     case _ => false
@@ -1410,6 +1411,16 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               decodeConfig.setColumnIfValueMatched(columnIfValueMatched)
               decodeConfig.setColumnIfValueNotMatched(columnIfValueNotMatched)
               val regExFn = new MahaRegisteredLookupExtractionFn(null, lookupNamespace, false, DruidQuery.replaceMissingValueWith, false, true, columnToCheck, decodeConfig, dimensionOverrideMap.asJava, null, useQueryLevelCache)
+              val primaryColumn = queryContext.factBestCandidate.fact.publicDimToForeignKeyColMap(db.publicDim.name)
+              (new ExtractionDimensionSpec(primaryColumn.alias.getOrElse(primaryColumn.name), alias, getDimValueType(column), regExFn, null), Option.empty)
+
+            case lookupFunc@LOOKUP_WITH_DECODE_ON_OTHER_COLUMN_REPLACE_MISSING(lookupNamespace, columnToCheck, valueToCheck, columnIfValueMatched, columnIfValueNotMatched, dimensionOverrideMap, replaceMissingValueWith) =>
+              val decodeConfig = new DecodeConfig()
+              decodeConfig.setColumnToCheck(columnToCheck)
+              decodeConfig.setValueToCheck(valueToCheck)
+              decodeConfig.setColumnIfValueMatched(columnIfValueMatched)
+              decodeConfig.setColumnIfValueNotMatched(columnIfValueNotMatched)
+              val regExFn = new MahaRegisteredLookupExtractionFn(null, lookupNamespace, false, replaceMissingValueWith, false, true, columnToCheck, decodeConfig, dimensionOverrideMap.asJava, null, useQueryLevelCache)
               val primaryColumn = queryContext.factBestCandidate.fact.publicDimToForeignKeyColMap(db.publicDim.name)
               (new ExtractionDimensionSpec(primaryColumn.alias.getOrElse(primaryColumn.name), alias, getDimValueType(column), regExFn, null), Option.empty)
 

--- a/core/src/test/scala/com/yahoo/maha/core/DerivedFunctionTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/DerivedFunctionTest.scala
@@ -51,6 +51,7 @@ class DerivedFunctionTest extends AnyFunSuite with Matchers {
     val lwd = LOOKUP_WITH_DECODE("namespace", "valCol", Map("b" -> "a"), "arg1", "decodeVal1", "arg2", "decodeVal2", "default")
     val lwe = LOOKUP_WITH_EMPTY_VALUE_OVERRIDE("namespace", "valCol", "ovr", Map("c" -> "d"))
     val lwo = LOOKUP_WITH_DECODE_ON_OTHER_COLUMN("namespace", "valCol", "valToCheck", "valIfMatched", "valIfNot", Map("2" -> "4", "b" -> "a"))
+    val lwr = LOOKUP_WITH_DECODE_ON_OTHER_COLUMN_REPLACE_MISSING("namespace", "valCol", "valToCheck", "valIfMatched", "valIfNot", Map("2" -> "4", "b" -> "a"), "")
     val ltf = LOOKUP_WITH_TIMEFORMATTER("namespace", "valCol", "yyyyMMdd", "yyyy", Map("do" -> "dont"), Some("override"))
     val ldr = LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE("namespace", "valCol", true, true, Map("rtn" -> "not"), "arg1", "decodeVal1", "arg2", "decodeVal2", "default")
     val dtz = DRUID_TIME_FORMAT("format", DateTimeZone.forID("Asia/Jakarta"))
@@ -58,7 +59,7 @@ class DerivedFunctionTest extends AnyFunSuite with Matchers {
     val rc = TIME_FORMAT_WITH_REQUEST_CONTEXT("yyyy")
     val lwt = LOOKUP_WITH_TIMESTAMP("namespace", "val", "fmt", Map.empty, Some("ovrVal"), asMillis = false)
 
-    val resultArray = List(gid, dow, dtf, dd, js, rgx, lu, lur, lwd, lwe, lwo, ltf, ldr, dtz, dpg, rc, lwt)
+    val resultArray = List(gid, dow, dtf, dd, js, rgx, lu, lur, lwd, lwe, lwo, ltf, ldr, dtz, dpg, rc, lwt, lwr)
 
     val expectedJSONs = List(
       """{"function_type":"GET_INTERVAL_DATE","fieldName":"fieldName","format":"yyyyMMdd"}""",
@@ -72,6 +73,7 @@ class DerivedFunctionTest extends AnyFunSuite with Matchers {
       """{"function_type":"LOOKUP_WITH_DECODE","lookupNamespace":"namespace","valueColumn":"valCol","dimensionOverrideMap":{"b":"a"},"args":"arg1,decodeVal1,arg2,decodeVal2,default"}""",
       """{"function_type":"LOOKUP_WITH_EMPTY_VALUE_OVERRIDE","lookupNamespace":"namespace","valueColumn":"valCol","overrideValue":"ovr","dimensionOverrideMap":{"c":"d"}}""",
       """{"function_type":"LOOKUP_WITH_DECODE_ON_OTHER_COLUMN","lookupNamespace":"namespace","columnToCheck":"valCol","valueToCheck":"valToCheck","columnIfValueMatched":"valIfMatched","columnIfValueNotMatched":"valIfNot","dimensionOverrideMap":{"2":"4","b":"a"}}""",
+      """{"function_type":"LOOKUP_WITH_DECODE_ON_OTHER_COLUMN_REPLACE_MISSING","lookupNamespace":"namespace","columnToCheck":"valCol","valueToCheck":"valToCheck","columnIfValueMatched":"valIfMatched","columnIfValueNotMatched":"valIfNot","dimensionOverrideMap":{"2":"4","b":"a"},"replaceMissingValueWith":""}""",
       """{"function_type":"LOOKUP_WITH_TIMEFORMATTER","lookupNamespace":"namespace","valueColumn":"valCol","inputFormat":"yyyyMMdd","resultFormat":"yyyy","dimensionOverrideMap":{"do":"dont"}}""",
       """{"function_type":"LOOKUP_WITH_DECODE_RETAIN_MISSING_VALUE","lookupNamespace":"namespace","valueColumn":"valCol","retainMissingValue":true,"injective":true,"dimensionOverrideMap":{"rtn":"not"},"args":"arg1,decodeVal1,arg2,decodeVal2,default"}""",
       """{"function_type":"DRUID_TIME_FORMAT","format":"format","zone":"Asia/Jakarta"}""",

--- a/core/src/test/scala/com/yahoo/maha/core/query/SharedDimSchema.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/SharedDimSchema.scala
@@ -722,6 +722,7 @@ trait SharedDimSchema {
             , DimCol("currency", StrType())
             , DimCol("managed_by", IntType())
             , DimCol("timezone", StrType())
+            , DimCol("timezone2", StrType())
             , OracleDerDimCol("Advertiser Status", StrType(), DECODE_DIM("{status}", "'ON'", "'ON'", "'OFF'"))
           )
           , Option(Map(AsyncRequest -> 400, SyncRequest -> 400))
@@ -742,6 +743,7 @@ trait SharedDimSchema {
             , DimCol("currency", StrType())
             , DimCol("managed_by", IntType())
             , DimCol("timezone", StrType())
+            , DimCol("timezone2", StrType())
             , PostgresDerDimCol("Advertiser Status", StrType(), DECODE_DIM("{status}", "'ON'", "'ON'", "'OFF'"))
           )
           , Option(Map(AsyncRequest -> 400, SyncRequest -> 400))
@@ -760,6 +762,7 @@ trait SharedDimSchema {
             , DimCol("status", StrType())
             , DimCol("managed_by", IntType())
             , DimCol("timezone", StrType())
+            , DimCol("timezone2", StrType())
             , BigqueryDerDimCol("Advertiser Status", StrType(), DECODE_DIM("{status}", "'ON'", "'ON'", "'OFF'"))
             , BigqueryPartDimCol("load_time", StrType(), partitionLevel = FirstPartitionLevel)
             , BigqueryPartDimCol("shard", StrType(10, default="all"), partitionLevel = SecondPartitionLevel)
@@ -779,6 +782,7 @@ trait SharedDimSchema {
             , DimCol("status", StrType())
             , DimCol("managed_by", IntType())
             , DimCol("timezone", StrType())
+            , DimCol("timezone2", StrType())
             , HiveDerDimCol("Advertiser Status", StrType(), DECODE_DIM("{status}", "'ON'", "'ON'", "'OFF'"))
             , HivePartDimCol("load_time", StrType(), partitionLevel = FirstPartitionLevel)
             , HivePartDimCol("shard", StrType(10, default="all"), partitionLevel = SecondPartitionLevel)
@@ -798,7 +802,8 @@ trait SharedDimSchema {
             DruidFuncDimCol("Advertiser Status", StrType(), LOOKUP("advertiser_lookup", "status")),
             DruidFuncDimCol("currency", StrType(), LOOKUP("advertiser_lookup", "currency", dimensionOverrideMap = Map("-3" -> "Unknown", "" -> "Unknown"))),
             DruidFuncDimCol("managed_by", StrType(), LOOKUP("advertiser_lookup", "managed_by")),
-            DruidFuncDimCol("timezone", StrType(), LOOKUP_WITH_DECODE_ON_OTHER_COLUMN("advertiser_lookup", "timezone", "US", "timezone", "currency"))
+            DruidFuncDimCol("timezone", StrType(), LOOKUP_WITH_DECODE_ON_OTHER_COLUMN("advertiser_lookup", "timezone", "US", "timezone", "currency")),
+            DruidFuncDimCol("timezone2", StrType(), LOOKUP_WITH_DECODE_ON_OTHER_COLUMN_REPLACE_MISSING("advertiser_lookup", "timezone", "US", "timezone", "currency", replaceMissingValueWith = "COL_IS_MISSING!!"))
           )
           , Option(Map(AsyncRequest -> 14, SyncRequest -> 14)), schemas = Set(AdvertiserSchema, ResellerSchema, InternalSchema)
         )
@@ -812,6 +817,7 @@ trait SharedDimSchema {
           , PubCol("managed_by", "Reseller ID", InEquality)
           , PubCol("currency", "Currency", Equality)
           , PubCol("timezone", "Timezone", Equality)
+          , PubCol("timezone2", "Timezone2", Equality)
           , PubCol("Advertiser Status", "Advertiser Status", InEquality)
         ), revision = 2, highCardinalityFilters = Set(NotInFilter("Advertiser Status", List("DELETED")))
       )

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.130-SNAPSHOT</version>
+    <version>6.131-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.130-SNAPSHOT</version>
+        <version>6.131-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
Currently, col additions will always return MAHA_LOOKUP_EMPTY if the inner decoded column isn't there.  
This will allow users to create their own overrides so that requests can filter on expected values like nulls or empty Strings.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
