### PR TITLE
Fix: OGB query should not render unused primitive cols at pre-outer layer

### DIFF
--- a/api-example/pom.xml
+++ b/api-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha api-example</name>

--- a/api-jersey/pom.xml
+++ b/api-jersey/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha api-jersey</name>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha bigquery executor</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha core</name>

--- a/core/src/main/scala/com/yahoo/maha/core/query/BigqueryHivePrestoQueryCommon.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/BigqueryHivePrestoQueryCommon.scala
@@ -132,7 +132,7 @@ method to crawl the NoopRollup fact cols recursively and fill up the parent colu
  whose dependent source columns is/are NoopRollup column.
  All such parent noop rollup columns has to be rendered at OuterGroupBy layer
  */
-  def dfsNoopRollupCols(fact:Fact, cols: Set[(Column, String)], parentList: List[(Column, String)], noopRollupColSet: mutable.LinkedHashSet[(String, Column)]): Unit = {
+  def dfsNoopRollupCols(fact:Fact, cols: List[(Column, String)], parentList: List[(Column, String)], noopRollupColSet: mutable.LinkedHashSet[(String, Column)]): Unit = {
     cols.foreach {
       case (col, alias)=>
         col match {
@@ -166,7 +166,7 @@ method to crawl the NoopRollup fact cols recursively and fill up the parent colu
                   val sourceColAlias = sourceCol.alias.getOrElse(sourceCol.name)
                   if (col.alias.getOrElse(col.name) != sourceColAlias) {
                     // avoid adding self dependent columns
-                    dfsNoopRollupCols(fact, Set((sourceCol, sourceColAlias)), parentList++List((col, alias)), noopRollupColSet)
+                    dfsNoopRollupCols(fact, List((sourceCol, sourceColAlias)), parentList++List((col, alias)), noopRollupColSet)
                   }
               }
             }
@@ -188,7 +188,7 @@ method to crawl the NoopRollup fact cols recursively and fill up the parent colu
                   val sourceColAlias = sourceCol.alias.getOrElse(sourceCol.name)
                   if (col.alias.getOrElse(col.name) != sourceColAlias) {
                     // avoid adding self dependent columns
-                    dfsNoopRollupCols(fact, Set((sourceCol, sourceColAlias)), parentList++List((col, alias)), noopRollupColSet)
+                    dfsNoopRollupCols(fact, List((sourceCol, sourceColAlias)), parentList++List((col, alias)), noopRollupColSet)
                   }
               }
             }
@@ -210,7 +210,7 @@ method to crawl the NoopRollup fact cols recursively and fill up the parent colu
                   val sourceColAlias = sourceCol.alias.getOrElse(sourceCol.name)
                   if (col.alias.getOrElse(col.name) != sourceColAlias) {
                     // avoid adding self dependent columns
-                    dfsNoopRollupCols(fact, Set((sourceCol, sourceColAlias)), parentList++List((col, alias)), noopRollupColSet)
+                    dfsNoopRollupCols(fact, List((sourceCol, sourceColAlias)), parentList++List((col, alias)), noopRollupColSet)
                   }
               }
             }
@@ -228,7 +228,7 @@ method to crawl the NoopRollup fact cols recursively and fill up the parent colu
           val sourceColAlias = sourceCol.alias.getOrElse(sourceCol.name)
           if (col.alias.getOrElse(col.name) != sourceColAlias) {
             // avoid adding self dependent columns
-            dfsNoopRollupCols(fact, Set((sourceCol, sourceColAlias)), parentList++List((col, alias)), noopRollupColSet)
+            dfsNoopRollupCols(fact, List((sourceCol, sourceColAlias)), parentList++List((col, alias)), noopRollupColSet)
           }
       }
     }

--- a/core/src/main/scala/com/yahoo/maha/core/query/bigquery/BigqueryOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/bigquery/BigqueryOuterGroupByQueryGenerator.scala
@@ -190,7 +190,7 @@ abstract case class BigqueryOuterGroupByQueryGenerator(
       dfsGetPrimitiveCols(fact, customRollupSet.map(_._1).toIndexedSeq, primitiveColsSet, BigqueryEngine)
     }
 
