### PR TITLE
Allow Binary StrType columns, restrict filtering

### DIFF
--- a/bigquery/src/main/scala/com/yahoo/maha/executor/bigquery/BigqueryQueryExecutor.scala
+++ b/bigquery/src/main/scala/com/yahoo/maha/executor/bigquery/BigqueryQueryExecutor.scala
@@ -215,7 +215,7 @@ class BigqueryQueryExecutor(
                   columnValue.getNumericValue
                 case DecType(_, _, _, _, _, _) =>
                   columnValue.getDoubleValue
-                case StrType(_, _, _) =>
+                case StrType(_, _, _, _) =>
                   columnValue.getStringValue
                 case any => throw new UnsupportedOperationException(s"Unhandled data type for column value extraction : $any")
               }

--- a/core/src/main/scala/com/yahoo/maha/core/DataType.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/DataType.scala
@@ -85,7 +85,7 @@ case class IntType private(length: Int, staticMapping: Option[StaticMapping[Int]
     )
 }
 
-case class StrType private(length: Int, staticMapping: Option[StaticMapping[String]], default: Option[String]) extends DataType {
+case class StrType private(length: Int, staticMapping: Option[StaticMapping[String]], default: Option[String], isBinary: Boolean = false) extends DataType {
   val hasStaticMapping = staticMapping.isDefined
   val hasUniqueStaticMapping = staticMapping.exists(_.hasUniqueMapping)
   val reverseStaticMapping = staticMapping.map(_.stringToTMap).getOrElse(Map.empty)
@@ -220,6 +220,10 @@ case object StrType {
 
   def apply() : StrType = {
     noLength
+  }
+
+  def apply(isBinary: Boolean) : StrType = {
+    new StrType(0, None, None, isBinary)
   }
 
   def apply(length: Int) : StrType = {

--- a/core/src/main/scala/com/yahoo/maha/core/FilterOperation.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/FilterOperation.scala
@@ -692,21 +692,21 @@ object SqlInFilterRenderer extends InFilterRenderer[SqlResult] {
     engine match {
       case OracleEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) IN (${renderedValues.map(l => s"lower($l)").mkString(",")})""")
           case _ =>
             DefaultResult(s"""$name IN (${renderedValues.mkString(",")})""")
         }
       case PostgresEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) IN (${renderedValues.map(l => s"lower($l)").mkString(",")})""")
           case _ =>
             DefaultResult(s"""$name IN (${renderedValues.mkString(",")})""")
         }
       case HiveEngine | PrestoEngine | BigqueryEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) IN (${renderedValues.map(l => s"lower($l)").mkString(",")})""")
           case _ =>
             DefaultResult(s"""$name IN (${renderedValues.mkString(",")})""")
@@ -729,14 +729,14 @@ object SqlNotInFilterRenderer extends NotInFilterRenderer[SqlResult] {
     engine match {
       case OracleEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) NOT IN (${renderedValues.map(l => s"lower($l)").mkString(",")})""")
           case _ =>
             DefaultResult(s"""$name NOT IN (${renderedValues.mkString(",")})""")
         }
       case PostgresEngine | BigqueryEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) NOT IN (${renderedValues.map(l => s"lower($l)").mkString(",")})""")
           case _ =>
             DefaultResult(s"""$name NOT IN (${renderedValues.mkString(",")})""")
@@ -761,28 +761,28 @@ object SqlEqualityFilterRenderer extends EqualityFilterRenderer[SqlResult] {
     engine match {
       case OracleEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) = lower($renderedValue)""")
           case _ =>
             DefaultResult(s"""$name = $renderedValue""")
         }
       case PostgresEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) = lower($renderedValue)""")
           case _ =>
             DefaultResult(s"""$name = $renderedValue""")
         }
       case HiveEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) = lower($renderedValue)""")
           case _ =>
             DefaultResult(s"""$name = $renderedValue""")
         }
       case PrestoEngine | BigqueryEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) = lower($renderedValue)""")
           case _ =>
             DefaultResult(s"""$name = $renderedValue""")
@@ -804,11 +804,11 @@ object SqlFieldEqualityFilterRenderer extends FieldEqualityFilterRenderer[SqlRes
     }
 
     (column.dataType, otherColumn.dataType) match {
-      case (StrType(_,_,_), StrType(_,_,_)) if column.caseInSensitive && otherColumn.caseInSensitive =>
+      case (StrType(_, _, _, _), StrType(_, _, _, _)) if column.caseInSensitive && otherColumn.caseInSensitive =>
         DefaultResult(s"""lower($name) = lower($compareTo)""")
-      case (StrType(_,_,_), StrType(_,_,_)) if column.caseInSensitive =>
+      case (StrType(_, _, _, _), StrType(_, _, _, _)) if column.caseInSensitive =>
         DefaultResult(s"""lower($name) = $compareTo""")
-      case (StrType(_,_,_), StrType(_,_,_)) if otherColumn.caseInSensitive =>
+      case (StrType(_, _, _, _), StrType(_, _, _, _)) if otherColumn.caseInSensitive =>
         DefaultResult(s"""$name = lower($compareTo)""")
       case _ =>
         DefaultResult(s"""$name = $compareTo""")
@@ -847,7 +847,7 @@ object SqlFilterRenderFactory {
     val renderedValue = literalMapper.toLiteral(column, filter.asInstanceOf[ForcedFilter].asValues, grainOption)
     if (validEngineSet.contains(engine)) {
       column.dataType match {
-        case StrType(_, _, _) if column.caseInSensitive =>
+        case StrType(_, _, _, _) if column.caseInSensitive =>
           DefaultResult(s"""lower($name) $operator lower($renderedValue)""")
         case _ =>
           DefaultResult(s"""$name $operator $renderedValue""")
@@ -912,7 +912,7 @@ object SqlLikeFilterRenderer extends LikeFilterRenderer[SqlResult] {
     engine match {
       case OracleEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             if(escaped) {
               DefaultResult( s"""lower($name) LIKE lower($renderedValue) ESCAPE '\\'""", escaped = escaped)
             } else {
@@ -927,7 +927,7 @@ object SqlLikeFilterRenderer extends LikeFilterRenderer[SqlResult] {
         }
       case PostgresEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             if(escaped) {
               DefaultResult( s"""lower($name) LIKE lower($renderedValue) ESCAPE '\\'""", escaped = escaped)
             } else {
@@ -942,7 +942,7 @@ object SqlLikeFilterRenderer extends LikeFilterRenderer[SqlResult] {
         }
       case HiveEngine | PrestoEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
               DefaultResult( s"""lower($name) LIKE lower($renderedValue)""", escaped = escaped)
           case _ =>
             DefaultResult(s"""$name LIKE $renderedValue""")
@@ -951,7 +951,7 @@ object SqlLikeFilterRenderer extends LikeFilterRenderer[SqlResult] {
         val escapedEscapeValue = escapeEscapeChars(escapeValue)
         val bqRenderedValue = literalMapper.toLiteral(column, s"%$escapedEscapeValue%", grainOption)
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult( s"""lower($name) LIKE lower($bqRenderedValue)""", escaped = escaped)
           case _ =>
             DefaultResult(s"""$name LIKE $bqRenderedValue""")
@@ -993,7 +993,7 @@ object SqlNotLikeFilterRenderer extends NotLikeFilterRenderer[SqlResult] {
     engine match {
       case OracleEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             if(escaped) {
               DefaultResult( s"""lower($name) NOT LIKE lower($renderedValue) ESCAPE '\\'""", escaped = escaped)
             } else {
@@ -1008,7 +1008,7 @@ object SqlNotLikeFilterRenderer extends NotLikeFilterRenderer[SqlResult] {
         }
       case PostgresEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             if(escaped) {
               DefaultResult( s"""lower($name) NOT LIKE lower($renderedValue) ESCAPE '\\'""", escaped = escaped)
             } else {
@@ -1023,7 +1023,7 @@ object SqlNotLikeFilterRenderer extends NotLikeFilterRenderer[SqlResult] {
         }
       case HiveEngine | PrestoEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult( s"""lower($name) NOT LIKE lower($renderedValue)""", escaped = escaped)
           case _ =>
             DefaultResult(s"""$name NOT LIKE $renderedValue""")
@@ -1032,7 +1032,7 @@ object SqlNotLikeFilterRenderer extends NotLikeFilterRenderer[SqlResult] {
         val escapedEscapeValue = escapeEscapeChars(escapeValue)
         val bqRenderedValue = literalMapper.toLiteral(column, s"%$escapedEscapeValue%", grainOption)
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult( s"""lower($name) NOT LIKE lower($bqRenderedValue)""", escaped = escaped)
           case _ =>
             DefaultResult(s"""$name NOT LIKE $bqRenderedValue""")
@@ -1055,14 +1055,14 @@ object SqlNotEqualToFilterRenderer extends NotEqualToFilterRenderer[SqlResult] {
     engine match {
       case OracleEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) <> lower($renderedValue)""")
           case _ =>
             DefaultResult(s"""$name <> $renderedValue""")
         }
       case PostgresEngine | BigqueryEngine =>
         column.dataType match {
-          case StrType(_, _, _) if column.caseInSensitive =>
+          case StrType(_, _, _, _) if column.caseInSensitive =>
             DefaultResult(s"""lower($name) <> lower($renderedValue)""")
           case _ =>
             DefaultResult(s"""$name <> $renderedValue""")
@@ -1433,7 +1433,7 @@ object FilterDruid {
       val sourceDimColFormat = sourceDimCol.dataType match {
         case DateType(sourceFormat) =>
           sourceFormat.getOrElse(grainOption.get.formatString)
-        case StrType(_, _, _) =>
+        case StrType(_, _, _, _) =>
           grainOption.get.formatString
         case any =>
           throw new UnsupportedOperationException(s"Found unhandled dataType : $any")

--- a/core/src/main/scala/com/yahoo/maha/core/LiteralMapper.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/LiteralMapper.scala
@@ -46,7 +46,7 @@ class OracleLiteralMapper extends SqlLiteralMapper {
       case _ if column.annotations.contains(DayColumn.instance) =>
         //it's a date column, treat same as date type
         renderDate(value, None, grainOption)
-      case StrType(_, _, _) =>
+      case StrType(_, _, _, _) =>
         s"'${getEscapedSqlString(value)}'"
       case IntType(_, _, _, _, _) => BigInt(value).toString
       case DecType(_, _, _, _, _, _) => BigDecimal(value).toString
@@ -79,7 +79,7 @@ class PostgresLiteralMapper extends SqlLiteralMapper {
       case _ if column.annotations.contains(DayColumn.instance) =>
         //it's a date column, treat same as date type
         renderDate(value, None, grainOption)
-      case StrType(_, _, _) =>
+      case StrType(_, _, _, _) =>
         s"'${getEscapedSqlString(value)}'"
       case IntType(_, _, _, _, _) => BigInt(value).toString
       case DecType(_, _, _, _, _, _) => BigDecimal(value).toString
@@ -98,7 +98,7 @@ class HiveLiteralMapper extends SqlLiteralMapper {
   def toLiteral(column: Column, value: String, grainOption: Option[Grain] = None) : String = {
     val grain = grainOption.getOrElse(DailyGrain)
     column.dataType match {
-      case StrType(_, _, _) =>
+      case StrType(_, _, _, _) =>
         s"'${getEscapedSqlString(value)}'"
       case DateType(fmt) =>
         //TODO: validate format
@@ -195,7 +195,7 @@ class BigqueryLiteralMapper extends SqlLiteralMapper {
     val grain = grainOption.getOrElse(DailyGrain)
     val escapedValue = getEscapedSqlString(value)
     column.dataType match {
-      case StrType(_, _, _) =>
+      case StrType(_, _, _, _) =>
         s"'$escapedValue'"
       case DateType(fmt) =>
         s"DATE('$escapedValue')"

--- a/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/RequestModel.scala
@@ -1375,7 +1375,7 @@ object RequestModel extends Logging {
 
     dataType match {
       case None => throw new IllegalArgumentException(s"Unable to find expected PublicTable as PublicFact or PublicDimension.")
-      case StrType(length, _, _) => filter match {
+      case StrType(length, _, _, _) => filter match {
         case InFilter(_, values, _, _) => validateLength(values, length)
         case NotInFilter(_, values, _, _) => validateLength(values, length)
         case EqualityFilter(_, value, _, _) => validateLength(List(value), length)

--- a/core/src/main/scala/com/yahoo/maha/core/ddl/HiveDDLGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/ddl/HiveDDLGenerator.scala
@@ -72,7 +72,7 @@ class HiveDDLGenerator {
     val dataType = col.dataType match {
       case IntType(length, _, _, _, _) if length <= 3 => "tinyint"
       case DateType(_) => "string"
-      case StrType(_, _, _) => "string"
+      case StrType(_, _, _, isBoolean) => if(!isBoolean) "string" else "binary"
       case DecType(_, _, _, _, _, _) => "double"
       case _ => "bigint"
     }

--- a/core/src/main/scala/com/yahoo/maha/core/ddl/OracleDDLGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/ddl/OracleDDLGenerator.scala
@@ -30,7 +30,8 @@ class OracleDDLGenerator {
           s"""NUMBER($length)"""
         case DecType(length, scale, _, _, _, _) =>
           s"""NUMBER($length, $scale)"""
-        case StrType(length, _, _) =>
+        case StrType(length, _, _, isBinary) =>
+          require(!isBinary, "Oracle Generator is not yet compatible with Binary/RAW data types yet!")
           s"""VARCHAR2($length CHAR)"""
         case _ =>
           s"""${dataType.jsonDataType.toUpperCase}"""

--- a/core/src/main/scala/com/yahoo/maha/core/ddl/PostgresDDLGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/ddl/PostgresDDLGenerator.scala
@@ -38,7 +38,8 @@ class PostgresDDLGenerator {
             s"""NUMERIC($length, $scale)"""
           else
             "NUMERIC"
-        case StrType(length, _, _) =>
+        case StrType(length, _, _, isBinary) =>
+          require(!isBinary, "POSTGRESQL Generator is not yet compatible with Binary/Bytea data types yet!")
           if(length > 0)
             s"""VARCHAR($length)"""
           else

--- a/core/src/main/scala/com/yahoo/maha/core/fact/Fact.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/fact/Fact.scala
@@ -2115,6 +2115,11 @@ case class PublicFactTable private[fact](name: String
         s"fact column ${col.name} in public fact $name does not exist in any underlying facts")
     }
     validateForcedFilters()
+    dimCols.filter(col => col.filters.nonEmpty).foreach { col =>
+      require(!facts.values.exists(_.dimCols.exists(dc => ((dc.name == col.name) || dc.alias.contains(col.name)) && (dc.dataType.isInstanceOf[StrType] && dc.dataType.asInstanceOf[StrType].isBinary))),
+        s"dim column ${col.name} in public fact $name is a Binary type and should not be filterable (binary data must be cast via UDF or otherwise first)")
+
+    }
   }
 
   def dataTypeForAlias(alias: String): DataType = {

--- a/core/src/main/scala/com/yahoo/maha/core/query/BigqueryHivePrestoQueryCommon.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/BigqueryHivePrestoQueryCommon.scala
@@ -397,19 +397,19 @@ method to crawl the NoopRollup fact cols recursively and fill up the parent colu
           case (from, to) => s"WHEN ($nameOrAlias IN ($from)) THEN '$to'"
         }
         s"CASE ${whenClauses.mkString(" ")} ELSE '$defaultValue' END"
-      case StrType(_, sm, _) if sm.isDefined && engine == HiveEngine =>
+      case StrType(_, sm, _, _) if sm.isDefined && engine == HiveEngine =>
         val defaultValue = sm.get.default
         val decodeValues = sm.get.tToStringMap.map {
           case (from, to) => s"'$from', '$to'"
         }
         s"""decodeUDF($nameOrAlias, ${decodeValues.mkString(", ")}, '$defaultValue')"""
-      case StrType(_, sm, _) if sm.isDefined && engine == BigqueryEngine =>
+      case StrType(_, sm, _, _) if sm.isDefined && engine == BigqueryEngine =>
         val defaultValue = sm.get.default
         val whenClauses = sm.get.tToStringMap.map {
           case (from, to) => s"WHEN ($nameOrAlias IN ('$from')) THEN '$to'"
         }
         s"CASE ${whenClauses.mkString(" ")} ELSE '$defaultValue' END"
-      case StrType(_, sm, _) if sm.isDefined && engine == PrestoEngine =>
+      case StrType(_, sm, _, _) if sm.isDefined && engine == PrestoEngine =>
         val defaultValue = sm.get.default
         val whenClauses = sm.get.tToStringMap.map {
           case (from, to) => s"WHEN ($nameOrAlias IN ('$from')) THEN '$to'"

--- a/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/RowList.scala
@@ -47,7 +47,7 @@ case class Row(aliasMap: Map[String, Int], cols: collection.mutable.ArrayBuffer[
         cols.update(index, oldValue.toString.toInt + value.toString.toInt)
       case DecType(_,_,_,_,_,_) =>
         cols.update(index, oldValue.toString.toDouble + value.toString.toDouble)
-      case StrType(_,_,_) =>
+      case StrType(_, _, _, _) =>
         cols.update(index, value)
       case _ =>
         cols.update(index, value)

--- a/core/src/main/scala/com/yahoo/maha/core/query/bigquery/BigqueryOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/bigquery/BigqueryOuterGroupByQueryGenerator.scala
@@ -528,13 +528,15 @@ abstract case class BigqueryOuterGroupByQueryGenerator(
           }
         case TimestampType(_) =>
           s"""$finalAlias"""
-        case StrType(_, sm, df) =>
+        case StrType(_, sm, df, isBinary) =>
           val defaultValue = df.getOrElse("")
           if (sm.isDefined && isOuterGroupBy) {
             handleStaticMappingString(sm, finalAlias, defaultValue)
           }
-          else {
+          else if(!isBinary){
             s"""COALESCE($finalAlias, '$defaultValue')"""
+          } else {
+            s"""$finalAlias"""
           }
         case _ => s"""COALESCE($finalAlias, '')"""
       }

--- a/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/druid/DruidQueryGenerator.scala
@@ -1234,7 +1234,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
       val targetTimeFormat: String = dimCol.dataType match {
         case DateType(sourceFormat) =>
           sourceFormat.getOrElse(fact.grain.formatString)
-        case StrType(_, _, _) =>
+        case StrType(_, _, _, _) =>
           fact.grain.formatString
         case any =>
           throw new UnsupportedOperationException(s"Found unhandled dataType : $any")
@@ -1260,7 +1260,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               val lookup = new MapLookupExtractor(map.asJava, false)
               val exFn = new LookupExtractionFn(lookup, false, defaultValue, false, true)
               (new ExtractionDimensionSpec(name, alias, getDimValueType(column), exFn, null), Option.empty)
-            case StrType(_, sm, _) if sm.isDefined =>
+            case StrType(_, sm, _, _) if sm.isDefined =>
               val defaultValue = sm.get.default
               val lookup = new MapLookupExtractor(sm.get.tToStringMap.asJava, false)
               val exFn = new LookupExtractionFn(lookup, false, defaultValue, false, true)
@@ -1275,7 +1275,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               val targetTimeFormat: String = dimCol.dataType match {
                 case DateType(sourceFormat) =>
                   sourceFormat.getOrElse(fact.grain.formatString)
-                case StrType(_, _, _) =>
+                case StrType(_, _, _, _) =>
                   fact.grain.formatString
                 case any =>
                   throw new UnsupportedOperationException(s"Found unhandled dataType : $any")
@@ -1288,7 +1288,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
               val targetTimeFormat: String = dimCol.dataType match {
                 case DateType(sourceFormat) =>
                   sourceFormat.getOrElse(fact.grain.formatString)
-                case StrType(_, _, _) =>
+                case StrType(_, _, _, _) =>
                   fact.grain.formatString
                 case any =>
                   throw new UnsupportedOperationException(s"Found unhandled dataType : $any")
@@ -1299,7 +1299,7 @@ class DruidQueryGenerator(queryOptimizer: DruidQueryOptimizer
 
             case decodeDimFunction@DECODE_DIM(fieldName, args@_*) =>
               dt match {
-                case IntType(_, _, _, _, _) | StrType(_, _, _) if args.length > 1 =>
+                case IntType(_, _, _, _, _) | StrType(_, _, _, _) if args.length > 1 =>
                   val map = args.grouped(2).filter(_.size == 2).map(seq => (seq.head, seq(1))).toMap
                   val lookup = new MapLookupExtractor(map.asJava, false)
                   val exFn = {

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveOuterGroupByQueryGenerator.scala
@@ -512,13 +512,15 @@ abstract case class HiveOuterGroupByQueryGenerator(partitionColumnRenderer:Parti
               s"""COALESCE($finalAlias, ${df.getOrElse(0)}L)"""
             }
           case DateType(_) => s"""getFormattedDate($finalAlias)"""
-          case StrType(_, sm, df) =>
+          case StrType(_, sm, df, isBinary) =>
             val defaultValue = df.getOrElse("NA")
             if (sm.isDefined && isOuterGroupBy) {
               handleStaticMappingString(sm, finalAlias, defaultValue)
             }
-            else {
+            else if(!isBinary) {
               s"""COALESCE($finalAlias, '$defaultValue')"""
+            } else {
+              s"""$finalAlias"""
             }
           case _ => s"""COALESCE($finalAlias, 'NA')"""
         }

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveQueryGenerator.scala
@@ -69,9 +69,13 @@ class HiveQueryGenerator(partitionColumnRenderer:PartitionColumnRenderer, udfSta
           case IntType(_,sm,df,_,_) =>
             s"""COALESCE($finalAlias, ${df.getOrElse(0)}L)"""
           case DateType(_) => s"""getFormattedDate($finalAlias)"""
-          case StrType(_, sm, df) =>
+          case StrType(_, sm, df, isBinary) =>
             val defaultValue = df.getOrElse("NA")
-            s"""COALESCE($finalAlias, "$defaultValue")"""
+            if(!isBinary) {
+              s"""COALESCE($finalAlias, "$defaultValue")"""
+            } else {
+              s"""$finalAlias"""
+            }
           case _ => s"""COALESCE($finalAlias, "NA")"""
         }
         if (column.annotations.contains(EscapingRequired)) {

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryCommon.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryCommon.scala
@@ -195,7 +195,8 @@ trait OracleQueryCommon extends  BaseQueryGenerator[WithOracleEngine] {
           case (from, to) => s"WHEN (${nameOrAlias} IN ($from)) THEN '$to'"
         }
         s"CASE ${whenClauses.mkString(" ")} ELSE '$defaultValue' END"
-      case StrType(_, sm, _) if sm.isDefined =>
+      case StrType(_, sm, _, isBinary) if sm.isDefined =>
+        require(!isBinary, "Oracle does not currently support BINARY/RAW dataType")
         val defaultValue = sm.get.default
         val decodeValues = sm.get.tToStringMap.map {
           case (from, to) => s"'$from', '$to'"

--- a/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/oracle/OracleQueryGenerator.scala
@@ -880,7 +880,8 @@ b. Dim Driven
           case IntType(_, sm, _, _, _) if sm.isDefined && queryContext.requestModel.isDimDriven =>
             val defaultValue = sm.get.default
             s"""COALESCE(${alias}, '$defaultValue')"""
-          case StrType(_, sm, _) if sm.isDefined && queryContext.requestModel.isDimDriven =>
+          case StrType(_, sm, _, isBinary) if sm.isDefined && queryContext.requestModel.isDimDriven =>
+            require(!isBinary, "Oracle does not currently support BINARY/RAW data type!")
             val defaultValue = sm.get.default
             s"""COALESCE(${alias}, '$defaultValue')"""
           case DateType(fmt) if fmt.isDefined => s"to_char($alias, '${fmt.get}')"

--- a/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryCommon.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryCommon.scala
@@ -204,7 +204,8 @@ trait PostgresQueryCommon extends  BaseQueryGenerator[WithPostgresEngine] {
           case (from, to) => s"WHEN (${nameOrAlias} IN ($from)) THEN '$to'"
         }
         s"CASE ${whenClauses.mkString(" ")} ELSE '$defaultValue' END"
-      case StrType(_, sm, _) if sm.isDefined =>
+      case StrType(_, sm, _, isBinary) if sm.isDefined =>
+        require(!isBinary, "POSTGRES generator does not currently support BINARY/BYTEA data type!")
         val exp = nameOrAlias
         val default = s"ELSE '${sm.get.default}' "
 

--- a/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/postgres/PostgresQueryGenerator.scala
@@ -877,7 +877,8 @@ b. Dim Driven
           case IntType(_, sm, _, _, _) if sm.isDefined && queryContext.requestModel.isDimDriven =>
             val defaultValue = sm.get.default
             s"""COALESCE(${alias}, '$defaultValue')"""
-          case StrType(_, sm, _) if sm.isDefined && queryContext.requestModel.isDimDriven =>
+          case StrType(_, sm, _, isBinary) if sm.isDefined && queryContext.requestModel.isDimDriven =>
+            require(!isBinary, "POSTGRES does not currently support BINARY/RAW data types!")
             val defaultValue = sm.get.default
             s"""COALESCE(${alias}, '$defaultValue')"""
           case DateType(fmt) if fmt.isDefined => s"to_char($alias, '${fmt.get}')"

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
@@ -560,12 +560,14 @@ abstract case class PrestoOuterGroupByQueryGenerator(partitionColumnRenderer:Par
               s"""COALESCE(CAST($finalAlias as BIGINT), ${df.getOrElse(0)})"""
             }
           case DateType(_) => s"""getFormattedDate($finalAlias)"""
-          case StrType(_, sm, df) =>
+          case StrType(_, sm, df, isBinary) =>
             val defaultValue = df.getOrElse("NA")
             if (sm.isDefined) {
               handleStaticMappingString(sm, finalAlias, defaultValue)
-            } else {
+            } else if(!isBinary) {
               s"""COALESCE(CAST($finalAlias as VARCHAR), '$defaultValue')"""
+            } else {
+              s"""CAST($finalAlias as BINARY)"""
             }
           case _ => s"""COALESCE(cast($finalAlias as VARCHAR), 'NA')"""
         }

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorCommon.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorCommon.scala
@@ -98,9 +98,13 @@ abstract class PrestoQueryGeneratorCommon(partitionColumnRenderer:PartitionColum
           s"""COALESCE(CAST($finalAlias as bigint), ${df.getOrElse(0)})"""
         }
       case DateType(_) => s"""getFormattedDate($finalAlias)"""
-      case StrType(_, sm, df) =>
+      case StrType(_, sm, df, isBinary) =>
         val defaultValue = df.getOrElse("NA")
-        s"""COALESCE(CAST($finalAlias as VARCHAR), '$defaultValue')"""
+        if(!isBinary) {
+          s"""COALESCE(CAST($finalAlias as VARCHAR), '$defaultValue')"""
+        } else {
+          s"""CAST($finalAlias as BINARY)"""
+        }
       case _ => s"""COALESCE(cast($finalAlias as VARCHAR), 'NA')"""
     }
     if (column.annotations.contains(EscapingRequired)) {

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorV1.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorV1.scala
@@ -96,7 +96,7 @@ class PrestoQueryGeneratorV1(partitionColumnRenderer:PartitionColumnRenderer, ud
               case (from, to) => s"WHEN ($nameOrAlias IN ($from)) THEN '$to'"
             }
             s"CASE ${whenClauses.mkString(" ")} ELSE '$defaultValue' END"
-          case StrType(_, sm, _) if sm.isDefined =>
+          case StrType(_, sm, _,  _) if sm.isDefined =>
             val defaultValue = sm.get.default
             val whenClauses = sm.get.tToStringMap.map {
               case (from, to) => s"WHEN ($nameOrAlias IN ('$from')) THEN '$to'"

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/BaseHiveQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/BaseHiveQueryGeneratorTest.scala
@@ -71,6 +71,7 @@ trait BaseHiveQueryGeneratorTest
           , HiveDerDimAggregateCol("Keyword Count Scaled", IntType(), COUNT("{keyword_id} * {stats_source} * 10"))
           , DimCol("internal_bucket_id", StrType())
           , HiveDerDimCol("click_exp_id", StrType(), REGEX_EXTRACT("internal_bucket_id", "(cl-)(.*?)(,|$)", 2, replaceMissingValue = true, "-3"))
+          , DimCol("binarycol", StrType(isBinary = true))
         ),
         Set(
           FactCol("impressions", IntType(3, 1))
@@ -83,6 +84,7 @@ trait BaseHiveQueryGeneratorTest
           , HiveDerFactCol("Average CPC Cents", DecType(), "{Average CPC}" * "100", rollupExpression = NoopRollup)
           , HiveDerFactCol("CTR", DecType(), "{clicks}" /- "{impressions}", rollupExpression = HiveCustomRollup(SUM("{clicks}") /- SUM("{impressions}")))
           , FactCol("avg_pos", DecType(3, "0.0", "0.1", "500"), HiveCustomRollup(SUM("{weighted_position}" * "{impressions}") /- SUM("{impressions}")))
+          , HiveDerFactCol("binaryColDecode", IntType(), DECODE("{ad_group_id}", "1", "{binarycol}", "null"))
         ), underlyingTableName = Some("s_stats_fact_underlying")
       )
     }
@@ -112,7 +114,8 @@ trait BaseHiveQueryGeneratorTest
           PubCol("network_type", "Network ID", InEquality),
           PubCol("device_id", "Device ID", InEquality),
           PubCol("internal_bucket_id", "Internal Bucket ID", InEquality),
-          PubCol("click_exp_id", "Click Exp ID", InEquality)
+          PubCol("click_exp_id", "Click Exp ID", InEquality),
+          PubCol("binarycol", "Binary Col", Set.empty)
         ),
         Set(
           PublicFactCol("impressions", "Impressions", InNotInBetweenEqualityNotEqualsGreaterLesser),
@@ -123,7 +126,8 @@ trait BaseHiveQueryGeneratorTest
           PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
           PublicFactCol("Average CPC Cents", "Average CPC Cents", InBetweenEquality),
           PublicFactCol("CTR", "CTR", InNotInBetweenEqualityNotEqualsGreaterLesser),
-          PublicFactCol("max_price_type", "Max Price Type", Equality)
+          PublicFactCol("max_price_type", "Max Price Type", Equality),
+          PublicFactCol("binaryColDecode", "Decoded Binary Col", InBetweenEquality)
         ),
         Set(),
         getMaxDaysWindow, getMaxDaysLookBack

--- a/core/src/test/scala/com/yahoo/maha/core/query/presto/BasePrestoQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/presto/BasePrestoQueryGeneratorTest.scala
@@ -89,6 +89,7 @@ trait BasePrestoQueryGeneratorTest
           , ConstFactCol("constantFact", IntType(), "0")
           , FactCol("Count", IntType(), rollupExpression = CountRollup)
           , PrestoDerFactCol("binaryColDecode", IntType(), DECODE("ad_group_id", "1", "{binarycol}", "null"))
+          , PrestoDerFactCol("binaryColDecode2", IntType(), DECODE("ad_group_id", "1", "{start_time}", "null"))
         ),underlyingTableName = Some("s_stats_fact_underlying")
       )
     }
@@ -128,7 +129,8 @@ trait BasePrestoQueryGeneratorTest
           PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
           PublicFactCol("Average CPC Cents", "Average CPC Cents", InBetweenEquality),
           PublicFactCol("Count", "Count", InBetweenEquality),
-          PublicFactCol("binaryColDecode", "Decoded Binary Col", InBetweenEquality)
+          PublicFactCol("binaryColDecode", "Decoded Binary Col", InBetweenEquality),
+          PublicFactCol("binaryColDecode2", "Decoded Binary Col2", InBetweenEquality)
         ),
         Set(),
         getMaxDaysWindow, getMaxDaysLookBack

--- a/core/src/test/scala/com/yahoo/maha/core/query/presto/BasePrestoQueryGeneratorTest.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/presto/BasePrestoQueryGeneratorTest.scala
@@ -73,6 +73,7 @@ trait BasePrestoQueryGeneratorTest
           , DimCol("device_type", IntType(8, (Map(5199520 -> "SmartPhone", 5199503 -> "Tablet", 5199421 -> "Desktop", -1 -> "UNKNOWN"), "UNKNOWN")), alias = Option("device_id"))
           , DimCol("column_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned")))
           , DimCol("column2_id", IntType(), annotations = Set(ForeignKey("non_hash_partitioned_with_singleton")))
+          , DimCol("binarycol", StrType(isBinary = true))
           , PrestoDerDimCol("Ad Group Start Date Full", StrType(), TIMESTAMP_TO_FORMATTED_DATE("{start_time}", "YYYY-MM-dd HH:mm:ss"))
 
         ),
@@ -87,6 +88,7 @@ trait BasePrestoQueryGeneratorTest
           , FactCol("avg_pos", DecType(3, "0.0", "0.1", "500"), PrestoCustomRollup(SUM("{weighted_position}" * "{impressions}") /- SUM("{impressions}")))
           , ConstFactCol("constantFact", IntType(), "0")
           , FactCol("Count", IntType(), rollupExpression = CountRollup)
+          , PrestoDerFactCol("binaryColDecode", IntType(), DECODE("ad_group_id", "1", "{binarycol}", "null"))
         ),underlyingTableName = Some("s_stats_fact_underlying")
       )
     }
@@ -112,7 +114,8 @@ trait BasePrestoQueryGeneratorTest
           PubCol("ad_format_type", "Ad Format Type", InNotInEqualityNotEqualsLikeNullNotNull),
           PubCol("ad_format_sub_type", "Ad Format Sub Type", InNotInEqualityNotEqualsLikeNullNotNull),
           PubCol("device_id", "Device ID", InNotInEqualityNotEqualsLikeNullNotNull, incompatibleColumns = Set("Device Type")),
-          PubCol("device_type", "Device Type", InNotInEqualityNotEqualsLikeNullNotNull, incompatibleColumns = Set("Device ID"))
+          PubCol("device_type", "Device Type", InNotInEqualityNotEqualsLikeNullNotNull, incompatibleColumns = Set("Device ID")),
+          PubCol("binarycol", "Binary Col", Set.empty)
 
         ),
         Set(
@@ -124,7 +127,8 @@ trait BasePrestoQueryGeneratorTest
           PublicFactCol("max_bid", "Max Bid", FieldEquality),
           PublicFactCol("Average CPC", "Average CPC", InBetweenEquality),
           PublicFactCol("Average CPC Cents", "Average CPC Cents", InBetweenEquality),
-          PublicFactCol("Count", "Count", InBetweenEquality)
+          PublicFactCol("Count", "Count", InBetweenEquality),
+          PublicFactCol("binaryColDecode", "Decoded Binary Col", InBetweenEquality)
         ),
         Set(),
         getMaxDaysWindow, getMaxDaysLookBack

--- a/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/AvaticaRowListTransformer.scala
+++ b/service/src/main/scala/com/yahoo/maha/service/calcite/avatica/AvaticaRowListTransformer.scala
@@ -49,7 +49,7 @@ class DefaultAvaticaRowListTransformer extends AvaticaRowListTransformer {
               columnOption.get.dataType match {
                 case i@IntType(_, _, _, _, _) if !i.hasStaticMapping => arrayList.add(value)
                 case DecType(_, _, _, _, _, _) => arrayList.add(value)
-                case StrType(_, _, _) => arrayList.add(value)
+                case StrType(_, _, _, _) => arrayList.add(value)
                 case DateType(format) => arrayList.add(value.toString)
                 case TimestampType(format) => arrayList.add(value.toString)
                 case _ => arrayList.add(value.toString)


### PR DESCRIPTION
Issue:
- The Binary dataType is allowed in Hive/Presto.
- Currently, we have no capability of querying these columns with our queries, as all data types cast to varchar or bigint in Outer GroupBy queries.
- Even when queried, this column type may not be filtered unless it is casted via UDF to String or ThetaSketch (not part of this feature)

Resolution:
- Allows querying as a flag in StrType which is disabled by default.
  - Should generate any inner or outer casting as either the direct column type itself, or as a cast to binary type.
  - Should not prevent the column from being queried directly.  Though the column won't be human-readable, we don't restrict this sort of raw data querying.
- Prevents any direct filtering.  This column type may only be filtered indirectly through other columns which derive it into new properties.
  - This is directly enforced in PublicFact, as we don't want users to be able to even specify Binary columns as filterable.

Below queries show behavior change in PrestoV1/HiveV2.  This will make for simpler checking of when this PR is meant to "do"

Example existing query, using start_time as the Fact decoded column:
```
SELECT CAST(advertiser_id as VARCHAR) AS advertiser_id, CAST(mang_decoded_binary_col2 as VARCHAR) AS mang_decoded_binary_col2, CAST(mang_campaign_name as VARCHAR) AS mang_campaign_name, CAST(mang_impressions as VARCHAR) AS mang_impressions
FROM(
SELECT advertiser_id AS advertiser_id, decodeUDF(ad_group_id, 1, start_time, null) AS mang_decoded_binary_col2, mang_campaign_name AS mang_campaign_name, impressions AS mang_impressions
FROM(
SELECT COALESCE(CAST(account_id as BIGINT), 0) advertiser_id, getCsvEscapedString(CAST(COALESCE(c1.mang_campaign_name, '') AS VARCHAR)) mang_campaign_name, SUM(impressions) AS impressions, COALESCE(CAST(start_time as BIGINT), 0) start_time
FROM(SELECT account_id, campaign_id, SUM(impressions) impressions, start_time
FROM s_stats_fact_underlying
WHERE (account_id = 12345) AND (stats_date >= '2023-06-14' AND stats_date <= '2023-06-21')
GROUP BY account_id, campaign_id, start_time

       )
ssfu0
LEFT OUTER JOIN (
SELECT campaign_name AS mang_campaign_name, id c1_id
FROM campaign_presto_underlying
WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (advertiser_id = 12345)
)
c1
ON
CAST(ssfu0.campaign_id AS VARCHAR) = CAST(c1.c1_id AS VARCHAR)
       
GROUP BY COALESCE(CAST(account_id as BIGINT), 0), getCsvEscapedString(CAST(COALESCE(c1.mang_campaign_name, '') AS VARCHAR)), COALESCE(CAST(start_time as BIGINT), 0)
ORDER BY impressions DESC) OgbQueryAlias
)
        queryAlias LIMIT 200
```

Example new query, now decoding on the OGB Binary column:
```
SELECT CAST(advertiser_id as VARCHAR) AS advertiser_id, CAST(mang_decoded_binary_col as VARCHAR) AS mang_decoded_binary_col, CAST(mang_campaign_name as VARCHAR) AS mang_campaign_name, CAST(mang_impressions as VARCHAR) AS mang_impressions
FROM(
SELECT advertiser_id AS advertiser_id, decodeUDF(ad_group_id, 1, binarycol, null) AS mang_decoded_binary_col, mang_campaign_name AS mang_campaign_name, impressions AS mang_impressions
FROM(
SELECT COALESCE(CAST(account_id as BIGINT), 0) advertiser_id, getCsvEscapedString(CAST(COALESCE(c1.mang_campaign_name, '') AS VARCHAR)) mang_campaign_name, SUM(impressions) AS impressions, CAST(binarycol as BINARY) binarycol
FROM(SELECT account_id, campaign_id, SUM(impressions) impressions, binarycol
FROM s_stats_fact_underlying
WHERE (account_id = 12345) AND (stats_date >= '2023-06-14' AND stats_date <= '2023-06-21')
GROUP BY account_id, campaign_id, binarycol

       )
ssfu0
LEFT OUTER JOIN (
SELECT campaign_name AS mang_campaign_name, id c1_id
FROM campaign_presto_underlying
WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (advertiser_id = 12345)
)
c1
ON
CAST(ssfu0.campaign_id AS VARCHAR) = CAST(c1.c1_id AS VARCHAR)
       
GROUP BY COALESCE(CAST(account_id as BIGINT), 0), getCsvEscapedString(CAST(COALESCE(c1.mang_campaign_name, '') AS VARCHAR)), CAST(binarycol as BINARY)
ORDER BY impressions DESC) OgbQueryAlias
)
        queryAlias LIMIT 200
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
