### PR TITLE
Fix Apache Calcite Avatica JDBC driver Improper Initialization

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.calcite.avatica</groupId>
             <artifactId>avatica-core</artifactId>
-            <version>1.17.0</version>
+            <version>1.22.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Apache Calcite Avatica JDBC driver creates HTTP client instances based on class names provided via httpclient_impl connection property; however, the driver does not verify if the class implements the expected interface before instantiating it, which can lead to code execution loaded via arbitrary classes and in rare cases remote code execution. To exploit the vulnerability: 1) the attacker needs to have privileges to control JDBC connection parameters; 2) and there should be a vulnerable class (constructor with URL parameter and ability to execute code) in the classpath. From Apache Calcite Avatica 1.22.0 onwards, it will be verified that the class implements the expected interface before invoking its constructor.

[CWE-665](https://cwe.mitre.org/data/definitions/665.html)
CVE-2022-36364