-    dfsNoopRollupCols(fact, factCols.toSet, List.empty, noopRollupColSet)
+    dfsNoopRollupCols(fact, factCols.distinct, List.empty, noopRollupColSet)
     noopRollupColSet.foreach(derCol => aliasColumnMapOfRequestCols += (renderColumnAlias(derCol._1) -> derCol._2))
 
     primitiveColsSet.foreach {

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveOuterGroupByQueryGenerator.scala
@@ -174,7 +174,7 @@ abstract case class HiveOuterGroupByQueryGenerator(partitionColumnRenderer:Parti
     }
 
     // Find out all the NoopRollup cols recursively
-    dfsNoopRollupCols(fact, factCols.toSet, List.empty, noopRollupColSet)
+    dfsNoopRollupCols(fact, factCols.distinct, List.empty, noopRollupColSet)
 
     // Render Primitive columns
     primitiveColsSet.foreach {
@@ -331,7 +331,7 @@ abstract case class HiveOuterGroupByQueryGenerator(partitionColumnRenderer:Parti
       case _ => throw new UnsupportedOperationException("Unsupported Column Type")
     }
     // Render primitive cols
-    primitiveInnerAliasColMap.foreach {
+    requiredPrimitiveColAtPreOuterLayer().foreach {
       // if primitive col is not already rendered
       case (alias, col) if !preOuterRenderedColAliasMap.contains(col) =>
         col match {

--- a/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/hive/HiveOuterGroupByQueryGenerator.scala
@@ -394,35 +394,26 @@ abstract case class HiveOuterGroupByQueryGenerator(partitionColumnRenderer:Parti
     }
     
     def requiredPrimitiveColAtPreOuterLayer(): Map[String, Column] = {
-      println("noopRollup: \n"+ noopRollupColsMap)
-
       val srcColToDerCol = factBest.factColMapping.keySet
         .filter(colName => factBest.fact.columnsByNameMap(colName).isDerivedColumn)
         .flatMap(colName => factBest.fact.columnsByNameMap(colName).asInstanceOf[DerivedColumn].derivedExpression.sourceColumns.map(_ -> colName))
         .groupBy(_._1)
         .mapValues(_.map(_._2))
-      println(srcColToDerCol)
 
       val srcColToNoopRollupCol = noopRollupColsMap.values
         .flatMap(col => col.asInstanceOf[DerivedFactColumn].derivedExpression.sourceColumns.map(_ -> col.name))
         .groupBy(_._1)
         .mapValues(_.map(_._2).toSet)
-      println(srcColToNoopRollupCol)
 
       val srcColToNoneNoopRollupCol = srcColToDerCol.map {
         case (depColName, derColNames) =>
           depColName -> (derColNames -- srcColToNoopRollupCol.getOrElse(depColName, Set()))
       }
-      println(srcColToNoneNoopRollupCol)
-      println()
 
-      println("before filter: \n" + primitiveInnerAliasColMap)
       val updatedPrimitiveInnerAliasColMap = primitiveInnerAliasColMap.filter {
         case (alias, col) =>
           !srcColToNoneNoopRollupCol.contains(alias) || srcColToNoneNoopRollupCol.getOrElse(alias, Set()).nonEmpty
       }
-      println("\nafter filter: \n" + updatedPrimitiveInnerAliasColMap)
-
       updatedPrimitiveInnerAliasColMap
     }
 

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
@@ -118,7 +118,7 @@ abstract case class PrestoOuterGroupByQueryGenerator(partitionColumnRenderer:Par
       }
 
       // Find out all the NoopRollup cols recursively
-      dfsNoopRollupCols(fact, factCols.toSet, List.empty, noopRollupColSet)
+      dfsNoopRollupCols(fact, factCols.distinct, List.empty, noopRollupColSet)
       noopRollupColSet.foreach(derCol => aliasColumnMapOfRequestCols += (renderColumnAlias(derCol._1) -> derCol._2))
 
       // Render Primitive columns

--- a/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
+++ b/core/src/main/scala/com/yahoo/maha/core/query/presto/PrestoOuterGroupByQueryGenerator.scala
@@ -374,7 +374,7 @@ abstract case class PrestoOuterGroupByQueryGenerator(partitionColumnRenderer:Par
       case _ => throw new UnsupportedOperationException("Unsupported Column Type")
     }
     // Render primitive cols
-    primitiveInnerAliasColMap.foreach {
+    requiredPrimitiveColAtPreOuterLayer().foreach {
       // if primitive col is not already rendered
       case (alias, col) if !preOuterRenderedColAliasMap.contains(col) =>
         col match {
@@ -434,6 +434,30 @@ abstract case class PrestoOuterGroupByQueryGenerator(partitionColumnRenderer:Par
       preOuterRenderedColAliasMap.put(innerSelectCol, colInnerAlias)
       queryBuilderContext.setPreOuterAliasToColumnMap(colInnerAliasQuoted, finalAlias, innerSelectCol)
       queryBuilder.addPreOuterColumn(preOuterFactColRendered)
+    }
+
+    def requiredPrimitiveColAtPreOuterLayer(): Map[String, Column] = {
+      val srcColToDerCol = factBest.factColMapping.keySet
+        .filter(colName => factBest.fact.columnsByNameMap(colName).isDerivedColumn)
+        .flatMap(colName => factBest.fact.columnsByNameMap(colName).asInstanceOf[DerivedColumn].derivedExpression.sourceColumns.map(_ -> colName))
+        .groupBy(_._1)
+        .mapValues(_.map(_._2))
+
+      val srcColToNoopRollupCol = noopRollupColsMap.values
+        .flatMap(col => col.asInstanceOf[DerivedFactColumn].derivedExpression.sourceColumns.map(_ -> col.name))
+        .groupBy(_._1)
+        .mapValues(_.map(_._2).toSet)
+
+      val srcColToNoneNoopRollupCol = srcColToDerCol.map {
+        case (depColName, derColNames) =>
+          depColName -> (derColNames -- srcColToNoopRollupCol.getOrElse(depColName, Set()))
+      }
+      
+      val updatedPrimitiveInnerAliasColMap = primitiveInnerAliasColMap.filter {
+        case (alias, col) =>
+          !srcColToNoneNoopRollupCol.contains(alias) || srcColToNoneNoopRollupCol.getOrElse(alias, Set()).nonEmpty
+      }
+      updatedPrimitiveInnerAliasColMap
     }
 
   } //end ogbGeneratePreOuterColumns

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
@@ -1391,8 +1391,6 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
     val result =  queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
     assert(queryChain.drivingQuery.queryGenVersion.isDefined)
     assert(queryChain.drivingQuery.queryGenVersion.get == Version.v2)
-    
-    println(result)
 
     assert(result.contains(s"""(COUNT(distinct keyword_id)) mang_keyword_count"""))
   }

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
@@ -1948,7 +1948,7 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
     val requestModel = getRequestModel(request, registry)
     assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
 
-    val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v0)
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v2)
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
     
     val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
@@ -2061,7 +2061,6 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
            }"""
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
-
     val registry = getDefaultRegistry()
     val requestModel = getRequestModel(request, registry)
 
@@ -2122,7 +2121,6 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
            }"""
 
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
-
     val registry = getDefaultRegistry()
     val requestModel = getRequestModel(request, registry)
 
@@ -2182,7 +2180,6 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
                               ]
                }"""
     val request: ReportingRequest = getReportingRequestAsync(jsonString)
-
     val registry = getDefaultRegistry()
     val requestModel = getRequestModel(request, registry)
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/hive/HiveQueryGeneratorV2Test.scala
@@ -2097,8 +2097,6 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
          |) OgbQueryAlias
          |) queryAlias LIMIT 200
          |""".stripMargin
-         
-    println(result)
     
     result should equal(expected)(after being whiteSpaceNormalised)
   }
