### PR TITLE
Druid lookup changes to support MSQ queries on Druid29

### DIFF
--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactoryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactoryTest.java
@@ -134,7 +134,7 @@ public class URIExtractionNamespaceCacheFactoryTest {
         Callable<String> versionedCache = obj.getCachePopulator("blah",
                 namespace, "500", cache);
 
-        Assert.assertEquals(versionedCache.call(), "8675309000", versionedCache.call());
+        Assert.assertEquals(versionedCache.call(), "8675309123", versionedCache.call());
         Assert.assertEquals(cache.size() , 3);
         Assert.assertTrue(cache.containsKey("222"));
         Assert.assertTrue(cache.containsValue(Arrays.asList("111", "0.3", "22220103")));

--- a/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactoryTest.java
+++ b/druid-lookups/src/test/java/com/yahoo/maha/maha_druid_lookups/server/lookup/namespace/URIExtractionNamespaceCacheFactoryTest.java
@@ -134,7 +134,7 @@ public class URIExtractionNamespaceCacheFactoryTest {
         Callable<String> versionedCache = obj.getCachePopulator("blah",
                 namespace, "500", cache);
 
-        Assert.assertEquals(versionedCache.call(), "8675309123", versionedCache.call());
+        Assert.assertEquals(versionedCache.call(), "8675309000", versionedCache.call());
         Assert.assertEquals(cache.size() , 3);
         Assert.assertTrue(cache.containsKey("222"));
         Assert.assertTrue(cache.containsValue(Arrays.asList("111", "0.3", "22220103")));


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fix **MahaRegisteredLookupExtractionFn** class to work with Druid29 MSQ queries with maha lookup.

Issue: When we use MSQ to get data using Druid Deep Storage feature, we get the error 
```
{"error":"Cannot construct instance of com.yahoo.maha.maha_druid_lookups.query.lookup.MahaRegisteredLookupExtractionFn`, problem: Guice configuration errors:\n\n1) 
Could not find a suitable constructor in org.apache.druid.query.lookup.LookupListeningAnnouncerConfig. Classes must have either one (and only one) constructor annotated with @Inject or a zero-argument constructor that is not private.\n

  at org.apache.druid.query.lookup.LookupListeningAnnouncerConfig.class(LookupListeningAnnouncerConfig.java:33)\n 
 while locating org.apache.druid.query.lookup.LookupListeningAnnouncerConfig\n
    for the 4th parameter of org.apache.druid.query.lookup.LookupReferencesManager.<init>(LookupReferencesManager.java:131)\n
  while locating org.apache.druid.query.lookup.LookupReferencesManager\n\n1
```