@@ -2133,44 +2131,16 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
     assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[HiveQuery].asString
 
-//    val expected =
-//      s"""
-//         |SELECT CONCAT_WS(',', CAST(NVL(mang_advertiser_name,'') AS STRING),CAST(NVL(mang_device_name,'') AS STRING),CAST(NVL(mang_impressions,'') AS STRING),CAST(NVL(mang_ctr,'') AS STRING),CAST(NVL(mang_derived_impressions,'') AS STRING),CAST(NVL(mang_derived_clicks,'') AS STRING),CAST(NVL(mang_derived_ctr,'') AS STRING),CAST(NVL(mang_decoded_nooprollup_binary_col,'') AS STRING))
-//         |FROM(
-//         |SELECT mang_advertiser_name AS mang_advertiser_name, mang_device_name, impressions AS mang_impressions, CASE WHEN impressions = 0 THEN 0.0 ELSE clicks / impressions END AS mang_ctr, derived_impressions AS mang_derived_impressions, derived_clicks AS mang_derived_clicks, derived_ctr AS mang_derived_ctr, binarycoldecodenooprollup AS mang_decoded_nooprollup_binary_col
-//         |FROM(
-//         |SELECT COALESCE(a1.mang_advertiser_name, 'NA') mang_advertiser_name, COALESCE(mang_device_name, 'NA') mang_device_name, SUM(impressions) AS impressions, SUM(clicks) AS clicks, (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS derived_clicks, (SUM(decodeUDF(device_id, 1, impressions, 0))) AS derived_impressions, (CASE WHEN (SUM(decodeUDF(device_id, 1, impressions, 0))) = 0 THEN 0.0 ELSE (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) / (SUM(decodeUDF(device_id, 1, impressions, 0))) END) AS derived_ctr, (decodeUDF(ad_group_id, 1, getAbyB(binarycol), null)) AS binarycoldecodenooprollup
-//         |FROM(SELECT account_id, decodeUDF(device_id, 1, 'DeviceA', 2, 'DeviceB', 'UNKNOWN') mang_device_name, SUM(impressions) impressions, SUM(clicks) clicks, delivered_match_type, device_id, ad_group_id, binarycol
-//         |FROM s_stats_fact_underlying
-//         |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
-//         |GROUP BY account_id, decodeUDF(device_id, 1, 'DeviceA', 2, 'DeviceB', 'UNKNOWN'), delivered_match_type, device_id, ad_group_id, binarycol
-//         |
-//         |       )
-//         |ssfu0
-//         |LEFT OUTER JOIN (
-//         |SELECT name AS mang_advertiser_name, id a1_id
-//         |FROM advertiser_hive
-//         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
-//         |)
-//         |a1
-//         |ON
-//         |ssfu0.account_id = a1.a1_id
-//         |       
-//         |GROUP BY COALESCE(a1.mang_advertiser_name, 'NA'), COALESCE(mang_device_name, 'NA')
-//         |) OgbQueryAlias
-//         |) queryAlias LIMIT 200
-//         |""".stripMargin
-    
     val expected =
       s"""
          |SELECT CONCAT_WS(',', CAST(NVL(mang_advertiser_name,'') AS STRING),CAST(NVL(mang_device_name,'') AS STRING),CAST(NVL(mang_impressions,'') AS STRING),CAST(NVL(mang_ctr,'') AS STRING),CAST(NVL(mang_derived_impressions,'') AS STRING),CAST(NVL(mang_derived_clicks,'') AS STRING),CAST(NVL(mang_derived_ctr,'') AS STRING),CAST(NVL(mang_decoded_nooprollup_binary_col,'') AS STRING))
          |FROM(
          |SELECT mang_advertiser_name AS mang_advertiser_name, mang_device_name, impressions AS mang_impressions, CASE WHEN impressions = 0 THEN 0.0 ELSE clicks / impressions END AS mang_ctr, derived_impressions AS mang_derived_impressions, derived_clicks AS mang_derived_clicks, derived_ctr AS mang_derived_ctr, binarycoldecodenooprollup AS mang_decoded_nooprollup_binary_col
          |FROM(
-         |SELECT COALESCE(a1.mang_advertiser_name, 'NA') mang_advertiser_name, COALESCE(mang_device_name, 'NA') mang_device_name, SUM(impressions) AS impressions, CASE WHEN (device_id IN (11)) THEN 'Desktop' WHEN (device_id IN (22)) THEN 'Tablet' WHEN (device_id IN (33)) THEN 'SmartPhone' WHEN (device_id IN (-1)) THEN 'UNKNOWN' ELSE 'UNKNOWN' END device_id, CASE WHEN (delivered_match_type IN (1)) THEN 'Exact' WHEN (delivered_match_type IN (2)) THEN 'Broad' WHEN (delivered_match_type IN (3)) THEN 'Phrase' ELSE 'UNKNOWN' END delivered_match_type, COALESCE(ad_group_id, 0L) ad_group_id, binarycol binarycol, SUM(clicks) AS clicks, (CASE WHEN (SUM(decodeUDF(device_id, 1, impressions, 0))) = 0 THEN 0.0 ELSE (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) / (SUM(decodeUDF(device_id, 1, impressions, 0))) END) AS derived_ctr, (decodeUDF(ad_group_id, 1, getAbyB(binarycol), null)) AS binarycoldecodenooprollup, (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS derived_clicks, (SUM(decodeUDF(device_id, 1, impressions, 0))) AS derived_impressions
+         |SELECT COALESCE(a1.mang_advertiser_name, 'NA') mang_advertiser_name, COALESCE(mang_device_name, 'NA') mang_device_name, SUM(impressions) AS impressions, SUM(clicks) AS clicks, (CASE WHEN (SUM(decodeUDF(device_id, 1, impressions, 0))) = 0 THEN 0.0 ELSE (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) / (SUM(decodeUDF(device_id, 1, impressions, 0))) END) AS derived_ctr, (decodeUDF(ad_group_id, 1, getAbyB(binarycol), null)) AS binarycoldecodenooprollup, (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS derived_clicks, (SUM(decodeUDF(device_id, 1, impressions, 0))) AS derived_impressions
          |FROM(SELECT account_id, decodeUDF(device_id, 1, 'DeviceA', 2, 'DeviceB', 'UNKNOWN') mang_device_name, SUM(impressions) impressions, SUM(clicks) clicks, delivered_match_type, device_id, ad_group_id, binarycol
          |FROM s_stats_fact_underlying
-         |WHERE (account_id = 12345) AND (stats_date >= '2023-07-13' AND stats_date <= '2023-07-20')
+         |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
          |GROUP BY account_id, decodeUDF(device_id, 1, 'DeviceA', 2, 'DeviceB', 'UNKNOWN'), delivered_match_type, device_id, ad_group_id, binarycol
          |
          |       )
@@ -2184,12 +2154,11 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
          |ON
          |ssfu0.account_id = a1.a1_id
          |       
-         |GROUP BY COALESCE(a1.mang_advertiser_name, 'NA'), COALESCE(mang_device_name, 'NA'), CASE WHEN (device_id IN (11)) THEN 'Desktop' WHEN (device_id IN (22)) THEN 'Tablet' WHEN (device_id IN (33)) THEN 'SmartPhone' WHEN (device_id IN (-1)) THEN 'UNKNOWN' ELSE 'UNKNOWN' END, CASE WHEN (delivered_match_type IN (1)) THEN 'Exact' WHEN (delivered_match_type IN (2)) THEN 'Broad' WHEN (delivered_match_type IN (3)) THEN 'Phrase' ELSE 'UNKNOWN' END, COALESCE(ad_group_id, 0L), binarycol
+         |GROUP BY COALESCE(a1.mang_advertiser_name, 'NA'), COALESCE(mang_device_name, 'NA')
          |) OgbQueryAlias
          |) queryAlias LIMIT 200
          |""".stripMargin
 
-    println(result)
     result should equal(expected)(after being whiteSpaceNormalised)
   }
 
@@ -2246,7 +2215,6 @@ class HiveQueryGeneratorV2Test extends BaseHiveQueryGeneratorTest {
          |) queryAlias LIMIT 200
          |""".stripMargin
 
-    println(result)
     result should equal(expected)(after being whiteSpaceNormalised)
   }
 

--- a/core/src/test/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorV1Test.scala
+++ b/core/src/test/scala/com/yahoo/maha/core/query/presto/PrestoQueryGeneratorV1Test.scala
@@ -3032,4 +3032,224 @@ class PrestoQueryGeneratorV1Test extends BasePrestoQueryGeneratorTest {
     val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PrestoQuery].asString
     assert(result.contains("HAVING (SUM(decodeUDF(ad_group_id, 1, binarycol, null)) = 1608)"))
   }
+
+  test("generating presto query with filter on derived fact col") {
+    val jsonString =
+      s"""{
+                          "cube": "s_stats",
+                          "selectFields": [
+                              {"field": "Advertiser ID"},
+                              {"field": "Derived CTR"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"},
+                              {"field": "Derived CTR", "operator": ">", "value": "0.1"}
+                          ]
+                          }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = getRequestModel(request, registry)
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v1)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+
+    val result =  queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PrestoQuery].asString
+    val expected =
+      s"""
+         |SELECT CAST(advertiser_id as VARCHAR) AS advertiser_id, CAST(mang_derived_ctr as VARCHAR) AS mang_derived_ctr
+         |FROM(
+         |SELECT COALESCE(CAST(account_id as bigint), 0) advertiser_id, ROUND(COALESCE(mang_derived_ctr, 0), 10) mang_derived_ctr
+         |FROM(SELECT account_id, (CASE WHEN (SUM(decodeUDF(device_id, 1, impressions, 0))) = 0 THEN 0.0 ELSE CAST((SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS DOUBLE) / (SUM(decodeUDF(device_id, 1, impressions, 0))) END) mang_derived_ctr
+         |FROM s_stats_fact_underlying
+         |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
+         |GROUP BY account_id
+         |HAVING ((CASE WHEN (SUM(decodeUDF(device_id, 1, impressions, 0))) = 0 THEN 0.0 ELSE CAST((SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS DOUBLE) / (SUM(decodeUDF(device_id, 1, impressions, 0))) END) > 0.1)
+         |       )
+         |ssfu0
+         |
+         |
+         |          )
+         |        queryAlias LIMIT 200
+         |""".stripMargin
+
+    result should equal (expected) (after being whiteSpaceNormalised)
+  }
+
+  test("OGB query should not render source cols in pre-outer select if the only derived cols who use it rendered at pre-outer select") {
+    val jsonString =
+      s"""{
+                          "cube": "s_stats",
+                          "selectFields": [
+                              {"field": "Advertiser Name"},
+                              {"field": "Impressions"},
+                              {"field": "Derived Impressions"},
+                              {"field": "Derived Clicks"},
+                              {"field": "Derived CTR"},
+                              {"field": "Decoded NoopRollup Binary Col"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"}
+                          ]
+           }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = getRequestModel(request, registry)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v1)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PrestoQuery].asString
+
+    val expected =
+      s"""
+         |SELECT CAST(mang_advertiser_name as VARCHAR) AS mang_advertiser_name, CAST(mang_impressions as VARCHAR) AS mang_impressions, CAST(mang_derived_impressions as VARCHAR) AS mang_derived_impressions, CAST(mang_derived_clicks as VARCHAR) AS mang_derived_clicks, CAST(mang_derived_ctr as VARCHAR) AS mang_derived_ctr, CAST(mang_decoded_nooprollup_binary_col as VARCHAR) AS mang_decoded_nooprollup_binary_col
+         |FROM(
+         |SELECT mang_advertiser_name AS mang_advertiser_name, impressions AS mang_impressions, derived_impressions AS mang_derived_impressions, derived_clicks AS mang_derived_clicks, derived_ctr AS mang_derived_ctr, binarycoldecodenooprollup AS mang_decoded_nooprollup_binary_col
+         |FROM(
+         |SELECT COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA') mang_advertiser_name, SUM(impressions) AS impressions, (CASE WHEN (SUM(decodeUDF(device_id, 1, impressions, 0))) = 0 THEN 0.0 ELSE CAST((SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS DOUBLE) / (SUM(decodeUDF(device_id, 1, impressions, 0))) END) AS derived_ctr, (decodeUDF(ad_group_id, 1, getAbyB(binarycol), null)) AS binarycoldecodenooprollup, (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS derived_clicks, (SUM(decodeUDF(device_id, 1, impressions, 0))) AS derived_impressions
+         |FROM(SELECT account_id, SUM(impressions) impressions, SUM(clicks) clicks, delivered_match_type, device_id, ad_group_id, binarycol
+         |FROM s_stats_fact_underlying
+         |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
+         |GROUP BY account_id, delivered_match_type, device_id, ad_group_id, binarycol
+         |
+         |       )
+         |ssfu0
+         |LEFT OUTER JOIN (
+         |SELECT name AS mang_advertiser_name, id a1_id
+         |FROM advertiser_presto
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
+         |)
+         |a1
+         |ON
+         |ssfu0.account_id = a1.a1_id
+         |       
+         |GROUP BY COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA')
+         |) OgbQueryAlias
+         |)
+         |        queryAlias LIMIT 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
+  }
+
+  test("OGB query should not render source cols in pre-outer select if the only derived cols who use it rendered at pre-outer select with derived dim") {
+    val jsonString =
+      s"""{
+                          "cube": "s_stats",
+                          "selectFields": [
+                              {"field": "Advertiser Name"},
+                              {"field": "Device Name"},
+                              {"field": "Impressions"},
+                              {"field": "Derived Impressions"},
+                              {"field": "Derived Clicks"},
+                              {"field": "Derived CTR"},
+                              {"field": "Decoded NoopRollup Binary Col"}
+                          ],
+                          "filterExpressions": [
+                              {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                              {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"}
+                          ]
+           }"""
+
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = getRequestModel(request, registry)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v1)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PrestoQuery].asString
+
+    val expected =
+      s"""
+         |SELECT CAST(mang_advertiser_name as VARCHAR) AS mang_advertiser_name, CAST(mang_device_name as VARCHAR) AS mang_device_name, CAST(mang_impressions as VARCHAR) AS mang_impressions, CAST(mang_derived_impressions as VARCHAR) AS mang_derived_impressions, CAST(mang_derived_clicks as VARCHAR) AS mang_derived_clicks, CAST(mang_derived_ctr as VARCHAR) AS mang_derived_ctr, CAST(mang_decoded_nooprollup_binary_col as VARCHAR) AS mang_decoded_nooprollup_binary_col
+         |FROM(
+         |SELECT mang_advertiser_name AS mang_advertiser_name, mang_device_name, impressions AS mang_impressions, derived_impressions AS mang_derived_impressions, derived_clicks AS mang_derived_clicks, derived_ctr AS mang_derived_ctr, binarycoldecodenooprollup AS mang_decoded_nooprollup_binary_col
+         |FROM(
+         |SELECT COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA') mang_advertiser_name, COALESCE(CAST(mang_device_name as VARCHAR), 'NA') mang_device_name, SUM(impressions) AS impressions, (CASE WHEN (SUM(decodeUDF(device_id, 1, impressions, 0))) = 0 THEN 0.0 ELSE CAST((SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS DOUBLE) / (SUM(decodeUDF(device_id, 1, impressions, 0))) END) AS derived_ctr, (decodeUDF(ad_group_id, 1, getAbyB(binarycol), null)) AS binarycoldecodenooprollup, (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS derived_clicks, (SUM(decodeUDF(device_id, 1, impressions, 0))) AS derived_impressions
+         |FROM(SELECT account_id, decodeUDF(device_id, 1, 'DeviceA', 2, 'DeviceB', 'UNKNOWN') mang_device_name, SUM(impressions) impressions, SUM(clicks) clicks, delivered_match_type, device_id, ad_group_id, binarycol
+         |FROM s_stats_fact_underlying
+         |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
+         |GROUP BY account_id, decodeUDF(device_id, 1, 'DeviceA', 2, 'DeviceB', 'UNKNOWN'), delivered_match_type, device_id, ad_group_id, binarycol
+         |
+         |       )
+         |ssfu0
+         |LEFT OUTER JOIN (
+         |SELECT name AS mang_advertiser_name, id a1_id
+         |FROM advertiser_presto
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
+         |)
+         |a1
+         |ON
+         |ssfu0.account_id = a1.a1_id
+         |       
+         |GROUP BY COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA'), COALESCE(CAST(mang_device_name as VARCHAR), 'NA')
+         |) OgbQueryAlias
+         |)
+         |        queryAlias LIMIT 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
+  }
+
+  test("Non OGB query should render aggregation metrics in the inner most select, which keeps the same behavior as before") {
+    val jsonString =
+      s"""{
+                              "cube": "s_stats",
+                              "selectFields": [
+                                  {"field": "Advertiser ID"},
+                                  {"field": "Advertiser Name"},
+                                  {"field": "Impressions"},
+                                  {"field": "Derived Impressions"},
+                                  {"field": "Derived Clicks"},
+                                  {"field": "Derived CTR"},
+                                  {"field": "Decoded NoopRollup Binary Col"}
+                              ],
+                              "filterExpressions": [
+                                  {"field": "Advertiser ID", "operator": "=", "value": "12345"},
+                                  {"field": "Day", "operator": "between", "from": "$fromDate", "to": "$toDate"}
+                              ]
+               }"""
+    val request: ReportingRequest = getReportingRequestAsync(jsonString)
+    val registry = getDefaultRegistry()
+    val requestModel = getRequestModel(request, registry)
+
+    assert(requestModel.isSuccess, requestModel.errorMessage("Building request model failed"))
+    val queryPipelineTry = generatePipeline(requestModel.toOption.get, Version.v1)
+    assert(queryPipelineTry.isSuccess, queryPipelineTry.errorMessage("Fail to get the query pipeline"))
+    val result = queryPipelineTry.toOption.get.queryChain.drivingQuery.asInstanceOf[PrestoQuery].asString
+
+    val expected =
+      s"""
+         |SELECT CAST(advertiser_id as VARCHAR) AS advertiser_id, CAST(mang_advertiser_name as VARCHAR) AS mang_advertiser_name, CAST(mang_impressions as VARCHAR) AS mang_impressions, CAST(mang_derived_impressions as VARCHAR) AS mang_derived_impressions, CAST(mang_derived_clicks as VARCHAR) AS mang_derived_clicks, CAST(mang_derived_ctr as VARCHAR) AS mang_derived_ctr, CAST(mang_decoded_nooprollup_binary_col as VARCHAR) AS mang_decoded_nooprollup_binary_col
+         |FROM(
+         |SELECT COALESCE(CAST(ssfu0.account_id as bigint), 0) advertiser_id, COALESCE(CAST(a1.mang_advertiser_name as VARCHAR), 'NA') mang_advertiser_name, COALESCE(CAST(impressions as bigint), 1) mang_impressions, COALESCE(CAST(mang_derived_impressions as bigint), 0) mang_derived_impressions, COALESCE(CAST(mang_derived_clicks as bigint), 0) mang_derived_clicks, ROUND(COALESCE(mang_derived_ctr, 0), 10) mang_derived_ctr, COALESCE(CAST(mang_decoded_nooprollup_binary_col as bigint), 0) mang_decoded_nooprollup_binary_col
+         |FROM(SELECT account_id, SUM(impressions) impressions, (CASE WHEN (SUM(decodeUDF(device_id, 1, impressions, 0))) = 0 THEN 0.0 ELSE CAST((SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) AS DOUBLE) / (SUM(decodeUDF(device_id, 1, impressions, 0))) END) mang_derived_ctr, (decodeUDF(ad_group_id, 1, getAbyB(binarycol), null)) mang_decoded_nooprollup_binary_col, (SUM(decodeUDF(delivered_match_type, 1, clicks, 0))) mang_derived_clicks, (SUM(decodeUDF(device_id, 1, impressions, 0))) mang_derived_impressions
+         |FROM s_stats_fact_underlying
+         |WHERE (account_id = 12345) AND (stats_date >= '$fromDate' AND stats_date <= '$toDate')
+         |GROUP BY account_id
+         |
+         |       )
+         |ssfu0
+         |LEFT OUTER JOIN (
+         |SELECT name AS mang_advertiser_name, id a1_id
+         |FROM advertiser_presto
+         |WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
+         |)
+         |a1
+         |ON
+         |ssfu0.account_id = a1.a1_id
+         |       
+         |
+         |          )
+         |        queryAlias LIMIT 200
+         |""".stripMargin
+
+    result should equal(expected)(after being whiteSpaceNormalised)
+  }
 }

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha db</name>

--- a/druid-lookups/pom.xml
+++ b/druid-lookups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maha-parent</artifactId>
         <groupId>com.yahoo.maha</groupId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha druid executor</name>

--- a/job-service/pom.xml
+++ b/job-service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha job service</name>

--- a/oracle/pom.xml
+++ b/oracle/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha oracle executor</name>

--- a/par-request-2/pom.xml
+++ b/par-request-2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.yahoo.maha</groupId>
     <artifactId>maha-parent</artifactId>
-    <version>6.137-SNAPSHOT</version>
+    <version>6.138-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>maha parent</name>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha postgres executor</name>

--- a/presto/pom.xml
+++ b/presto/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha presto executor</name>

--- a/request-log/pom.xml
+++ b/request-log/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha request log</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha service</name>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.yahoo.maha</groupId>
         <artifactId>maha-parent</artifactId>
-        <version>6.137-SNAPSHOT</version>
+        <version>6.138-SNAPSHOT</version>
     </parent>
 
     <name>maha worker</name>


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

### Motivation
The OGB query (Hive, Presto, Bigquery) cannot get an aggregated result if a derived NoopRollup metrics is queried. Because the NoopRollup column is rendered at the pre-outer layer, where the primitive columns which has rendered at the inner most layer will be rendered again at the pre-outer layer. 

### Solution
Before rendering primitive columns at the pre-outer layer, remove the primitive columns who are only used by NoopRollup columns who will be rendered at the pre-outer layer as well

### Example:
Here is a derived NoopRollup metrics:
```
HiveDerFactCol("derived_impressions", IntType(), SUM(DECODE("{device_id}", "1", "{impressions}", "0")), rollupExpression = NoopRollup)
```

Before the fix, the generated OGB query will be like the following query. Can find `CASE WHEN (device_id IN (11)) THEN 'Desktop' WHEN (device_id IN (22)) THEN 'Tablet' WHEN (device_id IN (33)) THEN 'SmartPhone' WHEN (device_id IN (-1)) THEN 'UNKNOWN' ELSE 'UNKNOWN' END device_id` was rendered at the pre-outer layer, even though only `derived_impressions` who is rendered at the same layer uses it
```
SELECT CONCAT_WS(',', CAST(NVL(mang_advertiser_name,'') AS STRING),CAST(NVL(mang_impressions,'') AS STRING),CAST(NVL(mang_derived_impressions,'') AS STRING))
FROM(
SELECT mang_advertiser_name AS mang_advertiser_name, impressions AS mang_impressions, derived_impressions AS mang_derived_impressions
FROM(
SELECT COALESCE(a1.mang_advertiser_name, 'NA') mang_advertiser_name, SUM(impressions) AS impressions, CASE WHEN (device_id IN (11)) THEN 'Desktop' WHEN (device_id IN (22)) THEN 'Tablet' WHEN (device_id IN (33)) THEN 'SmartPhone' WHEN (device_id IN (-1)) THEN 'UNKNOWN' ELSE 'UNKNOWN' END device_id, (SUM(decodeUDF(device_id, 1, impressions, 0))) AS derived_impressions
FROM(SELECT account_id, SUM(impressions) impressions, device_id
FROM s_stats_fact_underlying
WHERE (account_id = 12345) AND (stats_date >= '2023-07-18' AND stats_date <= '2023-07-25')
GROUP BY account_id, device_id

       )
ssfu0
LEFT OUTER JOIN (
SELECT name AS mang_advertiser_name, id a1_id
FROM advertiser_hive
WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
)
a1
ON
ssfu0.account_id = a1.a1_id
       
GROUP BY COALESCE(a1.mang_advertiser_name, 'NA'), CASE WHEN (device_id IN (11)) THEN 'Desktop' WHEN (device_id IN (22)) THEN 'Tablet' WHEN (device_id IN (33)) THEN 'SmartPhone' WHEN (device_id IN (-1)) THEN 'UNKNOWN' ELSE 'UNKNOWN' END
) OgbQueryAlias
) queryAlias LIMIT 200
```

After the fix, the generated OGB query will be:
```
SELECT CONCAT_WS(',', CAST(NVL(mang_advertiser_name,'') AS STRING),CAST(NVL(mang_impressions,'') AS STRING),CAST(NVL(mang_derived_impressions,'') AS STRING))
FROM(
SELECT mang_advertiser_name AS mang_advertiser_name, impressions AS mang_impressions, derived_impressions AS mang_derived_impressions
FROM(
SELECT COALESCE(a1.mang_advertiser_name, 'NA') mang_advertiser_name, SUM(impressions) AS impressions, (SUM(decodeUDF(device_id, 1, impressions, 0))) AS derived_impressions
FROM(SELECT account_id, SUM(impressions) impressions, device_id
FROM s_stats_fact_underlying
WHERE (account_id = 12345) AND (stats_date >= '2023-07-18' AND stats_date <= '2023-07-25')
GROUP BY account_id, device_id

       )
ssfu0
LEFT OUTER JOIN (
SELECT name AS mang_advertiser_name, id a1_id
FROM advertiser_hive
WHERE ((load_time = '%DEFAULT_DIM_PARTITION_PREDICTATE%' ) AND (shard = 'all' )) AND (id = 12345)
)
a1
ON
ssfu0.account_id = a1.a1_id
       
GROUP BY COALESCE(a1.mang_advertiser_name, 'NA')
) OgbQueryAlias
) queryAlias LIMIT 200
```